### PR TITLE
Generate Trust / Untrust status

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ dist
 .vscode/
 
 *.glade~
+
+src/bin

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -72,7 +72,7 @@ dependencies = [
 
 [[package]]
 name = "fapolicy-analyzer"
-version = "0.0.1"
+version = "0.0.3"
 dependencies = [
  "data-encoding",
  "dbus",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fapolicy-analyzer"
-version = "0.0.1"
+version = "0.0.3"
 edition = "2018"
 
 [lib]

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -121,7 +121,7 @@ dependencies = [
 
 [[package]]
 name = "fapolicy-analyzer"
-version = "0.0.1"
+version = "0.0.3"
 dependencies = [
  "data-encoding",
  "dbus",
@@ -132,7 +132,7 @@ dependencies = [
 
 [[package]]
 name = "fapolicy-analyzer-cli"
-version = "0.0.1"
+version = "0.0.3"
 dependencies = [
  "clap",
  "fapolicy-analyzer",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fapolicy-analyzer-cli"
-version = "0.0.1"
+version = "0.0.3"
 edition = "2018"
 
 [dependencies]

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -3,7 +3,7 @@ use clap::Clap;
 use fapolicy_analyzer::{svc, sys};
 
 #[derive(Clap)]
-#[clap(version = "0.0.1")]
+#[clap(version = "0.0.3")]
 /// File Access Policy Analyzer
 struct Opts {
     #[clap(subcommand)]
@@ -13,7 +13,7 @@ struct Opts {
 #[derive(Clap)]
 enum SubCommands {
     /// fapolicyd service commands
-    #[clap(version = "0.0.1")]
+    #[clap(version = "0.0.3")]
     Daemon(DaemonOpts),
     Trust(TrustOpts),
 }

--- a/py/Cargo.lock
+++ b/py/Cargo.lock
@@ -82,7 +82,7 @@ dependencies = [
 
 [[package]]
 name = "fapolicy-analyzer"
-version = "0.0.1"
+version = "0.0.3"
 dependencies = [
  "data-encoding",
  "dbus",
@@ -93,7 +93,7 @@ dependencies = [
 
 [[package]]
 name = "fapolicy-analyzer-python"
-version = "0.0.1"
+version = "0.0.3"
 dependencies = [
  "fapolicy-analyzer",
  "pyo3",

--- a/py/Cargo.toml
+++ b/py/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "fapolicy-analyzer-python"
-version = "0.0.1"
-authors = ["John Wass <wassj@ctc.com>"]
+version = "0.0.3"
 edition = "2018"
 
 [lib]

--- a/py/examples/system.py
+++ b/py/examples/system.py
@@ -1,10 +1,5 @@
 from fapolicy_analyzer.app import System
 
-s = System("/usr/local/data2/dev/code/isis/fapolicy-analyzer/.local/fapolicyd.trust", None)
-
-# dump the trust store
-for pt in s.trust():
-    print(f"{pt.path} {pt.size} {pt.hash}")
-
-# or
-# s.dump_trust()
+s = System(None, None, "tests/data/one.trust")
+for pt in s.ancillary_trust():
+    print(f"{pt.status} {pt.path} {pt.size} {pt.hash}")

--- a/py/examples/validate_install.py
+++ b/py/examples/validate_install.py
@@ -11,13 +11,6 @@ ts = s.split(' ')
 assert len(ts) == 3
 print("- Util library OK")
 
-# validate Trust object
-pt = Trust(ts[0], int(ts[1]), ts[2])
-assert pt.path == ts[0]
-assert pt.size == int(ts[1])
-assert pt.hash == ts[2]
-print("- Trust object OK")
-
 # validate default Trust stores
 s = System(None, None, "tests/data/one.trust")
 print(f"- System Trust OK ({len(s.system_trust())})")

--- a/py/examples/validate_install.py
+++ b/py/examples/validate_install.py
@@ -3,6 +3,7 @@ from fapolicy_analyzer import util
 from fapolicy_analyzer.app import System
 from fapolicy_analyzer.svc import Daemon
 from fapolicy_analyzer.trust import Trust
+from fapolicy_analyzer.util import fs
 
 # validate util library
 s = util.example_trust_entry()
@@ -28,3 +29,8 @@ syscheck.syscheck_rpm()
 # daemon binding
 d = Daemon("fakeunit")
 print("- Daemon object OK")
+
+# fs utils
+stat_str = fs.stat(__file__)
+print("- Stat OK")
+print(stat_str)

--- a/py/fapolicy_analyzer/__init__.py
+++ b/py/fapolicy_analyzer/__init__.py
@@ -1,2 +1,3 @@
 from .app import *
 from .trust import *
+from .util import fs

--- a/py/fapolicy_analyzer/util/fs.py
+++ b/py/fapolicy_analyzer/util/fs.py
@@ -1,0 +1,5 @@
+import subprocess
+
+
+def stat(path):
+    return subprocess.getoutput(f"stat {path}")

--- a/py/setup.py
+++ b/py/setup.py
@@ -3,7 +3,7 @@ from setuptools_rust import RustExtension
 
 setup(
     name="fapolicy-analyzer",
-    version="0.0.2",
+    version="0.0.3",
     packages=["fapolicy_analyzer"] + find_namespace_packages(include=['fapolicy_analyzer.*']),
     setup_requires=["setuptools", "setuptools_rust"],
     zip_safe=False,

--- a/py/src/trust.rs
+++ b/py/src/trust.rs
@@ -37,7 +37,7 @@ impl PyTrust {
 
     #[getter]
     fn get_hash(&self) -> PyResult<Option<&str>> {
-        Ok(self.e.hash.as_deref())
+        Ok(Some(&self.e.hash))
     }
 }
 

--- a/py/tests/data/one.trust
+++ b/py/tests/data/one.trust
@@ -1,6 +1,1 @@
-# This file contains a list of trusted files
-#
-#  FULL PATH        SIZE                             SHA256
-# /home/user/my-ls 157984 61a9960bf7d255a85811f4afcac51067b8f2e4c75e21cf4f2af95319d4ed1b87
-
-/home/user/my-ls 157984 61a9960bf7d255a85811f4afcac51067b8f2e4c75e21cf4f2af95319d4ed1b87
+/bin/ls 133792 0d06f9724af41b13cdacea133530b9129a48450230feef9632d53d5bbb837c8c

--- a/src/api.rs
+++ b/src/api.rs
@@ -4,6 +4,9 @@ pub enum TrustSource {
     Ancillary,
 }
 
+// todo;; from 0,1,2 for TrustSource
+
+// intent to match up with the fapolicyd trust db
 #[derive(Clone, Debug)]
 pub struct Trust {
     pub path: String,

--- a/src/api.rs
+++ b/src/api.rs
@@ -11,7 +11,7 @@ pub enum TrustSource {
 pub struct Trust {
     pub path: String,
     pub size: u64,
-    pub hash: Option<String>,
+    pub hash: String,
     pub source: TrustSource,
 }
 
@@ -20,7 +20,7 @@ impl Trust {
         Trust {
             path: path.to_string(),
             size,
-            hash: Some(hash.to_string()),
+            hash: hash.to_string(),
             source,
         }
     }

--- a/src/rpm.rs
+++ b/src/rpm.rs
@@ -53,12 +53,19 @@ fn parse(s: &str) -> Vec<api::Trust> {
         .iter()
         .flatten()
         .filter(|e| is_executable(e))
-        .map(|e| api::Trust {
-            path: e.path.clone(),
-            size: e.size,
-            hash: e.hash.clone(),
-            source: api::TrustSource::System,
+        .map(|e| {
+            if let Some(hash) = &e.hash {
+                Some(api::Trust {
+                    path: e.path.clone(),
+                    size: e.size,
+                    hash: hash.to_string(),
+                    source: api::TrustSource::System,
+                })
+            } else {
+                None
+            }
         })
+        .flatten()
         .collect()
 }
 

--- a/src/sha.rs
+++ b/src/sha.rs
@@ -1,6 +1,6 @@
 use std::io::{Read, Result};
 
-use data_encoding::HEXUPPER;
+use data_encoding::HEXLOWER;
 use ring::digest::{Context, SHA256};
 
 // sha example from cookbook
@@ -16,5 +16,5 @@ pub fn sha256_digest<R: Read>(mut reader: R) -> Result<String> {
         context.update(&buffer[..count]);
     }
 
-    Ok(HEXUPPER.encode(context.finish().as_ref()))
+    Ok(HEXLOWER.encode(context.finish().as_ref()))
 }

--- a/src/sys.rs
+++ b/src/sys.rs
@@ -12,15 +12,25 @@ pub struct SystemCfg {
 #[derive(Clone)]
 pub struct System {
     pub trust_db: Vec<Trust>,
-    pub system_trust: Vec<Trust>,
-    pub ancillary_trust: Vec<Trust>,
+    pub system_trust: Vec<trust::Status>,
+    pub ancillary_trust: Vec<trust::Status>,
 }
 
 impl System {
     pub fn boot(cfg: SystemCfg) -> System {
         let trust_db = trust::load_trust_db(&cfg.trust_db_path);
-        let system_trust = rpm::load_system_trust(&cfg.system_trust_path);
-        let ancillary_trust = trust::load_ancillary_trust(&cfg.ancillary_trust_path);
+        let system_trust: Vec<trust::Status> = rpm::load_system_trust(&cfg.system_trust_path)
+            .iter()
+            .map(trust::check)
+            .flatten()
+            .collect();
+
+        let ancillary_trust: Vec<trust::Status> =
+            trust::load_ancillary_trust(&cfg.ancillary_trust_path)
+                .iter()
+                .map(trust::check)
+                .flatten()
+                .collect();
 
         System {
             trust_db,

--- a/src/trust.rs
+++ b/src/trust.rs
@@ -144,6 +144,9 @@ mod tests {
         let e = parse_trust_record(s).unwrap();
         assert_eq!(e.path, "/home/user/my-ls");
         assert_eq!(e.size, 157984);
-        assert_eq!(e.hash, s.to_string());
+        assert_eq!(
+            e.hash,
+            "61a9960bf7d255a85811f4afcac51067b8f2e4c75e21cf4f2af95319d4ed1b87"
+        );
     }
 }

--- a/src/trust.rs
+++ b/src/trust.rs
@@ -13,6 +13,7 @@ use crate::sha;
 
 /// Trust status tag
 /// T / U / unk
+#[derive(Clone)]
 pub enum Status {
     /// No entry in database
     Unknown(api::Trust),
@@ -24,11 +25,11 @@ pub enum Status {
     // todo;; what about file does not exist?
 }
 
-pub fn check(t: api::Trust) -> Result<Status, String> {
+pub fn check(t: &api::Trust) -> Result<Status, String> {
     match File::open(&t.path) {
         Ok(f) => match sha256_digest(BufReader::new(f)) {
-            Ok(sha) if sha == t.hash => Ok(Status::Trusted(t)),
-            Ok(sha) => Ok(Status::Untrusted(t, sha)),
+            Ok(sha) if sha == t.hash => Ok(Status::Trusted(t.clone())),
+            Ok(sha) => Ok(Status::Untrusted(t.clone(), sha)),
             Err(e) => Err(format!("sha256 op failed, {}", e)),
         },
         _ => Err(format!("WARN: {} not found", t.path)),


### PR DESCRIPTION
- scan filesystem comparing trust entries with actuals and generates a trusted or untrusted status
- add stat function to python utils to capture file metadata

closes #16, closes #17