### PR TITLE
Issue-43: wired up the UI trust/untrust buttons

### DIFF
--- a/python/glade/ancillary_trust_database_admin.glade
+++ b/python/glade/ancillary_trust_database_admin.glade
@@ -52,6 +52,7 @@
                     <property name="sensitive">False</property>
                     <property name="can-focus">True</property>
                     <property name="receives-default">True</property>
+                    <signal name="clicked" handler="on_trustBtn_clicked" swapped="no"/>
                   </object>
                   <packing>
                     <property name="expand">True</property>
@@ -66,6 +67,7 @@
                     <property name="sensitive">False</property>
                     <property name="can-focus">True</property>
                     <property name="receives-default">True</property>
+                    <signal name="clicked" handler="on_untrustBtn_clicked" swapped="no"/>
                   </object>
                   <packing>
                     <property name="expand">True</property>


### PR DESCRIPTION
closes #43

This wires up the trust and untrust button on the Ancillary Trust Database Admin screen so they create `Changesets`, add them to the `stateManager` and refresh the file list view.