### PR TITLE
Async bindings for fetching trust

### DIFF
--- a/python/examples/show_ancillary_async.py
+++ b/python/examples/show_ancillary_async.py
@@ -1,0 +1,18 @@
+from fapolicy_analyzer import *
+from concurrent.futures import ThreadPoolExecutor
+
+executor = ThreadPoolExecutor(max_workers=2)
+
+s1 = System()
+print("executing ancillary_trust 1")
+future_1 = executor.submit(s1.ancillary_trust_async)
+
+s2 = System()
+print("executing ancillary_trust 2")
+future_2 = executor.submit(s2.ancillary_trust_async)
+
+result_1 = future_1.result()
+result_2 = future_2.result()
+
+print(f"found {len(result_1)} ancillary trust entries")
+print(f"found {len(result_2)} ancillary trust entries")

--- a/python/examples/show_system.py
+++ b/python/examples/show_system.py
@@ -1,24 +1,8 @@
 from fapolicy_analyzer import *
-from concurrent.futures import ThreadPoolExecutor
-
-executor = ThreadPoolExecutor(max_workers=2)
-
-s1 = System()
-print("executing 1")
-future_1 = executor.submit(s1.system_trust_allow_threads)
-
-s2 = System()
-print("executing 2")
-future_2 = executor.submit(s2.system_trust_allow_threads)
-
-result_1 = future_1.result()
-result_2 = future_2.result()
-
-
-print(f"found {len(result_1)} system trust entries")
-print(f"found {len(result_2)} system trust entries")
 
 # config is loaded from $HOME/.config/fapolicy-analyzer/fapolicy-analyzer.toml
+s1 = System()
+for t in s1.system_trust():
+    print(f"{t.path} {t.size} {t.hash}")
 
-# for t in s1.system_trust():
-#     print(f"{t.path} {t.size} {t.hash}")
+print(f"found {len(s1.system_trust())} system trust entries")

--- a/python/examples/show_system.py
+++ b/python/examples/show_system.py
@@ -1,8 +1,24 @@
 from fapolicy_analyzer import *
+from concurrent.futures import ThreadPoolExecutor
+
+executor = ThreadPoolExecutor(max_workers=2)
+
+s1 = System()
+print("executing 1")
+future_1 = executor.submit(s1.system_trust_allow_threads)
+
+s2 = System()
+print("executing 2")
+future_2 = executor.submit(s2.system_trust_allow_threads)
+
+result_1 = future_1.result()
+result_2 = future_2.result()
+
+
+print(f"found {len(result_1)} system trust entries")
+print(f"found {len(result_2)} system trust entries")
 
 # config is loaded from $HOME/.config/fapolicy-analyzer/fapolicy-analyzer.toml
-s1 = System()
-for t in s1.system_trust():
-    print(f"{t.path} {t.size} {t.hash}")
 
-print(f"found {len(s1.system_trust())} system trust entries")
+# for t in s1.system_trust():
+#     print(f"{t.path} {t.size} {t.hash}")

--- a/python/examples/show_system_async.py
+++ b/python/examples/show_system_async.py
@@ -1,0 +1,18 @@
+from fapolicy_analyzer import *
+from concurrent.futures import ThreadPoolExecutor
+
+executor = ThreadPoolExecutor(max_workers=2)
+
+s1 = System()
+print("executing system_trust 1")
+future_1 = executor.submit(s1.system_trust_async)
+
+s2 = System()
+print("executing system_trust 2")
+future_2 = executor.submit(s2.system_trust_async)
+
+result_1 = future_1.result()
+result_2 = future_2.result()
+
+print(f"found {len(result_1)} system trust entries")
+print(f"found {len(result_2)} system trust entries")

--- a/python/src/app.rs
+++ b/python/src/app.rs
@@ -50,6 +50,10 @@ impl PySystem {
             .collect()
     }
 
+    fn system_trust_allow_threads(&self, py: Python) -> Vec<PyTrust> {
+        py.allow_threads(|| self.system_trust())
+    }
+
     /// Obtain a list of trusted files sourced from the ancillary trust database.
     /// This represents state in the current fapolicyd database, not necessarily
     /// matching what is currently in the ancillary trust file.

--- a/python/src/app.rs
+++ b/python/src/app.rs
@@ -50,7 +50,12 @@ impl PySystem {
             .collect()
     }
 
-    fn system_trust_allow_threads(&self, py: Python) -> Vec<PyTrust> {
+    /// Obtain a list of trusted files sourced from the system trust database.
+    /// The system trust is generated from the contents of the RPM database.
+    /// This represents state in the current fapolicyd database, not necessarily
+    /// matching what is currently in the RPM database.
+    /// This call will not block other threads from executing.
+    fn system_trust_async(&self, py: Python) -> Vec<PyTrust> {
         py.allow_threads(|| self.system_trust())
     }
 
@@ -66,6 +71,14 @@ impl PySystem {
             .flatten()
             .map(PyTrust::from)
             .collect()
+    }
+
+    /// Obtain a list of trusted files sourced from the ancillary trust database.
+    /// This represents state in the current fapolicyd database, not necessarily
+    /// matching what is currently in the ancillary trust file.
+    /// This call will not block other threads from executing.
+    fn ancillary_trust_async(&self, py: Python) -> Vec<PyTrust> {
+        py.allow_threads(|| self.ancillary_trust())
     }
 
     /// Apply the changeset to the state of this System generating a new System


### PR DESCRIPTION
I put together an example of the `system_trust` method that will allow for python multithreading.  Its based on the [parallelism](https://pyo3.rs/v0.13.2/parallelism.html) section of the PYO3 docs.  @jw3 see what you think is the best way to integrate this into the bindings.

closes #112 