### PR TITLE
Issue-45: wired up UI ancillary db deploy button

### DIFF
--- a/python/fapolicy_analyzer/tests/mocks.py
+++ b/python/fapolicy_analyzer/tests/mocks.py
@@ -15,3 +15,6 @@ class mock_System:
 
     def system_trust_async(self):
         return [self.mock_trust]
+
+    def deploy(self):
+        pass

--- a/python/fapolicy_analyzer/ui/ancillary_trust_database_admin.py
+++ b/python/fapolicy_analyzer/ui/ancillary_trust_database_admin.py
@@ -130,6 +130,7 @@ SHA256: {fs.sha(trust.path)}"""
         confirm_resp = confirmDialog.run()
         confirmDialog.hide()
         if confirm_resp == Gtk.ResponseType.YES:
+            self.system.deploy()
             deployConfirmDialog = DeployConfirmDialog(parent).get_content()
             revert_resp = deployConfirmDialog.run()
             deployConfirmDialog.hide()


### PR DESCRIPTION
closes #45 

Wires up the UI to call the `System.deploy` method after an affirmative from the Confirm deployment dialog.