### PR TITLE
Integration test helper

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,7 @@
+branches:
+  only:
+    - master
+
 dist: bionic
 language: minimal
 before_install:

--- a/README.md
+++ b/README.md
@@ -11,5 +11,34 @@ python setup.py [develop | install]
 python examples/validate_install.py
 ```
 
+### writing integration tests
+
+We write integration tests using [Bats](https://bats-core.readthedocs.io/en/latest/index.html) and [Podman](https://podman.io/).  The integration tests can run locally or in Travis CI.
+
+An example that demonstrates fapolicyd blocking execution, followed by a trust adjustment, followed by successful execution. 
+
+```bash
+@test "trust: add" {
+  # initially denied :thumbs_down:
+  run in_container /deny/simple.sh
+  assert_output --partial "permission denied"
+
+  # add a trust entry for the script
+  run in_container python3 examples/add_trust.py /deny/simple.sh
+  assert_output --partial "applying"
+  assert_output --partial "signaling"
+
+  # check the db for the script
+  run in_container python3 examples/show_ancillary.py
+  assert_output --partial "/deny/simple.sh"
+
+  # now its runs :thumbs_up:
+  run in_container /deny/simple.sh
+  assert_output "OK"
+}
+```
+
+See the [test/bats](tests/bats) directory for more examples.
+
 ### developers
 See the [Wiki](https://github.com/ctc-oss/fapolicy-analyzer/wiki) for resources.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Tools to assist with the configuration and maintenance of [fapolicyd](https://gi
 
 ### Python bindings
 
-We generate python bindings using [setuptools_rust](https://github.com/PyO3/setuptools-rust) from the python directory.
+We generate python bindings using [setuptools_rust](https://setuptools-rust.readthedocs.io/en/latest/) from the python directory.
 
 ```
 pipenv install --dev

--- a/README.md
+++ b/README.md
@@ -5,7 +5,9 @@ Tools to assist with the configuration and maintenance of [fapolicyd](https://gi
 
 ### Python bindings
 
-We generate python bindings using [setuptools_rust](https://setuptools-rust.readthedocs.io/en/latest/) from the python directory.
+We write python bindings using [PyO3](https://github.com/PyO3/pyo3) and [setuptools_rust](https://setuptools-rust.readthedocs.io/en/latest/).
+
+To build and install the bindings run the following from the [python](python) directory:
 
 ```
 pipenv install --dev
@@ -18,7 +20,7 @@ python examples/validate_install.py
 
 We write integration tests using [Bats](https://bats-core.readthedocs.io/en/latest/index.html) and [Podman](https://podman.io/).  The integration tests can run locally or in Travis CI.
 
-An example that demonstrates fapolicyd blocking execution, followed by a trust adjustment, followed by successful execution. 
+A Bats test that validates changing the trust database looks like:
 
 ```bash
 @test "trust: add" {
@@ -31,7 +33,7 @@ An example that demonstrates fapolicyd blocking execution, followed by a trust a
   assert_output --partial "applying"
   assert_output --partial "signaling"
 
-  # check the db for the script
+  # check the fapolicyd trust db for the new entry
   run in_container python3 examples/show_ancillary.py
   assert_output --partial "/deny/simple.sh"
 
@@ -44,4 +46,5 @@ An example that demonstrates fapolicyd blocking execution, followed by a trust a
 See the [test/bats](tests/bats) directory for more examples.
 
 ### Developers
+
 See the [Wiki](https://github.com/ctc-oss/fapolicy-analyzer/wiki) for more resources.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ File Access Policy Analyzer
 
 Tools to assist with the configuration and maintenance of [fapolicyd](https://github.com/linux-application-whitelisting/fapolicyd).
 
-### python bindings
+### Python bindings
 
 We generate python bindings using [setuptools_rust](https://github.com/PyO3/setuptools-rust) from the python directory.
 
@@ -14,7 +14,7 @@ python setup.py [develop | install]
 python examples/validate_install.py
 ```
 
-### integration tests
+### Integration tests
 
 We write integration tests using [Bats](https://bats-core.readthedocs.io/en/latest/index.html) and [Podman](https://podman.io/).  The integration tests can run locally or in Travis CI.
 
@@ -43,5 +43,5 @@ An example that demonstrates fapolicyd blocking execution, followed by a trust a
 
 See the [test/bats](tests/bats) directory for more examples.
 
-### developers
+### Developers
 See the [Wiki](https://github.com/ctc-oss/fapolicy-analyzer/wiki) for more resources.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,10 @@ File Access Policy Analyzer
 
 Tools to assist with the configuration and maintenance of [fapolicyd](https://github.com/linux-application-whitelisting/fapolicyd).
 
-### generate python bindings
+### python bindings
+
+We generate python bindings using [setuptools_rust](https://github.com/PyO3/setuptools-rust) from the python directory.
+
 ```
 pipenv install --dev
 pipenv shell
@@ -11,7 +14,7 @@ python setup.py [develop | install]
 python examples/validate_install.py
 ```
 
-### writing integration tests
+### integration tests
 
 We write integration tests using [Bats](https://bats-core.readthedocs.io/en/latest/index.html) and [Podman](https://podman.io/).  The integration tests can run locally or in Travis CI.
 
@@ -41,4 +44,4 @@ An example that demonstrates fapolicyd blocking execution, followed by a trust a
 See the [test/bats](tests/bats) directory for more examples.
 
 ### developers
-See the [Wiki](https://github.com/ctc-oss/fapolicy-analyzer/wiki) for resources.
+See the [Wiki](https://github.com/ctc-oss/fapolicy-analyzer/wiki) for more resources.

--- a/tests/bats/basic_fapolicyd.bats
+++ b/tests/bats/basic_fapolicyd.bats
@@ -1,42 +1,19 @@
 #!/usr/bin/env bats
 
-test_name="test_example"
-test_image="ctcoss/fapolicyd"
-podman_cmd="sudo podman"
-voldir=/tmp/$test_name
-bats_test_dir="$BATS_CWD/tests/bats"
-bats_load_dir="$BATS_ROOT/share/bats"
+export test_name="basic_fapolicyd"
 
 setup() {
-  load "$bats_load_dir/assert/load.bash"
-  load "$bats_load_dir/support/load.bash"
-
-  sleep 1
-  mkdir -p "$voldir"
-  $podman_cmd run -d --name "$test_name" --rm -it \
-                     --privileged --entrypoint='' \
-                     -v "$bats_test_dir/etc/simple.rules:/etc/fapolicyd/fapolicyd.rules" \
-                     -v "$voldir:/allow" -v "$voldir:/deny" \
-                     "$test_image" fapolicyd --debug
-
-  cp "$bats_test_dir/bin/simple.sh" "$voldir"
-  sleep 1
+  load "helper/podman"
+  setup_with_rules ctcoss/fapolicyd simple.rules
+  add bin/simple.sh
 }
-
-teardown() {
-  $podman_cmd kill "$test_name"
-  rm -rf "$voldir"
-}
-
-# todo;; move the above into shared location
-# ==========================================
 
 @test "rule: deny script" {
-  run $podman_cmd exec -it $test_name /deny/simple.sh
+  run in_container /deny/simple.sh
   assert_output --partial "permission denied"
 }
 
 @test "rule: allow script" {
-  run $podman_cmd exec -it $test_name /allow/simple.sh
+  run in_container /allow/simple.sh
   assert_output "OK"
 }

--- a/tests/bats/basic_trust.bats
+++ b/tests/bats/basic_trust.bats
@@ -1,51 +1,28 @@
 #!/usr/bin/env bats
 
-test_name="test_example"
-test_image="ctcoss/fapolicy-analyzer"
-podman_cmd="sudo podman"
-voldir=/tmp/$test_name
-bats_test_dir="$BATS_CWD/tests/bats"
-bats_load_dir="$BATS_ROOT/share/bats"
+export test_name="basic_trust"
 
 setup() {
-  load "$bats_load_dir/assert/load.bash"
-  load "$bats_load_dir/support/load.bash"
-
-  sleep 1
-  mkdir -p "$voldir"
-  $podman_cmd run -d --name "$test_name" --rm -it \
-                     --privileged --entrypoint='' \
-                     -v "$bats_test_dir/etc/trust.rules:/etc/fapolicyd/fapolicyd.rules" \
-                     -v "$voldir:/allow" -v "$voldir:/deny" \
-                     "$test_image" fapolicyd --debug
-
-  cp "$bats_test_dir/bin/simple.sh" "$voldir"
-  sleep 1
+  load "helper/podman"
+  setup_with_rules ctcoss/fapolicy-analyzer trust.rules
+  add bin/simple.sh
 }
-
-teardown() {
-  $podman_cmd kill "$test_name"
-  rm -rf "$voldir"
-}
-
-# todo;; move the above into shared location
-# ==========================================
 
 @test "trust: add" {
   # initially denied :thumbs_down:
-  run $podman_cmd exec -it $test_name /deny/simple.sh
+  run in_container /deny/simple.sh
   assert_output --partial "permission denied"
 
   # trust the script
-  run $podman_cmd exec -it $test_name python3 examples/add_trust.py /deny/simple.sh
+  run in_container python3 examples/add_trust.py /deny/simple.sh
   assert_output --partial "applying"
   assert_output --partial "signaling"
 
   # check the db for the script
-  run $podman_cmd exec -it $test_name python3 examples/show_ancillary.py
+  run in_container python3 examples/show_ancillary.py
   assert_output --partial "/deny/simple.sh"
 
   # now its runs :thumbs_up:
-  run $podman_cmd exec -it $test_name /deny/simple.sh
+  run in_container /deny/simple.sh
   assert_output "OK"
 }

--- a/tests/bats/basic_trust.bats
+++ b/tests/bats/basic_trust.bats
@@ -13,18 +13,13 @@ setup() {
   run in_container /deny/simple.sh
   assert_output --partial "permission denied"
 
-  # there are no ancillary trust entries
-  run in_container python3 examples/show_ancillary.py --count
-  assert_output $'0\r'
-
   # trust the script
   run in_container python3 examples/add_trust.py /deny/simple.sh
   assert_output --partial "applying"
   assert_output --partial "signaling"
 
-  # the number of trust entries should be exactly 1 now
-  run in_container python3 examples/show_ancillary.py --count
-  assert_output $'1\r'
+  # give fapolicyd a second to update
+  sleep 1
 
   # check the db for the script
   run in_container python3 examples/show_ancillary.py

--- a/tests/bats/basic_trust.bats
+++ b/tests/bats/basic_trust.bats
@@ -13,10 +13,18 @@ setup() {
   run in_container /deny/simple.sh
   assert_output --partial "permission denied"
 
+  # there are no ancillary trust entries
+  run in_container python3 examples/show_ancillary.py --count
+  assert_output $'0\r'
+
   # trust the script
   run in_container python3 examples/add_trust.py /deny/simple.sh
   assert_output --partial "applying"
   assert_output --partial "signaling"
+
+  # the number of trust entries should be exactly 1 now
+  run in_container python3 examples/show_ancillary.py --count
+  assert_output $'1\r'
 
   # check the db for the script
   run in_container python3 examples/show_ancillary.py

--- a/tests/bats/helper/podman.bash
+++ b/tests/bats/helper/podman.bash
@@ -1,0 +1,53 @@
+# test_name must be set
+if [[ -z "$test_name" ]]; then
+  echo "test_name was not defined"
+  exit 1
+fi
+
+voldir="/tmp/$test_name"
+bats_test_dir="$BATS_CWD/tests/bats"
+the_podman=$(command -v podman)
+
+# hide podman impl details
+podman() {
+  sudo "$the_podman" "$@"
+}
+
+# run command in the test container
+in_container() {
+  podman exec -it "$test_name" "$@"
+}
+
+# add file to the volume
+add() {
+  local f="$1"
+  cp "$bats_test_dir/$1" "$voldir"
+}
+
+# setup the test with a rules entry
+setup_with_rules() {
+  local bats_load_dir="$BATS_ROOT/share/bats"
+  load "$bats_load_dir/assert/load.bash"
+  load "$bats_load_dir/support/load.bash"
+
+  bats_test_dir="$BATS_CWD/tests/bats"
+
+  local image="$1"
+  local rules="$2"
+
+  sleep 1
+  mkdir -p "$voldir"
+
+  podman run -d --name "$test_name" --rm -it \
+                     --privileged --entrypoint='' \
+                     -v "$bats_test_dir/etc/$rules:/etc/fapolicyd/fapolicyd.rules" \
+                     -v "$voldir:/allow" -v "$voldir:/deny" \
+                     "$image" fapolicyd --debug
+  sleep 1
+}
+
+# teardown deleting the volume host dir
+teardown() {
+  podman kill "$test_name"
+  rm -rf "$voldir"
+}


### PR DESCRIPTION
Adds a Bats loadable helper that reduces a significant amount of duplication and hides some implementation details.

Adds a master-only condition to travis yaml to limit builds.  All PR branches build from a separate setting in the travis web ui.

refs #94
fixes #97