### PR TITLE
Use stable str split_once

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -56,6 +56,10 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: 3.8
+      - name: Set up Rust Stable
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -59,7 +59,9 @@ jobs:
       - name: Set up Rust Stable
         uses: actions-rs/toolchain@v1
         with:
+          profile: minimal
           toolchain: stable
+          override: true
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/README.md
+++ b/README.md
@@ -45,6 +45,12 @@ A Bats test that validates changing the trust database looks like:
 
 See the [test/bats](tests/bats) directory for more examples.
 
+### Requirements
+
+- fapolicyd 1.0
+- Python 3.8
+- Rust 1.52
+
 ### Developers
 
 See the [Wiki](https://github.com/ctc-oss/fapolicy-analyzer/wiki) for more resources.

--- a/examples/trustdb_dump.rs
+++ b/examples/trustdb_dump.rs
@@ -13,7 +13,7 @@ struct Opts {
 fn main() {
     let opts: Opts = Opts::parse();
     let path = match opts.path {
-        Some(p) => p.clone(),
+        Some(p) => p,
         None => All::load().system.trust_db_path,
     };
     let path = Path::new(&path);

--- a/examples/trustdb_init.rs
+++ b/examples/trustdb_init.rs
@@ -27,7 +27,7 @@ struct Opts {
 fn main() {
     let opts: Opts = Opts::parse();
     let path = match opts.dbdir {
-        Some(p) => p.clone(),
+        Some(p) => p,
         None => All::load().system.trust_db_path,
     };
     let path = Path::new(&path);

--- a/src/rpm.rs
+++ b/src/rpm.rs
@@ -46,7 +46,7 @@ fn parse(s: &str) -> Vec<api::Trust> {
             e.hash.as_ref().map(|hash| api::Trust {
                 path: e.path.clone(),
                 size: e.size,
-                hash: hash.clone().to_string(),
+                hash: hash.clone(),
                 source: api::TrustSource::System,
             })
         })

--- a/src/rpm.rs
+++ b/src/rpm.rs
@@ -42,19 +42,14 @@ fn parse(s: &str) -> Vec<api::Trust> {
         .iter()
         .flatten()
         .filter(|e| keep_entry(&e.path))
-        .map(|e| {
-            if let Some(hash) = &e.hash {
-                Some(api::Trust {
-                    path: e.path.clone(),
-                    size: e.size,
-                    hash: hash.to_string(),
-                    source: api::TrustSource::System,
-                })
-            } else {
-                None
-            }
+        .flat_map(|e| {
+            e.hash.as_ref().map(|hash| api::Trust {
+                path: e.path.clone(),
+                size: e.size,
+                hash: hash.clone().to_string(),
+                source: api::TrustSource::System,
+            })
         })
-        .flatten()
         .collect()
 }
 

--- a/src/trust.rs
+++ b/src/trust.rs
@@ -39,18 +39,9 @@ impl TrustPair {
     }
 }
 
-// todo;; https://github.com/rust-lang/rust/issues/74773
-fn str_split_once(s: &str) -> (&str, String) {
-    let mut splits = s.split(' ');
-    let head = splits.next().unwrap();
-    let tail = splits.collect::<Vec<&str>>().join(" ");
-    (head, tail)
-}
-
 impl From<TrustPair> for api::Trust {
     fn from(kv: TrustPair) -> Self {
-        // todo;; let v = kv.v.split_once(' ').unwrap().1;
-        let (t, v) = str_split_once(&kv.v);
+        let (t, v) = kv.v.split_once(' ').unwrap();
         parse_strtyped_trust_record(format!("{} {}", kv.k, v).as_str(), t).unwrap()
     }
 }
@@ -263,6 +254,23 @@ mod tests {
         assert_eq!(e.size, 157984);
         assert_eq!(
             e.hash,
+            "61a9960bf7d255a85811f4afcac51067b8f2e4c75e21cf4f2af95319d4ed1b87"
+        );
+    }
+
+    #[test]
+    // todo;; additional coverage for type 2 and invalid type
+    fn parse_trust_pair() {
+        let tp = TrustPair::new((
+            "/home/user/my-ls".as_bytes(),
+            "1 157984 61a9960bf7d255a85811f4afcac51067b8f2e4c75e21cf4f2af95319d4ed1b87".as_bytes(),
+        ));
+        let t: Trust = tp.into();
+
+        assert_eq!(t.path, "/home/user/my-ls");
+        assert_eq!(t.size, 157984);
+        assert_eq!(
+            t.hash,
             "61a9960bf7d255a85811f4afcac51067b8f2e4c75e21cf4f2af95319d4ed1b87"
         );
     }


### PR DESCRIPTION
Rust 1.52 released today, using the new `split_once`

closes #116 