### PR TITLE
Issue 54 unapplied dlg

### DIFF
--- a/python/fapolicy_analyzer/tests/test_confirmation_dialog.py
+++ b/python/fapolicy_analyzer/tests/test_confirmation_dialog.py
@@ -22,6 +22,6 @@ def test_trust_database_admin_selection():
     dialog = ConfirmDialog("foo").get_content()
     for expected in [Gtk.ResponseType.YES, Gtk.ResponseType.NO]:
         button = dialog.get_widget_for_response(expected)
-        delayed_gui_action(button.clicked, delay=1)
+        delayed_gui_action(button.clicked, delay=5)
         response = dialog.run()
         assert response == expected

--- a/python/fapolicy_analyzer/ui/main_window.py
+++ b/python/fapolicy_analyzer/ui/main_window.py
@@ -5,7 +5,9 @@ from gi.repository import Gtk
 from .ui_widget import UIWidget
 from .database_admin_page import DatabaseAdminPage
 from .analyzer_selection_dialog import AnalyzerSelectionDialog, ANALYZER_SELECTION
+from .unapplied_changes_dialog import UnappliedChangesDialog
 
+#from fapolicy_analyzer import PyChangeSet
 
 class MainWindow(UIWidget):
     def __init__(self):
@@ -14,6 +16,16 @@ class MainWindow(UIWidget):
         self.window.show_all()
 
     def on_destroy(self, *args):
+        # Check backend for unapplied changes
+        if(True):
+            unappliedChangesDlg = UnappliedChangesDialog(self.window).get_content()
+            response = unappliedChangesDlg.run()
+            unappliedChangesDlg.destroy()
+            if response != Gtk.ResponseType.OK:
+                # Otherwise we keep the application open
+                return True
+
+        print('Terminating...')
         Gtk.main_quit()
 
     def on_aboutMenu_activate(self, menuitem, data=None):

--- a/python/fapolicy_analyzer/ui/main_window.py
+++ b/python/fapolicy_analyzer/ui/main_window.py
@@ -6,8 +6,7 @@ from .ui_widget import UIWidget
 from .database_admin_page import DatabaseAdminPage
 from .analyzer_selection_dialog import AnalyzerSelectionDialog, ANALYZER_SELECTION
 from .unapplied_changes_dialog import UnappliedChangesDialog
-
-#from fapolicy_analyzer import PyChangeSet
+from fapolicy_analyzer import Changeset
 
 class MainWindow(UIWidget):
     def __init__(self):
@@ -17,12 +16,15 @@ class MainWindow(UIWidget):
 
     def on_destroy(self, *args):
         # Check backend for unapplied changes
-        if(True):
-            unappliedChangesDlg = UnappliedChangesDialog(self.window).get_content()
+        if( Changeset().is_empty() == False ):
+            # Warn user pending changes will be lost. 
+            unapplied_changes_dlg = UnappliedChangesDialog(self.window)
+            unappliedChangesDlg = unapplied_changes_dlg.get_content()
             response = unappliedChangesDlg.run()
             unappliedChangesDlg.destroy()
+
+            # User returns to application
             if response != Gtk.ResponseType.OK:
-                # Otherwise we keep the application open
                 return True
 
         print('Terminating...')

--- a/python/fapolicy_analyzer/ui/main_window.py
+++ b/python/fapolicy_analyzer/ui/main_window.py
@@ -1,5 +1,5 @@
 import gi
-
+import time
 gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk
 from .ui_widget import UIWidget
@@ -16,7 +16,7 @@ class MainWindow(UIWidget):
 
     def on_destroy(self, *args):
         # Check backend for unapplied changes
-        if( Changeset().is_empty() == False ):
+        if not Changeset().is_empty():
             # Warn user pending changes will be lost. 
             unapplied_changes_dlg = UnappliedChangesDialog(self.window)
             unappliedChangesDlg = unapplied_changes_dlg.get_content()
@@ -26,7 +26,7 @@ class MainWindow(UIWidget):
             # User returns to application
             if response != Gtk.ResponseType.OK:
                 return True
-
+             
         print('Terminating...')
         Gtk.main_quit()
 

--- a/python/fapolicy_analyzer/ui/main_window.py
+++ b/python/fapolicy_analyzer/ui/main_window.py
@@ -16,21 +16,26 @@ class MainWindow(UIWidget):
         self.window = self.builder.get_object("mainWindow")
         self.window.show_all()
 
-    def on_destroy(self, *args):
+    def __unapplied_changes(self):
         # Check backend for unapplied changes
         if not Changeset().is_empty():
-            # Warn user pending changes will be lost.
-            unapplied_changes_dlg = UnappliedChangesDialog(self.window)
-            unappliedChangesDlg = unapplied_changes_dlg.get_content()
-            response = unappliedChangesDlg.run()
-            unappliedChangesDlg.destroy()
+            return False
 
-            # User returns to application
-            if response != Gtk.ResponseType.OK:
-                return True
+        # Warn user pending changes will be lost.
+        unapplied_changes_dlg = UnappliedChangesDialog(self.window)
+        unappliedChangesDlg = unapplied_changes_dlg.get_content()
+        response = unappliedChangesDlg.run()
+        unappliedChangesDlg.destroy()
+        return response != Gtk.ResponseType.OK
 
-        print("Terminating...")
+    def on_destroy(self, obj, *args):
+        if not isinstance(obj, Gtk.Window) and self.__unapplied_changes():
+            return True
+
         Gtk.main_quit()
+
+    def on_delete_event(self, *args):
+        return self.__unapplied_changes()
 
     def on_aboutMenu_activate(self, menuitem, data=None):
         aboutDialog = self.builder.get_object("aboutDialog")

--- a/python/fapolicy_analyzer/ui/main_window.py
+++ b/python/fapolicy_analyzer/ui/main_window.py
@@ -1,5 +1,6 @@
 import gi
 import time
+
 gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk
 from .ui_widget import UIWidget
@@ -7,6 +8,7 @@ from .database_admin_page import DatabaseAdminPage
 from .analyzer_selection_dialog import AnalyzerSelectionDialog, ANALYZER_SELECTION
 from .unapplied_changes_dialog import UnappliedChangesDialog
 from fapolicy_analyzer import Changeset
+
 
 class MainWindow(UIWidget):
     def __init__(self):
@@ -17,7 +19,7 @@ class MainWindow(UIWidget):
     def on_destroy(self, *args):
         # Check backend for unapplied changes
         if not Changeset().is_empty():
-            # Warn user pending changes will be lost. 
+            # Warn user pending changes will be lost.
             unapplied_changes_dlg = UnappliedChangesDialog(self.window)
             unappliedChangesDlg = unapplied_changes_dlg.get_content()
             response = unappliedChangesDlg.run()
@@ -26,8 +28,8 @@ class MainWindow(UIWidget):
             # User returns to application
             if response != Gtk.ResponseType.OK:
                 return True
-             
-        print('Terminating...')
+
+        print("Terminating...")
         Gtk.main_quit()
 
     def on_aboutMenu_activate(self, menuitem, data=None):

--- a/python/fapolicy_analyzer/ui/main_window.py
+++ b/python/fapolicy_analyzer/ui/main_window.py
@@ -1,5 +1,4 @@
 import gi
-import time
 
 gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk

--- a/python/fapolicy_analyzer/ui/unapplied_changes_dialog.py
+++ b/python/fapolicy_analyzer/ui/unapplied_changes_dialog.py
@@ -7,7 +7,7 @@ from .ui_widget import UIWidget
 
 
 class UnappliedChangesDialog(UIWidget):
-    def __init__(self, parent=None, cancel_time=30):
+    def __init__(self, parent=None):
         super().__init__()
         self.dialog = self.builder.get_object("unappliedChangesDialog")
         if parent:

--- a/python/fapolicy_analyzer/ui/unapplied_changes_dialog.py
+++ b/python/fapolicy_analyzer/ui/unapplied_changes_dialog.py
@@ -1,8 +1,3 @@
-import gi
-
-gi.require_version("Gtk", "3.0")
-from gi.repository import Gtk, GLib
-from time import sleep
 from .ui_widget import UIWidget
 
 

--- a/python/fapolicy_analyzer/ui/unapplied_changes_dialog.py
+++ b/python/fapolicy_analyzer/ui/unapplied_changes_dialog.py
@@ -16,3 +16,7 @@ class UnappliedChangesDialog(UIWidget):
     def get_content(self):
         return self.dialog
 
+    # ToDo: Only stubbed here to address thrown exception. Needs research to
+    # correctly code expected functionality.
+    def on_after_show(self, argUnhandled):
+        pass

--- a/python/fapolicy_analyzer/ui/unapplied_changes_dialog.py
+++ b/python/fapolicy_analyzer/ui/unapplied_changes_dialog.py
@@ -1,0 +1,18 @@
+import gi
+
+gi.require_version("Gtk", "3.0")
+from gi.repository import Gtk, GLib
+from time import sleep
+from .ui_widget import UIWidget
+
+
+class UnappliedChangesDialog(UIWidget):
+    def __init__(self, parent=None, cancel_time=30):
+        super().__init__()
+        self.dialog = self.builder.get_object("unappliedChangesDialog")
+        if parent:
+            self.dialog.set_transient_for(parent)
+
+    def get_content(self):
+        return self.dialog
+

--- a/python/fapolicy_analyzer/ui/unapplied_changes_dialog.py
+++ b/python/fapolicy_analyzer/ui/unapplied_changes_dialog.py
@@ -15,8 +15,3 @@ class UnappliedChangesDialog(UIWidget):
 
     def get_content(self):
         return self.dialog
-
-    # ToDo: Only stubbed here to address thrown exception. Needs research to
-    # correctly code expected functionality.
-    def on_after_show(self, argUnhandled):
-        pass

--- a/python/glade/main_window.glade
+++ b/python/glade/main_window.glade
@@ -54,6 +54,7 @@
     <property name="title" translatable="yes">File Access Policy Analyzer</property>
     <property name="default-width">1024</property>
     <property name="default-height">768</property>
+    <signal name="delete-event" handler="on_delete_event" swapped="no"/>
     <signal name="destroy" handler="on_destroy" swapped="no"/>
     <signal name="show" handler="on_start" swapped="no"/>
     <child>

--- a/python/glade/unapplied_changes_dialog.glade
+++ b/python/glade/unapplied_changes_dialog.glade
@@ -14,7 +14,6 @@
     <property name="text" translatable="yes">
 There are unapplied changes.</property>
     <property name="secondary_text" translatable="yes">Your changes will be lost.</property>
-    <signal name="show" handler="on_after_show" after="yes" swapped="no"/>
     <child internal-child="vbox">
       <object class="GtkBox">
         <property name="can_focus">False</property>

--- a/python/glade/unapplied_changes_dialog.glade
+++ b/python/glade/unapplied_changes_dialog.glade
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated with glade 3.22.1 -->
+<interface>
+  <requires lib="gtk+" version="3.22"/>
+  <object class="GtkMessageDialog" id="unappliedChangesDialog">
+    <property name="height_request">5</property>
+    <property name="can_focus">False</property>
+    <property name="title" translatable="yes">Unapplied Changes</property>
+    <property name="resizable">False</property>
+    <property name="modal">True</property>
+    <property name="type_hint">dialog</property>
+    <property name="message_type">warning</property>
+    <property name="buttons">ok-cancel</property>
+    <property name="text" translatable="yes">
+There are unapplied changes.</property>
+    <property name="secondary_text" translatable="yes">Your unapplied changes will be lost.</property>
+    <signal name="show" handler="on_after_show" after="yes" swapped="no"/>
+    <child internal-child="vbox">
+      <object class="GtkBox">
+        <property name="can_focus">False</property>
+        <property name="orientation">vertical</property>
+        <property name="spacing">2</property>
+        <child internal-child="action_area">
+          <object class="GtkButtonBox">
+            <property name="can_focus">False</property>
+            <property name="homogeneous">True</property>
+            <property name="layout_style">end</property>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">False</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
+      </object>
+    </child>
+  </object>
+</interface>

--- a/python/glade/unapplied_changes_dialog.glade
+++ b/python/glade/unapplied_changes_dialog.glade
@@ -13,7 +13,7 @@
     <property name="buttons">ok-cancel</property>
     <property name="text" translatable="yes">
 There are unapplied changes.</property>
-    <property name="secondary_text" translatable="yes">Your unapplied changes will be lost.</property>
+    <property name="secondary_text" translatable="yes">Your changes will be lost.</property>
     <signal name="show" handler="on_after_show" after="yes" swapped="no"/>
     <child internal-child="vbox">
       <object class="GtkBox">


### PR DESCRIPTION
Unapplied changes warning dialog at exit implemented.

- Created glade warning dialog
- Created new python wrapper class for above
- Modified the main window's on_destroy() callback to query the backend for non-empty Changeset; if non-empty present Warning dialog to user.
- closes #55 