### PR TITLE
Refine trust

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -57,7 +57,11 @@ fn main() {
                 ancillary_trust_path: opts.trustdb,
             });
 
-            println!("Loaded {} trust records", sys.trust.len())
+            println!(
+                "Loaded {}/{} trust records",
+                sys.system_trust.len(),
+                sys.ancillary_trust.len()
+            )
         }
         SubCommands::Daemon(opts) => {
             let daemon = Daemon::new("notfapolicyd.service");

--- a/py/examples/validate_install.py
+++ b/py/examples/validate_install.py
@@ -1,7 +1,8 @@
 import fapolicy_analyzer.syscheck as syscheck
 from fapolicy_analyzer import util
-from fapolicy_analyzer.trust import Trust
+from fapolicy_analyzer.app import System
 from fapolicy_analyzer.svc import Daemon
+from fapolicy_analyzer.trust import Trust
 
 # validate util library
 s = util.example_trust_entry()
@@ -15,6 +16,11 @@ assert pt.path == ts[0]
 assert pt.size == int(ts[1])
 assert pt.hash == ts[2]
 print("- Trust object OK")
+
+# validate Trust stores
+s = System("../tests/data/fapolicyd.trust", None)
+print(f"- System Trust OK ({len(s.system_trust())})")
+print(f"- Ancillary Trust OK ({len(s.ancillary_trust())})")
 
 # validate rpm
 syscheck.syscheck_rpm()

--- a/py/src/app.rs
+++ b/py/src/app.rs
@@ -30,16 +30,19 @@ impl PySystem {
         .into()
     }
 
-    fn dump_trust(&self) {
-        for t in &self.s.trust {
-            println!("{:?}", t);
-        }
-    }
-
-    fn trust(&self) -> PyResult<Vec<PyTrust>> {
+    fn system_trust(&self) -> PyResult<Vec<PyTrust>> {
         Ok(self
             .s
-            .trust
+            .system_trust
+            .iter()
+            .map(|t| PyTrust::from(t.clone()))
+            .collect())
+    }
+
+    fn ancillary_trust(&self) -> PyResult<Vec<PyTrust>> {
+        Ok(self
+            .s
+            .ancillary_trust
             .iter()
             .map(|t| PyTrust::from(t.clone()))
             .collect())

--- a/py/src/trust.rs
+++ b/py/src/trust.rs
@@ -39,7 +39,7 @@ impl PyTrust {
 
     #[getter]
     fn get_path(&self) -> PyResult<&str> {
-        Ok(&self.e.path.as_str())
+        Ok(&self.e.path)
     }
 
     #[getter]

--- a/src/rpm.rs
+++ b/src/rpm.rs
@@ -1,20 +1,27 @@
 use crate::api;
 use crate::rpm::RpmError::{Discovery, Execution, NotFound};
+use nom::bytes::complete::tag;
 use nom::character::complete::alphanumeric1;
 use nom::character::complete::digit1;
 use nom::character::complete::line_ending;
 use nom::character::complete::space1;
 use nom::combinator::iterator;
-use nom::sequence::terminated;
-use nom::InputIter;
+use nom::sequence::{delimited, terminated};
+use nom::{InputIter, Parser};
 use std::process::Command;
+
+#[derive(Debug)]
+struct RpmDbEntry {
+    pub path: String,
+    pub size: i64,
+    pub hash: Option<String>,
+    pub mode: String,
+}
 
 pub fn load_system_trust(rpmdb: &Option<String>) -> Vec<api::Trust> {
     let mut args = Vec::new();
     args.push("-qa");
     args.push("--dump");
-
-    // todo;; for now we are always setting this to support ubuntu dev environments
     args.push("--dbpath");
     if let Some(rpmdb_path) = rpmdb {
         args.push(rpmdb_path);
@@ -31,8 +38,28 @@ pub fn load_system_trust(rpmdb: &Option<String>) -> Vec<api::Trust> {
     parse(&clean)
 }
 
+// todo;; filtering on mode here for now as executable test
+fn is_executable(e: &RpmDbEntry) -> bool {
+    e.mode == "0100755"
+}
+
+fn contains_no_files(s: &str) -> nom::IResult<&str, Option<RpmDbEntry>> {
+    delimited(tag("("), tag("contains no files"), tag(")"))(s).map(|x| (x.0, None))
+}
+
 fn parse(s: &str) -> Vec<api::Trust> {
-    iterator(s, terminated(parse_line, line_ending)).collect()
+    iterator(s, terminated(contains_no_files.or(parse_line), line_ending))
+        .collect::<Vec<Option<RpmDbEntry>>>()
+        .iter()
+        .flatten()
+        .filter(|e| is_executable(e))
+        .map(|e| api::Trust {
+            path: e.path.clone(),
+            size: e.size,
+            hash: e.hash.clone(),
+            source: api::TrustSource::System,
+        })
+        .collect()
 }
 
 fn filepath(i: &str) -> nom::IResult<&str, &str> {
@@ -52,7 +79,7 @@ fn digest_or_not(i: &str) -> Option<&str> {
 }
 
 /// path size mtime digest mode owner group isconfig isdoc rdev symlink
-pub fn parse_line(i: &str) -> nom::IResult<&str, api::Trust> {
+fn parse_line(i: &str) -> nom::IResult<&str, Option<RpmDbEntry>> {
     match nom::combinator::complete(nom::sequence::tuple((
         filepath,
         space1,
@@ -88,7 +115,7 @@ pub fn parse_line(i: &str) -> nom::IResult<&str, api::Trust> {
                 _, // mtime
                 digest,
                 _,
-                _,
+                mode,
                 _, // mode
                 _,
                 _, // owner
@@ -104,12 +131,12 @@ pub fn parse_line(i: &str) -> nom::IResult<&str, api::Trust> {
             ),
         )) => Ok((
             remaining_input,
-            api::Trust {
+            Some(RpmDbEntry {
                 path: path.to_string(),
                 size: size.parse().unwrap(),
                 hash: digest_or_not(digest).map(|s| s.to_string()),
-                source: api::TrustSource::System,
-            },
+                mode: mode.to_string(),
+            }),
         )),
         Err(e) => Err(e),
     }
@@ -121,76 +148,74 @@ pub fn parse_line(i: &str) -> nom::IResult<&str, api::Trust> {
 mod tests {
     use super::*;
 
+    #[test]
+    fn with_contains_no_files_lines() {
+        let full = format!(
+            "{}\n,{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n",
+            NF, A, NF, B, NF, C, NF, D, NF
+        );
+        let r = parse(&full);
+        assert_eq!(2, r.len());
+    }
+
+    static NF: &str = "(contains no files)";
     static A: &str = "/usr/bin/hostname 21664 1557584275 26532eeae676157e70231d911474e48d31085b5f2e511ce908349dbb02f0f69c 0100755 root root 0 0 0 X";
     static B: &str = "/usr/share/man/man1/dnsdomainname.1.gz 13 1557584275 0000000000000000000000000000000000000000000000000000000000000000 0120777 root root 0 1 0 hostname.1.gz";
     static C: &str = "/usr/lib/.build-id/a8/a7ee9d5002492edfc62e3e2e44149e981f9866 28 1557584275 0000000000000000000000000000000000000000000000000000000000000000 0120777 root root 0 0 0 ../../../../usr/bin/hostname";
+    static D: &str = "/usr/bin/tar 459928 1595282074 7642954ec2d8cd43ac345eca0b4a20fc5d44811a309e62fa78340cce8cff10cc 0100755 root root 0 0 0 X";
 
     #[test]
     fn parse_a() {
-        let expected = api::Trust {
+        let expected = RpmDbEntry {
             path: "/usr/bin/hostname".to_string(),
             size: 21664,
             hash: Some(
                 "26532eeae676157e70231d911474e48d31085b5f2e511ce908349dbb02f0f69c".to_string(),
             ),
-            source: api::TrustSource::System,
+            mode: "0100755".to_string(),
         };
         let (_, actual) = parse_line(A).unwrap();
-        println!("{:?}", actual);
 
-        assert_eq!(actual.path, expected.path);
-        assert_eq!(actual.size, expected.size);
-        assert_eq!(actual.hash, expected.hash);
+        assert_eq!(actual.as_ref().unwrap().path, expected.path);
+        assert_eq!(actual.as_ref().unwrap().size, expected.size);
+        assert_eq!(actual.as_ref().unwrap().hash, expected.hash);
     }
 
     #[test]
     fn parse_b() {
-        let expected = api::Trust {
+        let expected = RpmDbEntry {
             path: "/usr/share/man/man1/dnsdomainname.1.gz".to_string(),
             size: 13,
             hash: None,
-            source: api::TrustSource::System,
+            mode: "0120777".to_string(),
         };
         let (_, actual) = parse_line(B).unwrap();
-        println!("{:?}", actual);
 
-        assert_eq!(actual.path, expected.path);
-        assert_eq!(actual.size, expected.size);
-        assert_eq!(actual.hash, expected.hash);
+        assert_eq!(actual.as_ref().unwrap().path, expected.path);
+        assert_eq!(actual.as_ref().unwrap().size, expected.size);
+        assert_eq!(actual.as_ref().unwrap().hash, expected.hash);
     }
 
     #[test]
     fn parse_c() {
-        let expected = api::Trust {
+        let expected = RpmDbEntry {
             path: "/usr/lib/.build-id/a8/a7ee9d5002492edfc62e3e2e44149e981f9866".to_string(),
             size: 28,
             hash: None,
-            source: api::TrustSource::System,
+            mode: "0120777".to_string(),
         };
         let (_, actual) = parse_line(C).unwrap();
-        println!("{:?}", actual);
 
-        assert_eq!(actual.path, expected.path);
-        assert_eq!(actual.size, expected.size);
-        assert_eq!(actual.hash, expected.hash);
+        assert_eq!(actual.as_ref().unwrap().path, expected.path);
+        assert_eq!(actual.as_ref().unwrap().size, expected.size);
+        assert_eq!(actual.as_ref().unwrap().hash, expected.hash);
     }
 
     #[test]
     fn parse_db() {
-        let mut abc = String::new();
-        abc.push_str(A);
-        abc.push('\n');
-        abc.push_str(B);
-        abc.push('\n');
-        abc.push_str(C);
-        abc.push('\n');
-
+        let abc = format!("{}\n{}\n{}\n{}\n", A, B, C, D);
         let files: Vec<api::Trust> = parse(&abc);
-
-        assert_eq!(files.len(), 3);
-        for x in files {
-            println!("{:?}", x);
-        }
+        assert_eq!(files.len(), 2);
     }
 }
 

--- a/src/svc.rs
+++ b/src/svc.rs
@@ -49,28 +49,28 @@ impl Daemon {
     }
 
     pub fn start(&self) -> Result<(), String> {
-        let m = msg(StartUnit).append2(self.name.as_str(), "fail");
+        let m = msg(StartUnit).append2(&self.name, "fail");
         match call(m) {
             Ok(_) => Ok(()),
             Err(e) => Err(e.to_string()),
         }
     }
     pub fn stop(&self) -> Result<(), String> {
-        let m = msg(StopUnit).append2(self.name.as_str(), "fail");
+        let m = msg(StopUnit).append2(&self.name, "fail");
         match call(m) {
             Ok(_) => Ok(()),
             Err(e) => Err(e.to_string()),
         }
     }
     pub fn enable(&self) -> Result<(), String> {
-        let m = msg(EnableUnitFiles).append3(vec![self.name.as_str()], true, false);
+        let m = msg(EnableUnitFiles).append3(vec![&self.name], true, false);
         match call(m) {
             Ok(_) => Ok(()),
             Err(e) => Err(e.to_string()),
         }
     }
     pub fn disable(&self) -> Result<(), String> {
-        let m = msg(DisableUnitFiles).append2(vec![self.name.as_str()], true);
+        let m = msg(DisableUnitFiles).append2(vec![&self.name], true);
         match call(m) {
             Ok(_) => Ok(()),
             Err(e) => Err(e.to_string()),

--- a/src/sys.rs
+++ b/src/sys.rs
@@ -9,17 +9,18 @@ pub struct SystemCfg {
 
 #[derive(Clone)]
 pub struct System {
-    pub trust: Vec<Trust>,
+    pub system_trust: Vec<Trust>,
+    pub ancillary_trust: Vec<Trust>,
 }
 
 impl System {
     pub fn boot(cfg: SystemCfg) -> System {
-        let trust: Vec<Trust> = [
-            load_system_trust(&cfg.system_trust_path),
-            load_ancillary_trust(&cfg.ancillary_trust_path),
-        ]
-        .concat();
+        let system_trust = load_system_trust(&cfg.system_trust_path);
+        let ancillary_trust = load_ancillary_trust(&cfg.ancillary_trust_path);
 
-        System { trust }
+        System {
+            system_trust,
+            ancillary_trust,
+        }
     }
 }


### PR DESCRIPTION
- separate trust stores
- filters system trust to executables
- handles `(contains no files)` lines from rpm
 
closes #14
closes #18 
closes #19 