### PR TITLE
Add untrusted system file to ancillary database

### DIFF
--- a/python/fapolicy_analyzer/tests/test_ancillary_trust_database_admin.py
+++ b/python/fapolicy_analyzer/tests/test_ancillary_trust_database_admin.py
@@ -20,15 +20,15 @@ def test_creates_widget(widget):
 
 def test_status_markup(widget):
     assert widget._AncillaryTrustDatabaseAdmin__status_markup("T") == (
-        "<b><u>T</u></b>/D/U",
+        "<b><u>T</u></b>/D",
         Colors.LIGHT_GREEN,
     )
     assert widget._AncillaryTrustDatabaseAdmin__status_markup("D") == (
-        "T/<b><u>D</u></b>/U",
+        "T/<b><u>D</u></b>",
         Colors.LIGHT_RED,
     )
     assert widget._AncillaryTrustDatabaseAdmin__status_markup("foo") == (
-        "T/D/<b><u>U</u></b>",
+        "T/D",
         Colors.LIGHT_YELLOW,
     )
 

--- a/python/fapolicy_analyzer/ui/ancillary_trust_database_admin.py
+++ b/python/fapolicy_analyzer/ui/ancillary_trust_database_admin.py
@@ -48,6 +48,15 @@ class AncillaryTrustDatabaseAdmin(UIWidget):
     def get_content(self):
         return self.content
 
+    def add_trusted_files(self, *files):
+        changeset = Changeset()
+        for f in files:
+            changeset.add_trust(f)
+
+        self.system = self.system.apply_changeset(changeset)
+        stateManager.add_changeset_q(changeset)
+        self.trustFileList.refresh(self.system.ancillary_trust)
+
     def on_file_selection_change(self, trust):
         trustBtn = self.get_object("trustBtn")
         untrustBtn = self.get_object("untrustBtn")
@@ -79,17 +88,9 @@ SHA256: {fs.sha(trust.path)}"""
             trustBtn.set_sensitive(False)
             untrustBtn.set_sensitive(False)
 
-    def on_files_added(self, paths):
-        if not paths:
-            return
-
-        changeset = Changeset()
-        for p in paths:
-            changeset.add_trust(p)
-
-        self.system = self.system.apply_changeset(changeset)
-        stateManager.add_changeset_q(changeset)
-        self.trustFileList.refresh(self.system.ancillary_trust)
+    def on_files_added(self, files):
+        if files:
+            self.add_trusted_files(files)
 
     def on_deployBtn_clicked(self, *args):
         parent = self.content.get_toplevel()

--- a/python/fapolicy_analyzer/ui/ancillary_trust_database_admin.py
+++ b/python/fapolicy_analyzer/ui/ancillary_trust_database_admin.py
@@ -38,11 +38,11 @@ class AncillaryTrustDatabaseAdmin(UIWidget):
     def __status_markup(self, status):
         s = status.lower()
         return (
-            ("<b><u>T</u></b>/D/U", Colors.LIGHT_GREEN)
+            ("<b><u>T</u></b>/D", Colors.LIGHT_GREEN)
             if s == "t"
-            else ("T/<b><u>D</u></b>/U", Colors.LIGHT_RED)
+            else ("T/<b><u>D</u></b>", Colors.LIGHT_RED)
             if s == "d"
-            else ("T/D/<b><u>U</u></b>", Colors.LIGHT_YELLOW)
+            else ("T/D", Colors.LIGHT_YELLOW)
         )
 
     def get_content(self):
@@ -80,8 +80,8 @@ SHA256: {fs.sha(trust.path)}"""
             self.trustFileDetails.set_trust_status(
                 "This file is trusted."
                 if trusted
-                else "This file is untrusted."
-                if status == "u"
+                else "There is a discrepancy with this file."
+                if status == "d"
                 else "The trust status of this file is unknown."
             )
         else:
@@ -90,7 +90,7 @@ SHA256: {fs.sha(trust.path)}"""
 
     def on_files_added(self, files):
         if files:
-            self.add_trusted_files(files)
+            self.add_trusted_files(*files)
 
     def on_deployBtn_clicked(self, *args):
         parent = self.content.get_toplevel()

--- a/python/fapolicy_analyzer/ui/database_admin_page.py
+++ b/python/fapolicy_analyzer/ui/database_admin_page.py
@@ -9,15 +9,26 @@ from .system_trust_database_admin import SystemTrustDatabaseAdmin
 class DatabaseAdminPage:
     def __init__(self):
         self.notebook = Gtk.Notebook()
+
+        self.systemTrustDbAdmin = SystemTrustDatabaseAdmin()
+        self.systemTrustDbAdmin.file_added_to_ancillary_trust += (
+            self.on_added_to_ancillary_trust
+        )
         self.notebook.append_page(
-            SystemTrustDatabaseAdmin().get_content(),
+            self.systemTrustDbAdmin.get_content(),
             Gtk.Label(label="System Trust Database"),
         )
+
+        self.ancillaryTrustDbAdmin = AncillaryTrustDatabaseAdmin()
         self.notebook.append_page(
-            AncillaryTrustDatabaseAdmin().get_content(),
+            self.ancillaryTrustDbAdmin.get_content(),
             Gtk.Label(label="Ancillary Trust Database"),
         )
+
         self.notebook.show_all()
 
     def get_content(self):
         return self.notebook
+
+    def on_added_to_ancillary_trust(self, file):
+        self.ancillaryTrustDbAdmin.add_trusted_files(file)

--- a/python/fapolicy_analyzer/ui/system_trust_database_admin.py
+++ b/python/fapolicy_analyzer/ui/system_trust_database_admin.py
@@ -59,7 +59,11 @@ SHA256: {trust.hash}"""
 SHA256: {fs.sha(trust.path)}"""
             )
             self.trustFileDetails.set_trust_status(
-                f"This file is {'trusted' if trusted else 'untrusted'}."
+                "This file is trusted."
+                if trusted
+                else "There is a discrepancy with this file."
+                if status == "d"
+                else "The trust status of this file is unknown."
             )
         else:
             addBtn.set_sensitive(False)

--- a/python/glade/system_trust_database_admin.glade
+++ b/python/glade/system_trust_database_admin.glade
@@ -46,6 +46,7 @@
                 <property name="sensitive">False</property>
                 <property name="can-focus">True</property>
                 <property name="receives-default">True</property>
+                <signal name="clicked" handler="on_addBtn_clicked" swapped="no"/>
               </object>
               <packing>
                 <property name="expand">True</property>


### PR DESCRIPTION
closes #103 

Wires up the Add to Ancillary Trust Database button on the System Trust Admin screen.