### PR TITLE
Added a conformation dialog before deployment

### DIFF
--- a/ui/fapolicy_analyzer/tests/test_ancillary_trust_database_admin.py
+++ b/ui/fapolicy_analyzer/tests/test_ancillary_trust_database_admin.py
@@ -5,6 +5,7 @@ import gi
 gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk
 from unittest.mock import MagicMock
+from helpers import delayed_gui_action
 from ui.ancillary_trust_database_admin import AncillaryTrustDatabaseAdmin
 
 
@@ -48,14 +49,46 @@ def test_updates_trust_details(widget, mocker):
     widget.trustFileDetails.set_trust_status.assert_called_with("This file is trusted.")
 
 
-def test_on_deployBtn_clicked(widget, mocker):
+def test_on_confirm_deployment(widget, mocker):
     parent = Gtk.Window()
     parent.add(widget.get_content())
-    mock_dialog = MagicMock(run=MagicMock(), hide=MagicMock())
+    mock_confirm_dialog = MagicMock(
+        run=MagicMock(return_value=Gtk.ResponseType.YES), hide=MagicMock()
+    )
+    mock_deploy_dialog = MagicMock(run=MagicMock(), hide=MagicMock())
+    mocker.patch(
+        "ui.ancillary_trust_database_admin.ConfirmDialog.get_content",
+        return_value=mock_confirm_dialog,
+    )
     mocker.patch(
         "ui.ancillary_trust_database_admin.DeployConfirmDialog.get_content",
-        return_value=mock_dialog,
+        return_value=mock_deploy_dialog,
     )
+
     widget.on_deployBtn_clicked()
-    mock_dialog.run.assert_called()
-    mock_dialog.hide.assert_called()
+    mock_confirm_dialog.run.assert_called()
+    mock_confirm_dialog.hide.assert_called()
+    mock_deploy_dialog.run.assert_called()
+    mock_deploy_dialog.hide.assert_called()
+
+
+def test_on_neg_confirm_deployment(widget, mocker):
+    parent = Gtk.Window()
+    parent.add(widget.get_content())
+    mock_confirm_dialog = MagicMock(
+        run=MagicMock(return_value=Gtk.ResponseType.NO), hide=MagicMock()
+    )
+    mock_deploy_dialog = MagicMock(run=MagicMock())
+    mocker.patch(
+        "ui.ancillary_trust_database_admin.ConfirmDialog.get_content",
+        return_value=mock_confirm_dialog,
+    )
+    mocker.patch(
+        "ui.ancillary_trust_database_admin.DeployConfirmDialog.get_content",
+        return_value=mock_deploy_dialog,
+    )
+
+    widget.on_deployBtn_clicked()
+    mock_confirm_dialog.run.assert_called()
+    mock_confirm_dialog.hide.assert_called()
+    mock_deploy_dialog.run.assert_not_called()

--- a/ui/fapolicy_analyzer/tests/test_confirmation_dialog.py
+++ b/ui/fapolicy_analyzer/tests/test_confirmation_dialog.py
@@ -1,0 +1,27 @@
+import context  # noqa: F401
+import gi
+
+gi.require_version("Gtk", "3.0")
+from gi.repository import Gtk
+from helpers import delayed_gui_action
+from ui.confirmation_dialog import ConfirmDialog
+
+
+def test_creates_widget():
+    widget = ConfirmDialog("foo")
+    assert type(widget.get_content()) is Gtk.MessageDialog
+
+
+def test_adds_dialog_to_parent():
+    parent = Gtk.Window()
+    widget = ConfirmDialog("foo", parent=parent)
+    assert widget.get_content().get_transient_for() == parent
+
+
+def test_trust_database_admin_selection():
+    dialog = ConfirmDialog("foo").get_content()
+    for expected in [Gtk.ResponseType.YES, Gtk.ResponseType.NO]:
+        button = dialog.get_widget_for_response(expected)
+        delayed_gui_action(button.clicked)
+        response = dialog.run()
+        assert response == expected

--- a/ui/fapolicy_analyzer/ui/ancillary_trust_database_admin.py
+++ b/ui/fapolicy_analyzer/ui/ancillary_trust_database_admin.py
@@ -1,7 +1,12 @@
+import gi
+
+gi.require_version("Gtk", "3.0")
+from gi.repository import Gtk
 from fapolicy_analyzer.util import fs
 from .ui_widget import UIWidget
 from .trust_file_list import TrustFileList
 from .trust_file_details import TrustFileDetails
+from .confirmation_dialog import ConfirmDialog
 from .deploy_confirm_dialog import DeployConfirmDialog
 
 
@@ -55,8 +60,16 @@ SHA256: {fs.sha(trust.path)}"""
             )
 
     def on_deployBtn_clicked(self, *args):
-        deployConfirmDialog = DeployConfirmDialog(
-            self.content.get_toplevel()
+        parent = self.content.get_toplevel()
+        confirmDialog = ConfirmDialog(
+            "Deploy Ancillary Trust Changes?",
+            "Are you sure you wish to deploy your changes to the ancillary trust database? "
+            + "This will update the fapolicy trust and restart the service.",
+            parent,
         ).get_content()
-        deployConfirmDialog.run()
-        deployConfirmDialog.hide()
+        response = confirmDialog.run()
+        confirmDialog.hide()
+        if response == Gtk.ResponseType.YES:
+            deployConfirmDialog = DeployConfirmDialog(parent).get_content()
+            deployConfirmDialog.run()
+            deployConfirmDialog.hide()

--- a/ui/fapolicy_analyzer/ui/confirmation_dialog.py
+++ b/ui/fapolicy_analyzer/ui/confirmation_dialog.py
@@ -1,0 +1,23 @@
+import gi
+
+gi.require_version("Gtk", "3.0")
+from gi.repository import Gtk
+from .ui_widget import UIWidget
+
+
+class ConfirmDialog(UIWidget):
+    def __init__(self, text, secondary_text=None, parent=None):
+        self.dialog = Gtk.MessageDialog(
+            transient_for=parent if parent else None,
+            message_type=Gtk.MessageType.QUESTION,
+            buttons=Gtk.ButtonsType.YES_NO,
+            text=text,
+        )
+
+        if secondary_text:
+            self.dialog.format_secondary_text(secondary_text)
+
+        self.dialog.get_widget_for_response(Gtk.ResponseType.NO).grab_focus()
+
+    def get_content(self):
+        return self.dialog

--- a/ui/fapolicy_analyzer/ui/deploy_confirm_dialog.py
+++ b/ui/fapolicy_analyzer/ui/deploy_confirm_dialog.py
@@ -8,7 +8,7 @@ from .ui_widget import UIWidget
 
 
 class DeployConfirmDialog(UIWidget):
-    def __init__(self, parent=None, cancel_time=15):
+    def __init__(self, parent=None, cancel_time=30):
         super().__init__()
         self.dialog = self.builder.get_object("deployConfirmDialog")
         if parent:

--- a/ui/glade/deploy_confirm_dialog.glade
+++ b/ui/glade/deploy_confirm_dialog.glade
@@ -19,7 +19,7 @@
           <object class="GtkButtonBox">
             <property name="can-focus">False</property>
             <property name="homogeneous">True</property>
-            <property name="layout-style">end</property>
+            <property name="layout-style">expand</property>
           </object>
           <packing>
             <property name="expand">False</property>


### PR DESCRIPTION
Closes #50 

Adds a confirmation dialog before the data would actually be deployed to the fapolicy service, then follows the deployment with the keep changes confirmation dialog.