### PR TITLE
Issue 62 localization of UI strings

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -93,7 +93,7 @@ jobs:
         id: install_deps
         run: |
           python -m pip install --upgrade pip
-          pip install flake8
+          pip install flake8 flake8-i18n
       - name: Lint with flake8
         run:  |
           cd python
@@ -114,6 +114,11 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: 3.8
+      - name: Install extra locales
+        id: install_locales
+        run: |
+          sudo apt-get -y install locales
+          sudo locale-gen es_ES.UTF-8
       - name: Install dependencies
         id: install_deps
         run: |
@@ -121,6 +126,7 @@ jobs:
           pip install pipenv
           cd python
           pipenv install --dev
+          pipenv run compile_catalog
           echo ::set-output name=virt_env::$(pipenv --venv)
       - name: Download bindings package
         id: download

--- a/.gitignore
+++ b/.gitignore
@@ -18,5 +18,6 @@ dist
 *.glade~
 .coverage
 .env
+*.mo
 
 src/bin

--- a/python/.flake8
+++ b/python/.flake8
@@ -1,3 +1,4 @@
 [flake8]
 ignore = E402,W503
 max-line-length = 120
+i18nfuncs = gettext ngettext _

--- a/python/Pipfile
+++ b/python/Pipfile
@@ -15,6 +15,9 @@ pytest = "*"
 pytest-cov = "*"
 pytest-mock = "*"
 pytest-watch = "*"
+babel = "*"
+babelgladeextractor = "*"
+flake8-i18n = "*"
 
 [packages]
 pycairo = "1.20.0"
@@ -30,3 +33,5 @@ allow_prereleases = true
 test = "pipenv run xvfb-run -a pytest -s --cov-report term-missing --cov=ui fapolicy_analyzer/"
 lint = "pipenv run flake8 fapolicy_analyzer/"
 watch-test = "pipenv run xvfb-run -a pytest-watch fapolicy_analyzer/ -- -s"
+extract_messages = "pipenv run python setup.py extract_messages"
+compile_catalog = "pipenv run python setup.py compile_catalog -f"

--- a/python/Pipfile.lock
+++ b/python/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "32d7205aa314d38b7d2bed24a97dd53dce35b5a87100e96a3585dbd8192fd651"
+            "sha256": "3eb9b4b896fa92fc48eec9394861d731019e086462e2e93355d8c22df1dc787c"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -72,100 +72,111 @@
         },
         "attrs": {
             "hashes": [
-                "sha256:31b2eced602aa8423c2aea9c76a724617ed67cf9513173fd3a4f03e3a929c7e6",
-                "sha256:832aa3cde19744e49938b91fea06d69ecb9e649c93ba974535d08ad92164f700"
+                "sha256:149e90d6d8ac20db7a955ad60cf0e6881a3f20d37096140088356da6c716b0b1",
+                "sha256:ef6aaac3ca6cd92904cdd0d83f629a15f18053ec84e6432106f7a4d04ae4f5fb"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==20.3.0"
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
+            "version": "==21.2.0"
+        },
+        "babel": {
+            "hashes": [
+                "sha256:ab49e12b91d937cd11f0b67cb259a57ab4ad2b59ac7a3b41d6c06c0ac5b0def9",
+                "sha256:bc0c176f9f6a994582230df350aa6e05ba2ebe4b3ac317eab29d9be5d2768da0"
+            ],
+            "index": "pypi",
+            "version": "==2.9.1"
+        },
+        "babelgladeextractor": {
+            "hashes": [
+                "sha256:bcf805e28b4bb18c8b6909a65a7cf5c7c2bcbf4ae50b164878c9682d22271798"
+            ],
+            "index": "pypi",
+            "version": "==0.7.0"
         },
         "black": {
             "hashes": [
-                "sha256:1c02557aa099101b9d21496f8a914e9ed2222ef70336404eeeac8edba836fbea"
+                "sha256:23695358dbcb3deafe7f0a3ad89feee5999a46be5fec21f4f1d108be0bcdb3b1",
+                "sha256:8a60071a0043876a4ae96e6c69bd3a127dad2c1ca7c8083573eb82f92705d008"
             ],
             "index": "pypi",
-            "version": "==20.8b1"
+            "version": "==21.5b1"
         },
         "click": {
             "hashes": [
-                "sha256:06b3a46da3b40f4bbe19b8ea5ba9a34e7925913a9b51608ff0c1d78ef0b814b4",
-                "sha256:7340a8666a3e2eff5f2ee778c2d06b606ce9891a61b2ee315e0a3994ffd2226a"
+                "sha256:8c04c11192119b1ef78ea049e0a6f0463e4c48ef00a30160c704337586f3ad7a",
+                "sha256:fba402a4a47334742d782209a7c79bc448911afe1149d07bdabdf480b3e2f4b6"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==8.0.0rc1"
+            "version": "==8.0.1"
         },
         "colorama": {
             "hashes": [
                 "sha256:5941b2b48a20143d2267e95b1c2a7603ce057ee39fd88e7329b0c292aa16869b",
                 "sha256:9f47eda37229f68eee03b24b9748937c7dc3868f906e8ba69fbcbdd3bc5dc3e2"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
             "version": "==0.4.4"
         },
         "coverage": {
-            "hashes": [
-                "sha256:00368e6328ebff76197fff5f4d5704b44098f89d8d99a67a349ad6674ec0b157",
-                "sha256:0389690e0a1c94e9a246dc3130355d70805e51ca509db1bf07fbde27efb33aa4",
-                "sha256:065d2181f44392893d37d0a4f9ff60b485d705f733356d0a2fb292a58c6f2e0f",
-                "sha256:082febdba717c769da92d5e19e14a659ebef6daab19b67fced304b7b8d2475e2",
-                "sha256:0a35ae0d590effb7cc96e7d6935ae2ab8a51526a111fbe0f12d1671aa9fdc377",
-                "sha256:142493f0400a0bd5acf03c52971229e937323c3e24c372800ae1c44a503e0921",
-                "sha256:186f53367a08e8d24cc534c7cbfa43a82d1618a48dec2e0c56e80577ec1888fe",
-                "sha256:2163a00bcd613e95e118c01ea2811f705fbbacf1904d657b24d306879e2303d3",
-                "sha256:24ecf342b1e23de259d81b3adc83578935babeb54f6950c9bd9534b12443a49c",
-                "sha256:2c24d3e09f433817ddd0cb2e8f82f8b42cd09a8ac558462fedf99be479ed4851",
-                "sha256:2d741575de4a13869c9d4a685235bacc897c94afd3703e2ad4fdc362f37e87da",
-                "sha256:305ca73c09dd84054a3a8f53d5b70e0325b5b303245d0b96ed505698dc7e8ea7",
-                "sha256:4bf1d0a390de707f8bfd49efdcdac9366ce77ed64cb35b344f58b1ec62517317",
-                "sha256:50d90d6b753debb7568621125aad4e5fb418e7bdcb0dba3fa6f4ee82994b35d4",
-                "sha256:5a2079bca21fa959608223b90cf2f95ce686a6497fb12bfaaa7bb24c3e298199",
-                "sha256:60c6d433f0357db7ed2a2a698fb75b8ce919ce547d6d6bc79c576e090f509768",
-                "sha256:66cfae29bccea703f02d8997f60d71e236c5a321588f5aa5a318bd88ca23dc0a",
-                "sha256:6d6fc990962559de1f3685eb3e365ca60f2e3257bfd145bf675c566b8ebb1944",
-                "sha256:703b126f3ad20c463b545e199c4da460695630da5fdfd949de6a6269b45eabab",
-                "sha256:730cee22c41852b90948343cdfd183db1e96a9de69fd4dabec3532c582afea68",
-                "sha256:7e4a16bde8a3b7424b2955130f5a6c29e741e7138fe05c5d9d72efc356076a80",
-                "sha256:801e8277958bc2e6cc1f2443a20a2a97f79583aa64524b130e1c0de44c287ca9",
-                "sha256:80baa69a78d5696c60b72dee44ac3d5ccf75ee82e84d018938ddf642d036a6a8",
-                "sha256:80c00ce9cef80afbf18d16cb3052f5601ba8d087501d829169eecb33c153346a",
-                "sha256:89db5a374d793344087732207ee15869549486b2148e3e2e6effe22146351fcd",
-                "sha256:917b98cc5725ea2e0b88c74d34182589a9be07092cb35b861ea9e74189174f71",
-                "sha256:9398f8fd89f6f260e94e57559df1885b8200b18312824b617a8789e0f5e7dc74",
-                "sha256:95b6f212bb0c7379f1f2f6e47c722fbdc7355d8b7488a68649e83dfa29522704",
-                "sha256:9f23313f3e494475581d46de3b8b6bdcf618ee1df412490e779a9aa0a6c72162",
-                "sha256:9f6f26e5b129bb0218aab30d368d6ead750517a457986f8854b1df4b4c318098",
-                "sha256:a502693c83a2c6558bc45b4c2dc01a00c9b99cb3cf846913438933a44af174fc",
-                "sha256:aa4999130a8e892fa9051edc18bf4daa0a2839d3f3de2dcfcbf0ae4619ee3b5e",
-                "sha256:b10be0b80784c1beb8061e5ce938d8511a182125de5fc695a60f0561b984d361",
-                "sha256:b1f7b23a606aaf2464eb81c23b5b20623e2ba44b4aaca6ea9bfe00e84a1a5264",
-                "sha256:b78c8d232d97dbc8ad3a3d94cc15fccabe9a331685d76d2e5cb5284acc4a5feb",
-                "sha256:b88fa862817035ad7921f2641c27a85dab12cc685ad3ef29c0caaf5b3d10a868",
-                "sha256:b93fb9137070899b5f10d6487724f4427b5945983a785e1e2f1102c5e175c516",
-                "sha256:b9639e16c1bc4eb8a78b3b30df4146bb78df5d52ba1b7454b634abd89aede6cc",
-                "sha256:baa3b6be365c97f80d92a397cb8963dcd9bc22d101b39784e77a9cad093812f8",
-                "sha256:c06c5758bae454a49dc3e7917804b46c31bb4a72cedfc8e7b4f17a318b3de9d6",
-                "sha256:c544153709e93ea7e9edcefee72f5afcf484a9cb526067065f9419419f4a3694",
-                "sha256:c6c74260ba130f7c20a340e8f9e544b0941621641f53edcf69e4602e12c9f29e",
-                "sha256:d040615ff5c02ffd97ba9f0f73b9db34c09b8142fbfdd363b2a79fa6a554242c",
-                "sha256:d85774b1ac09ec1d958e63baa436cc4c90e2e910294847ba51dcc3ca3ca04a63",
-                "sha256:e508bb216eee8350e77b436f9f99c4f2d8335ecb51483f5ffd8bf5e84aaa56d1",
-                "sha256:ea1cb38b1a52392ebb4e93eaf4a44b3cfdec35cca3f78a9a599f27b7f27031e2",
-                "sha256:ec310e0029d530d1043f638b7a326b349884421572626bc2909408da7b0d03e5",
-                "sha256:ed04b79f53fa975660f1a598120c504a0f4529170eeaf0d823fcc1f06f4d2e0f",
-                "sha256:f4909ee1ddabed351f0fa55063a7dbe498001e2245a9602d9fb0fd74afecdca9",
-                "sha256:f49ae9e19737493911e7f8e551310f719f463e442ea1ec92fe0804c62066a7e8",
-                "sha256:f4c93e6102087dda4931fcd50fa4ad44e8e43e09419290c5f05cc2c690961ebf",
-                "sha256:fa1b639d85af4794cb20d7cfd4c5ae38e94a418b17a2318a1992b470fb68260d"
+            "extras": [
+                "toml"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==5.6b1"
-        },
-        "dataclasses": {
             "hashes": [
-                "sha256:0201d89fa866f68c8ebd9d08ee6ff50c0b255f8ec63a71c16fda7af82bb887bf",
-                "sha256:8479067f342acf957dc82ec415d355ab5edb7e7646b90dc6e2fd1d96ad084c97"
+                "sha256:004d1880bed2d97151facef49f08e255a20ceb6f9432df75f4eef018fdd5a78c",
+                "sha256:01d84219b5cdbfc8122223b39a954820929497a1cb1422824bb86b07b74594b6",
+                "sha256:040af6c32813fa3eae5305d53f18875bedd079960822ef8ec067a66dd8afcd45",
+                "sha256:06191eb60f8d8a5bc046f3799f8a07a2d7aefb9504b0209aff0b47298333302a",
+                "sha256:13034c4409db851670bc9acd836243aeee299949bd5673e11844befcb0149f03",
+                "sha256:13c4ee887eca0f4c5a247b75398d4114c37882658300e153113dafb1d76de529",
+                "sha256:184a47bbe0aa6400ed2d41d8e9ed868b8205046518c52464fde713ea06e3a74a",
+                "sha256:18ba8bbede96a2c3dde7b868de9dcbd55670690af0988713f0603f037848418a",
+                "sha256:1aa846f56c3d49205c952d8318e76ccc2ae23303351d9270ab220004c580cfe2",
+                "sha256:217658ec7187497e3f3ebd901afdca1af062b42cfe3e0dafea4cced3983739f6",
+                "sha256:24d4a7de75446be83244eabbff746d66b9240ae020ced65d060815fac3423759",
+                "sha256:2910f4d36a6a9b4214bb7038d537f015346f413a975d57ca6b43bf23d6563b53",
+                "sha256:2949cad1c5208b8298d5686d5a85b66aae46d73eec2c3e08c817dd3513e5848a",
+                "sha256:2a3859cb82dcbda1cfd3e6f71c27081d18aa251d20a17d87d26d4cd216fb0af4",
+                "sha256:2cafbbb3af0733db200c9b5f798d18953b1a304d3f86a938367de1567f4b5bff",
+                "sha256:2e0d881ad471768bf6e6c2bf905d183543f10098e3b3640fc029509530091502",
+                "sha256:30c77c1dc9f253283e34c27935fded5015f7d1abe83bc7821680ac444eaf7793",
+                "sha256:3487286bc29a5aa4b93a072e9592f22254291ce96a9fbc5251f566b6b7343cdb",
+                "sha256:372da284cfd642d8e08ef606917846fa2ee350f64994bebfbd3afb0040436905",
+                "sha256:41179b8a845742d1eb60449bdb2992196e211341818565abded11cfa90efb821",
+                "sha256:44d654437b8ddd9eee7d1eaee28b7219bec228520ff809af170488fd2fed3e2b",
+                "sha256:4a7697d8cb0f27399b0e393c0b90f0f1e40c82023ea4d45d22bce7032a5d7b81",
+                "sha256:51cb9476a3987c8967ebab3f0fe144819781fca264f57f89760037a2ea191cb0",
+                "sha256:52596d3d0e8bdf3af43db3e9ba8dcdaac724ba7b5ca3f6358529d56f7a166f8b",
+                "sha256:53194af30d5bad77fcba80e23a1441c71abfb3e01192034f8246e0d8f99528f3",
+                "sha256:5fec2d43a2cc6965edc0bb9e83e1e4b557f76f843a77a2496cbe719583ce8184",
+                "sha256:6c90e11318f0d3c436a42409f2749ee1a115cd8b067d7f14c148f1ce5574d701",
+                "sha256:74d881fc777ebb11c63736622b60cb9e4aee5cace591ce274fb69e582a12a61a",
+                "sha256:7501140f755b725495941b43347ba8a2777407fc7f250d4f5a7d2a1050ba8e82",
+                "sha256:796c9c3c79747146ebd278dbe1e5c5c05dd6b10cc3bcb8389dfdf844f3ead638",
+                "sha256:869a64f53488f40fa5b5b9dcb9e9b2962a66a87dab37790f3fcfb5144b996ef5",
+                "sha256:8963a499849a1fc54b35b1c9f162f4108017b2e6db2c46c1bed93a72262ed083",
+                "sha256:8d0a0725ad7c1a0bcd8d1b437e191107d457e2ec1084b9f190630a4fb1af78e6",
+                "sha256:900fbf7759501bc7807fd6638c947d7a831fc9fdf742dc10f02956ff7220fa90",
+                "sha256:92b017ce34b68a7d67bd6d117e6d443a9bf63a2ecf8567bb3d8c6c7bc5014465",
+                "sha256:970284a88b99673ccb2e4e334cfb38a10aab7cd44f7457564d11898a74b62d0a",
+                "sha256:972c85d205b51e30e59525694670de6a8a89691186012535f9d7dbaa230e42c3",
+                "sha256:9a1ef3b66e38ef8618ce5fdc7bea3d9f45f3624e2a66295eea5e57966c85909e",
+                "sha256:af0e781009aaf59e25c5a678122391cb0f345ac0ec272c7961dc5455e1c40066",
+                "sha256:b6d534e4b2ab35c9f93f46229363e17f63c53ad01330df9f2d6bd1187e5eaacf",
+                "sha256:b7895207b4c843c76a25ab8c1e866261bcfe27bfaa20c192de5190121770672b",
+                "sha256:c0891a6a97b09c1f3e073a890514d5012eb256845c451bd48f7968ef939bf4ae",
+                "sha256:c2723d347ab06e7ddad1a58b2a821218239249a9e4365eaff6649d31180c1669",
+                "sha256:d1f8bf7b90ba55699b3a5e44930e93ff0189aa27186e96071fac7dd0d06a1873",
+                "sha256:d1f9ce122f83b2305592c11d64f181b87153fc2c2bbd3bb4a3dde8303cfb1a6b",
+                "sha256:d314ed732c25d29775e84a960c3c60808b682c08d86602ec2c3008e1202e3bb6",
+                "sha256:d636598c8305e1f90b439dbf4f66437de4a5e3c31fdf47ad29542478c8508bbb",
+                "sha256:deee1077aae10d8fa88cb02c845cfba9b62c55e1183f52f6ae6a2df6a2187160",
+                "sha256:ebe78fe9a0e874362175b02371bdfbee64d8edc42a044253ddf4ee7d3c15212c",
+                "sha256:f030f8873312a16414c0d8e1a1ddff2d3235655a2174e3648b4fa66b3f2f1079",
+                "sha256:f0b278ce10936db1a37e6954e15a3730bea96a0997c26d7fee88e6c396c2086d",
+                "sha256:f11642dddbb0253cc8853254301b51390ba0081750a8ac03f20ea8103f0c56b6"
             ],
-            "markers": "python_version < '3.7'",
-            "version": "==0.8"
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4'",
+            "version": "==5.5"
         },
         "docopt": {
             "hashes": [
@@ -175,19 +186,18 @@
         },
         "flake8": {
             "hashes": [
-                "sha256:1aa8990be1e689d96c745c5682b687ea49f2e05a443aff1f8251092b0014e378",
-                "sha256:3b9f848952dddccf635be78098ca75010f073bfe14d2c6bda867154bea728d2a"
+                "sha256:07528381786f2a6237b061f6e96610a4167b226cb926e2aa2b6b1d78057c576b",
+                "sha256:bf8fd333346d844f616e8d47905ef3a3384edae6b4e9beb0c5101e25e3110907"
             ],
             "index": "pypi",
-            "version": "==3.9.1"
+            "version": "==3.9.2"
         },
-        "importlib-metadata": {
+        "flake8-i18n": {
             "hashes": [
-                "sha256:19192b88d959336bfa6bdaaaef99aeafec179eca19c47c804e555703ee5f07ef",
-                "sha256:2e881981c9748d7282b374b68e759c87745c25427b67ecf0cc67fb6637a1bff9"
+                "sha256:6f17e780cb302b8532558d71abf0c99ca5fcc8df3e53ed34c74f0066404d466b"
             ],
-            "markers": "python_version < '3.8'",
-            "version": "==4.0.0"
+            "index": "pypi",
+            "version": "==0.1.0"
         },
         "iniconfig": {
             "hashes": [
@@ -227,11 +237,11 @@
         },
         "pluggy": {
             "hashes": [
-                "sha256:265a94bf44ca13662f12fcd1b074c14d4b269a712f051b6f644ef7e705d6735f",
-                "sha256:467f0219e89bb5061a8429c6fc5cf055fa3983a0e68e84a1d205046306b37d9e"
+                "sha256:15b2acde666561e1298d71b523007ed7364de07029219b604cf808bfa1c765b0",
+                "sha256:966c145cd83c96502c3c3868f50408687b38434af77734af1e9ca461a4081d2d"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==1.0.0.dev0"
+            "version": "==0.13.1"
         },
         "py": {
             "hashes": [
@@ -259,35 +269,35 @@
         },
         "pyparsing": {
             "hashes": [
-                "sha256:1c6409312ce2ce2997896af5756753778d5f1603666dba5587804f09ad82ed27",
-                "sha256:f4896b4cc085a1f8f8ae53a1a90db5a86b3825ff73eb974dffee3d9e701007f4"
+                "sha256:c203ec8783bf771a155b207279b9bccb8dea02d8f0c9e5f8ead507bc3246ecc1",
+                "sha256:ef9d7589ef3c200abe66653d3f1ab1033c3c419ae9b9bdb1240a85b024efc88b"
             ],
-            "markers": "python_version >= '3.5'",
-            "version": "==3.0.0b2"
+            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==2.4.7"
         },
         "pytest": {
             "hashes": [
-                "sha256:671238a46e4df0f3498d1c3270e5deb9b32d25134c99b7d75370a68cfbe9b634",
-                "sha256:6ad9c7bdf517a808242b998ac20063c41532a570d088d77eec1ee12b0b5574bc"
+                "sha256:50bcad0a0b9c5a72c8e4e7c9855a3ad496ca6a881a3641b4260605450772c54b",
+                "sha256:91ef2131a9bd6be8f76f1f08eac5c5317221d6ad1e143ae03894b862e8976890"
             ],
             "index": "pypi",
-            "version": "==6.2.3"
+            "version": "==6.2.4"
         },
         "pytest-cov": {
             "hashes": [
-                "sha256:359952d9d39b9f822d9d29324483e7ba04a3a17dd7d05aa6beb7ea01e359e5f7",
-                "sha256:bdb9fdb0b85a7cc825269a4c56b48ccaa5c7e365054b6038772c32ddcdc969da"
+                "sha256:8535764137fecce504a49c2b742288e3d34bc09eed298ad65963616cc98fd45e",
+                "sha256:95d4933dcbbacfa377bb60b29801daa30d90c33981ab2a79e9ab4452c165066e"
             ],
             "index": "pypi",
-            "version": "==2.11.1"
+            "version": "==2.12.0"
         },
         "pytest-mock": {
             "hashes": [
-                "sha256:379b391cfad22422ea2e252bdfc008edd08509029bcde3c25b2c0bd741e0424e",
-                "sha256:a1e2aba6af9560d313c642dae7e00a2a12b022b80301d9d7fc8ec6858e1dd9fc"
+                "sha256:30c2f2cc9759e76eee674b81ea28c9f0b94f8f0445a1b87762cadf774f0df7e3",
+                "sha256:40217a058c52a63f1042f0784f62009e976ba824c418cced42e88d5f40ab0e62"
             ],
             "index": "pypi",
-            "version": "==3.5.1"
+            "version": "==3.6.1"
         },
         "pytest-watch": {
             "hashes": [
@@ -295,6 +305,13 @@
             ],
             "index": "pypi",
             "version": "==4.2.0"
+        },
+        "pytz": {
+            "hashes": [
+                "sha256:83a4a90894bf38e243cf052c8b58f381bfe9a7a483f6a9cab140bc7f702ac4da",
+                "sha256:eb10ce3e7736052ed3623d49975ce333bcd712c7bb19a58b9e2089d4057d0798"
+            ],
+            "version": "==2021.1"
         },
         "regex": {
             "hashes": [
@@ -366,80 +383,28 @@
             "index": "pypi",
             "version": "==0.10.2"
         },
-        "typed-ast": {
-            "hashes": [
-                "sha256:01ae5f73431d21eead5015997ab41afa53aa1fbe252f9da060be5dad2c730ace",
-                "sha256:067a74454df670dcaa4e59349a2e5c81e567d8d65458d480a5b3dfecec08c5ff",
-                "sha256:0fb71b8c643187d7492c1f8352f2c15b4c4af3f6338f21681d3681b3dc31a266",
-                "sha256:1b3ead4a96c9101bef08f9f7d1217c096f31667617b58de957f690c92378b528",
-                "sha256:2068531575a125b87a41802130fa7e29f26c09a2833fea68d9a40cf33902eba6",
-                "sha256:209596a4ec71d990d71d5e0d312ac935d86930e6eecff6ccc7007fe54d703808",
-                "sha256:2c726c276d09fc5c414693a2de063f521052d9ea7c240ce553316f70656c84d4",
-                "sha256:398e44cd480f4d2b7ee8d98385ca104e35c81525dd98c519acff1b79bdaac363",
-                "sha256:52b1eb8c83f178ab787f3a4283f68258525f8d70f778a2f6dd54d3b5e5fb4341",
-                "sha256:5feca99c17af94057417d744607b82dd0a664fd5e4ca98061480fd8b14b18d04",
-                "sha256:7538e495704e2ccda9b234b82423a4038f324f3a10c43bc088a1636180f11a41",
-                "sha256:760ad187b1041a154f0e4d0f6aae3e40fdb51d6de16e5c99aedadd9246450e9e",
-                "sha256:777a26c84bea6cd934422ac2e3b78863a37017618b6e5c08f92ef69853e765d3",
-                "sha256:95431a26309a21874005845c21118c83991c63ea800dd44843e42a916aec5899",
-                "sha256:9ad2c92ec681e02baf81fdfa056fe0d818645efa9af1f1cd5fd6f1bd2bdfd805",
-                "sha256:9c6d1a54552b5330bc657b7ef0eae25d00ba7ffe85d9ea8ae6540d2197a3788c",
-                "sha256:aee0c1256be6c07bd3e1263ff920c325b59849dc95392a05f258bb9b259cf39c",
-                "sha256:af3d4a73793725138d6b334d9d247ce7e5f084d96284ed23f22ee626a7b88e39",
-                "sha256:b36b4f3920103a25e1d5d024d155c504080959582b928e91cb608a65c3a49e1a",
-                "sha256:b9574c6f03f685070d859e75c7f9eeca02d6933273b5e69572e5ff9d5e3931c3",
-                "sha256:bff6ad71c81b3bba8fa35f0f1921fb24ff4476235a6e94a26ada2e54370e6da7",
-                "sha256:c190f0899e9f9f8b6b7863debfb739abcb21a5c054f911ca3596d12b8a4c4c7f",
-                "sha256:c907f561b1e83e93fad565bac5ba9c22d96a54e7ea0267c708bffe863cbe4075",
-                "sha256:cae53c389825d3b46fb37538441f75d6aecc4174f615d048321b716df2757fb0",
-                "sha256:dd4a21253f42b8d2b48410cb31fe501d32f8b9fbeb1f55063ad102fe9c425e40",
-                "sha256:dde816ca9dac1d9c01dd504ea5967821606f02e510438120091b84e852367428",
-                "sha256:f2362f3cb0f3172c42938946dbc5b7843c2a28aec307c49100c8b38764eb6927",
-                "sha256:f328adcfebed9f11301eaedfa48e15bdece9b519fb27e6a8c01aa52a17ec31b3",
-                "sha256:f8afcf15cc511ada719a88e013cec87c11aff7b91f019295eb4530f96fe5ef2f",
-                "sha256:fb1bbeac803adea29cedd70781399c99138358c26d05fcbd23c13016b7f5ec65"
-            ],
-            "version": "==1.4.3"
-        },
-        "typing-extensions": {
-            "hashes": [
-                "sha256:7cb407020f00f7bfc3cb3e7881628838e69d8f3fcab2f64742a5e76b2f841918",
-                "sha256:99d4073b617d30288f569d3f13d2bd7548c3a7e4c8de87db09a9d29bb3a4a60c",
-                "sha256:dafc7639cde7f1b6e1acc0f457842a83e722ccca8eef5270af2d74792619a89f"
-            ],
-            "markers": "python_version < '3.8'",
-            "version": "==3.7.4.3"
-        },
         "watchdog": {
             "hashes": [
-                "sha256:035f4816daf3c62e03503c267620f3aa8fc7472df85ff3ef1e0c100ea1ed2744",
-                "sha256:0f7e9de9ba84af15e9e9fc29c3b13c972daa4d2b11de29aa86b26a26bc877c06",
-                "sha256:13c9ff58508dce55ba416eb0ef7af5aa5858558f2ec51112f099fd03503b670b",
-                "sha256:19675b8d1f00dabe74a0e66d87980623250d9360a21612e8c27b70a4b214ceeb",
-                "sha256:1cd715c4fb803581ded8943f39a51f21c17375d009ca9e3398d6b20638863a70",
-                "sha256:1f518a6940cde8720b8826a705c164e6b9bd6cf8c00f14269ffac51e017e06ec",
-                "sha256:3e933f3567c4521dd1a5d59fd54a522cae90bebcbeb8b74b84a2f33c90f08388",
-                "sha256:41b1a773f364f232b5bc184688e8d60451745d9e0971ac60c648bd47be8f4733",
-                "sha256:532fedd993e75554671faa36cd04c580ced3fae084254a779afbbd8aaf00566b",
-                "sha256:74528772516228f6a015a647027057939ff0b695a0b864cb3037e8e1aabc7ca0",
-                "sha256:89102465764e453609463cf620e744da1b0aa1f9f321b05961e2e7e15b3c9d8b",
-                "sha256:a412b1914e27f67b0a10e1ee19b5d035a9f7c115a062bbbd640653d9820ba4c8",
-                "sha256:ac6adbdf32e1d180574f9d0819e80259ae48e68727e80c3d950ed5a023714c3e",
-                "sha256:adda34bfe6db05485c1dfcd98232bdec385f991fe16358750c2163473eefb985",
-                "sha256:d2fcbc15772a82cd139c803a513c45b0fbc72a10a8a34dc2a8b429110b6f1236",
-                "sha256:d54e187b76053982180532cb7fd31152201c438b348c456f699929f8a89e786d",
-                "sha256:e0114e48ee981b38e328eaa0d5a625c7b4fc144b8dc7f7637749d6b5f7fefb0e"
+                "sha256:0237db4d9024859bea27d0efb59fe75eef290833fd988b8ead7a879b0308c2db",
+                "sha256:104266a778906ae0e971368d368a65c4cd032a490a9fca5ba0b78c6c7ae11720",
+                "sha256:188145185c08c73c56f1478ccf1f0f0f85101191439679b35b6b100886ce0b39",
+                "sha256:1a62a4671796dc93d1a7262286217d9e75823c63d4c42782912d39a506d30046",
+                "sha256:255a32d44bbbe62e52874ff755e2eefe271b150e0ec240ad7718a62a7a7a73c4",
+                "sha256:3d6405681471ebe0beb3aa083998c4870e48b57f8afdb45ea1b5957cc5cf1014",
+                "sha256:4b219d46d89cfa49af1d73175487c14a318a74cb8c5442603fd13c6a5b418c86",
+                "sha256:581e3548159fe7d2a9f377a1fbcb41bdcee46849cca8ab803c7ac2e5e04ec77c",
+                "sha256:58ebb1095ee493008a7789d47dd62e4999505d82be89fc884d473086fccc6ebd",
+                "sha256:598d772beeaf9c98d0df946fbabf0c8365dd95ea46a250c224c725fe0c4730bc",
+                "sha256:668391e6c32742d76e5be5db6bf95c455fa4b3d11e76a77c13b39bccb3a47a72",
+                "sha256:6ef9fe57162c4c361692620e1d9167574ba1975ee468b24051ca11c9bba6438e",
+                "sha256:91387ee2421f30b75f7ff632c9d48f76648e56bf346a7c805c0a34187a93aab4",
+                "sha256:a42e6d652f820b2b94cd03156c62559a2ea68d476476dfcd77d931e7f1012d4a",
+                "sha256:a6471517315a8541a943c00b45f1d252e36898a3ae963d2d52509b89a50cb2b9",
+                "sha256:d34ce2261f118ecd57eedeef95fc2a495fc4a40b3ed7b3bf0bd7a8ccc1ab4f8f",
+                "sha256:edcd9ef3fd460bb8a98eb1fcf99941e9fd9f275f45f1a82cb1359ec92975d647"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==2.0.2"
-        },
-        "zipp": {
-            "hashes": [
-                "sha256:3607921face881ba3e026887d8150cca609d517579abe052ac81fc5aeffdbd76",
-                "sha256:51cb66cc54621609dd593d1787f286ee42a5c0adbb4b29abea5a63edc3e03098"
-            ],
-            "markers": "python_version >= '3.6'",
-            "version": "==3.4.1"
+            "version": "==2.1.2"
         }
     }
 }

--- a/python/babel.cfg
+++ b/python/babel.cfg
@@ -1,0 +1,2 @@
+[python: **.py]
+[glade: **.glade]

--- a/python/fapolicy_analyzer/tests/test_main_window.py
+++ b/python/fapolicy_analyzer/tests/test_main_window.py
@@ -1,5 +1,6 @@
 import context  # noqa: F401
 import pytest
+import locale
 import gi
 
 gi.require_version("Gtk", "3.0")
@@ -27,6 +28,13 @@ class StubMainWindow(MainWindow):
 @pytest.fixture
 def mainWindow():
     return StubMainWindow()
+
+
+@pytest.fixture
+def es_locale():
+    locale.setlocale(locale.LC_ALL, "es_ES.UTF-8")
+    yield
+    locale.setlocale(locale.LC_ALL, "")
 
 
 def test_displays_window(mainWindow):
@@ -69,3 +77,11 @@ def test_raises_bad_selection_error(mainWindow, mocker):
     )
     with pytest.raises(Exception, match="Bad Selection"):
         mainWindow.original_on_start()
+
+
+def test_localization(es_locale):
+    mainWindow = StubMainWindow()
+    assert type(mainWindow.window) is Gtk.Window
+    assert (
+        mainWindow.window.get_title() == "Analizador de políticas de acceso a archivos"
+    )

--- a/python/fapolicy_analyzer/ui/ancillary_trust_database_admin.py
+++ b/python/fapolicy_analyzer/ui/ancillary_trust_database_admin.py
@@ -1,4 +1,5 @@
 import gi
+import ui.strings as strings
 
 gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk, GLib
@@ -107,11 +108,11 @@ SHA256: {fs.sha(trust.path)}"""
             )
 
             self.trustFileDetails.set_trust_status(
-                _("This file is trusted.")
+                strings.TRUSTED_FILE_MESSAGE
                 if trusted
-                else _("There is a discrepancy with this file.")
+                else strings.DISCREPANCY_FILE_MESSAGE
                 if status == "d"
-                else _("The trust status of this file is unknown.")
+                else strings.UNKNOWN_FILE_MESSAGE
             )
         else:
             trustBtn.set_sensitive(False)
@@ -132,11 +133,8 @@ SHA256: {fs.sha(trust.path)}"""
     def on_deployBtn_clicked(self, *args):
         parent = self.content.get_toplevel()
         confirmDialog = ConfirmDialog(
-            _("Deploy Ancillary Trust Changes?"),
-            _(
-                "Are you sure you wish to deploy your changes to the ancillary trust database? "
-                + "This will update the fapolicy trust and restart the service."
-            ),
+            strings.DEPLOY_ANCILLARY_CONFIRM_DIALOG_TITLE,
+            strings.DEPLOY_ANCILLARY_CONFIRM_DIALOG_TEXT,
             parent,
         ).get_content()
         confirm_resp = confirmDialog.run()

--- a/python/fapolicy_analyzer/ui/ancillary_trust_database_admin.py
+++ b/python/fapolicy_analyzer/ui/ancillary_trust_database_admin.py
@@ -4,7 +4,9 @@ gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk, GLib
 from concurrent.futures import ThreadPoolExecutor
 from fapolicy_analyzer import Changeset, System
-from fapolicy_analyzer.util import fs
+from locale import gettext as _
+from fapolicy_analyzer.util.format import f
+from fapolicy_analyzer.util import fs  # noqa: F401
 from .ui_widget import UIWidget
 from .trust_file_list import TrustFileList
 from .trust_file_details import TrustFileDetails
@@ -65,14 +67,14 @@ class AncillaryTrustDatabaseAdmin(UIWidget):
 
     def add_trusted_files(self, *files):
         changeset = Changeset()
-        for f in files:
-            changeset.add_trust(f)
+        for file in files:
+            changeset.add_trust(file)
         self.__apply_changeset(changeset)
 
     def delete_trusted_files(self, *files):
         changeset = Changeset()
-        for f in files:
-            changeset.del_trust(f)
+        for file in files:
+            changeset.del_trust(file)
         self.__apply_changeset(changeset)
 
     def on_file_selection_change(self, trust):
@@ -86,22 +88,30 @@ class AncillaryTrustDatabaseAdmin(UIWidget):
             untrustBtn.set_sensitive(trusted)
 
             self.trustFileDetails.set_in_databae_view(
-                f"""File: {trust.path}
+                f(
+                    _(
+                        """File: {trust.path}
 Size: {trust.size}
 SHA256: {trust.hash}"""
+                    )
+                )
             )
 
             self.trustFileDetails.set_on_file_system_view(
-                f"""{fs.stat(trust.path)}
+                f(
+                    _(
+                        """{fs.stat(trust.path)}
 SHA256: {fs.sha(trust.path)}"""
+                    )
+                )
             )
 
             self.trustFileDetails.set_trust_status(
-                "This file is trusted."
+                _("This file is trusted.")
                 if trusted
-                else "There is a discrepancy with this file."
+                else _("There is a discrepancy with this file.")
                 if status == "d"
-                else "The trust status of this file is unknown."
+                else _("The trust status of this file is unknown.")
             )
         else:
             trustBtn.set_sensitive(False)
@@ -122,9 +132,11 @@ SHA256: {fs.sha(trust.path)}"""
     def on_deployBtn_clicked(self, *args):
         parent = self.content.get_toplevel()
         confirmDialog = ConfirmDialog(
-            "Deploy Ancillary Trust Changes?",
-            "Are you sure you wish to deploy your changes to the ancillary trust database? "
-            + "This will update the fapolicy trust and restart the service.",
+            _("Deploy Ancillary Trust Changes?"),
+            _(
+                "Are you sure you wish to deploy your changes to the ancillary trust database? "
+                + "This will update the fapolicy trust and restart the service."
+            ),
             parent,
         ).get_content()
         confirm_resp = confirmDialog.run()

--- a/python/fapolicy_analyzer/ui/database_admin_page.py
+++ b/python/fapolicy_analyzer/ui/database_admin_page.py
@@ -2,6 +2,7 @@ import gi
 
 gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk
+from locale import gettext as _
 from .ancillary_trust_database_admin import AncillaryTrustDatabaseAdmin
 from .system_trust_database_admin import SystemTrustDatabaseAdmin
 
@@ -18,11 +19,11 @@ class DatabaseAdminPage:
 
         self.notebook.append_page(
             self.systemTrustDbAdmin.get_content(),
-            Gtk.Label(label="System Trust Database"),
+            Gtk.Label(label=_("System Trust Database")),
         )
         self.notebook.append_page(
             self.ancillaryTrustDbAdmin.get_content(),
-            Gtk.Label(label="Ancillary Trust Database"),
+            Gtk.Label(label=_("Ancillary Trust Database")),
         )
 
         self.notebook.set_current_page(1)

--- a/python/fapolicy_analyzer/ui/database_admin_page.py
+++ b/python/fapolicy_analyzer/ui/database_admin_page.py
@@ -1,8 +1,8 @@
 import gi
+import ui.strings as strings
 
 gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk
-from locale import gettext as _
 from .ancillary_trust_database_admin import AncillaryTrustDatabaseAdmin
 from .system_trust_database_admin import SystemTrustDatabaseAdmin
 
@@ -19,11 +19,11 @@ class DatabaseAdminPage:
 
         self.notebook.append_page(
             self.systemTrustDbAdmin.get_content(),
-            Gtk.Label(label=_("System Trust Database")),
+            Gtk.Label(label=strings.SYSTEM_TRUST_TAB_LABEL),
         )
         self.notebook.append_page(
             self.ancillaryTrustDbAdmin.get_content(),
-            Gtk.Label(label=_("Ancillary Trust Database")),
+            Gtk.Label(label=strings.ANCILLARY_TRUST_TAB_LABEL),
         )
 
         self.notebook.set_current_page(1)

--- a/python/fapolicy_analyzer/ui/deploy_confirm_dialog.py
+++ b/python/fapolicy_analyzer/ui/deploy_confirm_dialog.py
@@ -4,7 +4,9 @@ gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk, GLib
 from threading import Thread
 from time import sleep
+from locale import gettext as _
 from .ui_widget import UIWidget
+from fapolicy_analyzer.util.format import f
 
 
 class DeployConfirmDialog(UIWidget):
@@ -27,7 +29,7 @@ class DeployConfirmDialog(UIWidget):
         for i in reversed(range(0, self.cancel_time)):
             GLib.idle_add(
                 self.dialog.format_secondary_text,
-                f"Reverting to previous settings in {i+1} seconds",
+                f(_("Reverting to previous settings in {i+1} seconds")),
             )
             sleep(1)
         GLib.idle_add(self.dialog.response, Gtk.ResponseType.NO)

--- a/python/fapolicy_analyzer/ui/strings.py
+++ b/python/fapolicy_analyzer/ui/strings.py
@@ -1,0 +1,25 @@
+from locale import gettext as _
+
+DEPLOY_ANCILLARY_CONFIRM_DIALOG_TITLE = _("Deploy Ancillary Trust Changes?")
+DEPLOY_ANCILLARY_CONFIRM_DIALOG_TEXT = _(
+    """Are you sure you wish to deploy your changes to the ancillary trust database?
+ This will update the fapolicy trust and restart the service."""
+)
+
+TRUSTED_FILE_MESSAGE = _("This file is trusted.")
+DISCREPANCY_FILE_MESSAGE = _("There is a discrepancy with this file.")
+UNKNOWN_FILE_MESSAGE = _("The trust status of this file is unknown.")
+
+SYSTEM_TRUST_TAB_LABEL = _("System Trust Database")
+ANCILLARY_TRUST_TAB_LABEL = _("Ancillary Trust Database")
+
+FILE_LIST_TRUST_HEADER = _("Trust")
+FILE_LIST_FILE_HEADER = _("File")
+
+ADD_FILE_BUTTON_LABEL = _("Add File")
+
+WHITESPACE_WARNING_DIALOG_TITLE = _("File path(s) contains embedded whitespace.")
+WHITESPACE_WARNING_DIALOG_TEXT = _(
+    "fapolicyd currently does not support paths containing spaces. The following paths will not be added to the "
+    + "Trusted Files List.\n(fapolicyd: V TBD)\n\n"
+)

--- a/python/fapolicy_analyzer/ui/system_trust_database_admin.py
+++ b/python/fapolicy_analyzer/ui/system_trust_database_admin.py
@@ -5,7 +5,9 @@ from gi.repository import GLib
 from events import Events
 from concurrent.futures import ThreadPoolExecutor
 from fapolicy_analyzer import System
-from fapolicy_analyzer.util import fs
+from locale import gettext as _
+from fapolicy_analyzer.util.format import f
+from fapolicy_analyzer.util import fs  # noqa: F401
 from .trust_file_list import TrustFileList
 from .trust_file_details import TrustFileDetails
 from .ui_widget import UIWidget
@@ -63,20 +65,28 @@ class SystemTrustDatabaseAdmin(UIWidget, Events):
             addBtn.set_sensitive(not trusted)
 
             self.trustFileDetails.set_in_databae_view(
-                f"""File: {trust.path}
+                f(
+                    _(
+                        """File: {trust.path}
 Size: {trust.size}
 SHA256: {trust.hash}"""
+                    )
+                )
             )
             self.trustFileDetails.set_on_file_system_view(
-                f"""{fs.stat(trust.path)}
+                f(
+                    _(
+                        """{fs.stat(trust.path)}
 SHA256: {fs.sha(trust.path)}"""
+                    )
+                )
             )
             self.trustFileDetails.set_trust_status(
-                "This file is trusted."
+                _("This file is trusted.")
                 if trusted
-                else "There is a discrepancy with this file."
+                else _("There is a discrepancy with this file.")
                 if status == "d"
-                else "The trust status of this file is unknown."
+                else _("The trust status of this file is unknown.")
             )
         else:
             addBtn.set_sensitive(False)

--- a/python/fapolicy_analyzer/ui/system_trust_database_admin.py
+++ b/python/fapolicy_analyzer/ui/system_trust_database_admin.py
@@ -1,4 +1,5 @@
 import gi
+import ui.strings as strings
 
 gi.require_version("Gtk", "3.0")
 from gi.repository import GLib
@@ -82,11 +83,11 @@ SHA256: {fs.sha(trust.path)}"""
                 )
             )
             self.trustFileDetails.set_trust_status(
-                _("This file is trusted.")
+                strings.TRUSTED_FILE_MESSAGE
                 if trusted
-                else _("There is a discrepancy with this file.")
+                else strings.DISCREPANCY_FILE_MESSAGE
                 if status == "d"
-                else _("The trust status of this file is unknown.")
+                else strings.UNKNOWN_FILE_MESSAGE
             )
         else:
             addBtn.set_sensitive(False)

--- a/python/fapolicy_analyzer/ui/trust_file_list.py
+++ b/python/fapolicy_analyzer/ui/trust_file_list.py
@@ -1,11 +1,12 @@
 import gi
 import re
+import ui.strings as strings
+
 
 gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk, GdkPixbuf
 from os import path
 from events import Events
-from locale import gettext as _
 from .ui_widget import UIWidget
 
 
@@ -17,11 +18,16 @@ class TrustFileList(UIWidget, Events):
             self.trustView = self.get_object("trustView")
             trustCell = Gtk.CellRendererText()
             trustCell.set_property("background", "light gray")
-            trustColumn = Gtk.TreeViewColumn(_("Trust"), trustCell, markup=0)
+            trustColumn = Gtk.TreeViewColumn(
+                strings.FILE_LIST_TRUST_HEADER, trustCell, markup=0
+            )
             trustColumn.set_sort_column_id(0)
             self.trustView.append_column(trustColumn)
             fileColumn = Gtk.TreeViewColumn(
-                _("File"), Gtk.CellRendererText(), text=1, cell_background=3
+                strings.FILE_LIST_FILE_HEADER,
+                Gtk.CellRendererText(),
+                text=1,
+                cell_background=3,
             )
             fileColumn.set_sort_column_id(1)
             self.trustView.append_column(fileColumn)
@@ -96,7 +102,7 @@ class TrustFileList(UIWidget, Events):
 
     def on_addBtn_clicked(self, *args):
         fcd = Gtk.FileChooserDialog(
-            _("Add File"),
+            strings.ADD_FILE_BUTTON_LABEL,
             self.trustFileList.get_toplevel(),
             Gtk.FileChooserAction.OPEN,
             (
@@ -125,19 +131,14 @@ class TrustFileList(UIWidget, Events):
                     flags=0,
                     message_type=Gtk.MessageType.INFO,
                     buttons=Gtk.ButtonsType.OK,
-                    text=_("File path(s) contains embedded whitespace."),
+                    text=strings.WHITESPACE_WARNING_DIALOG_TITLE,
                 )
 
                 # Convert list of paths to a single string
                 strListRejected = "\n".join(listRejected)
 
                 dlgWhitespaceInfo.format_secondary_text(
-                    _(
-                        "  fapolicyd currently does not support paths containing\n"
-                        + "    spaces. The following paths will not be added to the\n"
-                        + "            Trusted Files List.(fapolicyd: V TBD)\n\n"
-                    )
-                    + strListRejected
+                    strings.WHITESPACE_WARNING_DIALOG_TEXT + strListRejected
                 )
                 dlgWhitespaceInfo.run()
                 dlgWhitespaceInfo.destroy()

--- a/python/fapolicy_analyzer/ui/trust_file_list.py
+++ b/python/fapolicy_analyzer/ui/trust_file_list.py
@@ -1,4 +1,3 @@
-
 import gi
 import re
 
@@ -6,6 +5,7 @@ gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk, GdkPixbuf
 from os import path
 from events import Events
+from locale import gettext as _
 from .ui_widget import UIWidget
 
 
@@ -17,11 +17,11 @@ class TrustFileList(UIWidget, Events):
             self.trustView = self.get_object("trustView")
             trustCell = Gtk.CellRendererText()
             trustCell.set_property("background", "light gray")
-            trustColumn = Gtk.TreeViewColumn("Trust", trustCell, markup=0)
+            trustColumn = Gtk.TreeViewColumn(_("Trust"), trustCell, markup=0)
             trustColumn.set_sort_column_id(0)
             self.trustView.append_column(trustColumn)
             fileColumn = Gtk.TreeViewColumn(
-                "File", Gtk.CellRendererText(), text=1, cell_background=3
+                _("File"), Gtk.CellRendererText(), text=1, cell_background=3
             )
             fileColumn.set_sort_column_id(1)
             self.trustView.append_column(fileColumn)
@@ -96,7 +96,7 @@ class TrustFileList(UIWidget, Events):
 
     def on_addBtn_clicked(self, *args):
         fcd = Gtk.FileChooserDialog(
-            "Add File",
+            _("Add File"),
             self.trustFileList.get_toplevel(),
             Gtk.FileChooserAction.OPEN,
             (
@@ -125,16 +125,20 @@ class TrustFileList(UIWidget, Events):
                     flags=0,
                     message_type=Gtk.MessageType.INFO,
                     buttons=Gtk.ButtonsType.OK,
-                    text="File path(s) contains embedded whitespace.")
+                    text=_("File path(s) contains embedded whitespace."),
+                )
 
                 # Convert list of paths to a single string
                 strListRejected = "\n".join(listRejected)
 
                 dlgWhitespaceInfo.format_secondary_text(
-                    "  fapolicyd currently does not support paths containing\n"
-                    "    spaces. The following paths will not be added to the\n"
-                    "            Trusted Files List.(fapolicyd: V TBD)\n\n"
-                    + strListRejected)
+                    _(
+                        "  fapolicyd currently does not support paths containing\n"
+                        + "    spaces. The following paths will not be added to the\n"
+                        + "            Trusted Files List.(fapolicyd: V TBD)\n\n"
+                    )
+                    + strListRejected
+                )
                 dlgWhitespaceInfo.run()
                 dlgWhitespaceInfo.destroy()
             files = listAccepted

--- a/python/fapolicy_analyzer/ui/ui_widget.py
+++ b/python/fapolicy_analyzer/ui/ui_widget.py
@@ -1,18 +1,18 @@
+import locale
 import os
 import sys
-import locale
 import gi
 
 gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk
 from abc import ABC
 
-domain = "fapolicy_analyzer"
+
+DOMAIN = "fapolicy_analyzer"
 locale_path = os.path.join(os.path.abspath(os.path.dirname(__file__)), "../../locale")
 locale.setlocale(locale.LC_ALL, locale.getlocale())
-locale.bindtextdomain(domain, locale_path)
-locale.textdomain(domain)
-# translate = gettext.translation("", localedir, fallback=True)
+locale.bindtextdomain(DOMAIN, locale_path)
+locale.textdomain(DOMAIN)
 
 
 class UIWidget(ABC):
@@ -21,7 +21,7 @@ class UIWidget(ABC):
             f"../../glade/{self.__module__.split('.')[-1]}.glade"
         )
         self.builder = Gtk.Builder()
-        self.builder.set_translation_domain(domain)
+        self.builder.set_translation_domain(DOMAIN)
         self.builder.add_from_file(gladeFile)
         self.builder.connect_signals(self)
 

--- a/python/fapolicy_analyzer/ui/ui_widget.py
+++ b/python/fapolicy_analyzer/ui/ui_widget.py
@@ -1,10 +1,18 @@
 import os
 import sys
+import locale
 import gi
 
 gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk
 from abc import ABC
+
+domain = "fapolicy_analyzer"
+locale_path = os.path.join(os.path.abspath(os.path.dirname(__file__)), "../../locale")
+locale.setlocale(locale.LC_ALL, locale.getlocale())
+locale.bindtextdomain(domain, locale_path)
+locale.textdomain(domain)
+# translate = gettext.translation("", localedir, fallback=True)
 
 
 class UIWidget(ABC):
@@ -13,6 +21,7 @@ class UIWidget(ABC):
             f"../../glade/{self.__module__.split('.')[-1]}.glade"
         )
         self.builder = Gtk.Builder()
+        self.builder.set_translation_domain(domain)
         self.builder.add_from_file(gladeFile)
         self.builder.connect_signals(self)
 

--- a/python/fapolicy_analyzer/util/format.py
+++ b/python/fapolicy_analyzer/util/format.py
@@ -1,0 +1,6 @@
+from inspect import currentframe
+
+
+def f(formatString):
+    frame = currentframe().f_back
+    return eval(f'f"""{formatString}"""', frame.f_locals, frame.f_globals)

--- a/python/locale/es/LC_MESSAGES/fapolicy_analyzer.po
+++ b/python/locale/es/LC_MESSAGES/fapolicy_analyzer.po
@@ -1,5 +1,3 @@
-#: fapolicy_analyzer/ui/ancillary_trust_database_admin.py:92
-#: fapolicy_analyzer/ui/system_trust_database_admin.py:69
 msgid ""
 "File: {trust.path}\n"
 "Size: {trust.size}\n"
@@ -9,26 +7,18 @@ msgstr ""
 "Tamaño: {trust.size}\n"
 "SHA256: {trust.hash}"
 
-#: fapolicy_analyzer/ui/ancillary_trust_database_admin.py:110
-#: fapolicy_analyzer/ui/system_trust_database_admin.py:85
 msgid "This file is trusted."
 msgstr "Este archivo es de confianza."
 
-#: fapolicy_analyzer/ui/ancillary_trust_database_admin.py:112
-#: fapolicy_analyzer/ui/system_trust_database_admin.py:87
 msgid "There is a discrepancy with this file."
 msgstr "Existe una discrepancia con este archivo."
 
-#: fapolicy_analyzer/ui/ancillary_trust_database_admin.py:114
-#: fapolicy_analyzer/ui/system_trust_database_admin.py:89
 msgid "The trust status of this file is unknown."
 msgstr "Se desconoce el estado de confianza de este archivo."
 
-#: fapolicy_analyzer/ui/ancillary_trust_database_admin.py:126
 msgid "Deploy Ancillary Trust Changes?"
 msgstr "¿Implementar cambios de confianza complementarios?"
 
-#: fapolicy_analyzer/ui/ancillary_trust_database_admin.py:127
 msgid ""
 "Are you sure you wish to deploy your changes to the ancillary trust "
 "database? This will update the fapolicy trust and restart the service."
@@ -36,129 +26,98 @@ msgstr ""
 "¿Está seguro de que desea implementar sus cambios en el fideicomiso auxiliar "
 "base de datos? Esto actualizará la confianza de fapolicy y reiniciará el servicio."
 
-#: fapolicy_analyzer/ui/database_admin_page.py:22
 msgid "System Trust Database"
 msgstr "Base de datos de confianza del sistema"
 
-#: fapolicy_analyzer/ui/database_admin_page.py:26
 msgid "Ancillary Trust Database"
 msgstr "Base de datos de confianza auxiliar"
 
-#: fapolicy_analyzer/ui/deploy_confirm_dialog.py:30
 msgid "Reverting to previous settings in {i+1} seconds"
 msgstr "Volviendo a la configuración anterior en {i+1} segundos"
 
-
-#: fapolicy_analyzer/ui/trust_file_list.py:23
 msgid "File"
 msgstr "Fichero"
 
-#: fapolicy_analyzer/ui/trust_file_list.py:98
 msgid "Add File"
 msgstr "Agregar Fichero"
 
-#: fapolicy_analyzer/ui/trust_file_list.py:128
 msgid "File path(s) contains embedded whitespace."
 msgstr "Las rutas de fichero contienen espacios en blanco incrustados."
 
-#: fapolicy_analyzer/ui/trust_file_list.py:135
 msgid ""
-"  fapolicyd currently does not support paths containing\n"
-"    spaces. The following paths will not be added to the\n"
-"            Trusted Files List.(fapolicyd: V TBD)\n"
+"fapolicyd currently does not support paths containing spaces. The "
+"following paths will not be added to the Trusted Files List.\n"
+"(fapolicyd: V TBD)\n"
 "\n"
 msgstr ""
-"  fapolicyd actualmente no admite rutas que contengan\n"
-"    espacios. Las siguientes rutas no se agregarán a la\n"
-"            Lista de archivos de confianza (fapolicyd: V TBD)\n"
+"fapolicyd actualmente no admite rutas que contengan espacios. Las "
+"siguientes rutas no se agregarán a la Lista de archivos de confianza.\n"
+"(fapolicyd: V TBD)\n"
 "\n"
 
-#: glade/analyzer_selection_dialog.glade:25
 msgid "Scan System"
 msgstr "Sistema de escaneo"
 
-#: glade/analyzer_selection_dialog.glade:39
 msgid "Administer Trust Databases"
 msgstr "Administrar bases de datos de confianza"
 
-#: glade/analyzer_selection_dialog.glade:61
 msgid "Analyzer Selection"
 msgstr "Selección del analizador"
 
-#: glade/analyzer_selection_dialog.glade:94
 msgid "Analyze From Audit"
 msgstr "Analizar desde auditoría"
 
-#: fapolicy_analyzer/ui/trust_file_list.py:19
-#: glade/ancillary_trust_database_admin.glade:50
 msgid "Trust"
 msgstr "Confianza"
 
-#: glade/ancillary_trust_database_admin.glade:65
 msgid "Untrust"
 msgstr "Desconfianza"
 
-#: glade/ancillary_trust_database_admin.glade:102
 msgid "Deploy Ancillary Trust"
 msgstr "Implementar confianza auxiliar"
 
-#: glade/deploy_confirm_dialog.glade:10
 msgid "Keep these trust changes?"
 msgstr "¿Conservar estos cambios de confianza?"
 
-#: glade/deploy_confirm_dialog.glade:11
 msgid "Reverting to previous settings in 15 seconds."
 msgstr "Volviendo a la configuración anterior en 15 segundos."
 
-#: glade/main_window.glade:7
 msgid "About File Acccess Policy Analyzer"
 msgstr "Acerca del analizador de políticas de acceso a archivos"
 
-#: glade/main_window.glade:54
 msgid "File Access Policy Analyzer"
 msgstr "Analizador de políticas de acceso a archivos"
 
-#: glade/main_window.glade:73
 msgid "_File"
 msgstr "_Archivo"
 
-#: glade/main_window.glade:97
 msgid "_Help"
 msgstr "_Ayudar"
 
-#: glade/system_trust_database_admin.glade:44
 msgid "Add File To Ancillary Trust Database"
 msgstr "Agregar archivo a la base de datos de confianza auxiliar"
 
-#: glade/trust_file_details.glade:41
 msgid "In Database"
 msgstr "En base de datos"
 
-#: glade/trust_file_details.glade:81
 msgid "On File System"
 msgstr "En el sistema de archivos"
 
-#: glade/trust_file_details.glade:120
 msgid "File Trust Status"
 msgstr "Estado de confianza del archivo"
 
-#: glade/trust_file_list.glade:75
 msgid "page0"
 msgstr "página0"
 
-#: glade/trust_file_list.glade:102
 msgid "Loading..."
 msgstr "Cargando..."
 
-#: glade/trust_file_list.glade:117
 msgid "page1"
 msgstr "página1"
 
-#: glade/unapplied_changes_dialog.glade:8
 msgid "Unapplied Changes"
 msgstr "Cambios no aplicados"
 
-#: glade/unapplied_changes_dialog.glade:15
 msgid ""
 "\n"
 "There are unapplied changes."
@@ -166,6 +125,5 @@ msgstr ""
 "\n"
 "Hay cambios sin aplicar."
 
-#: glade/unapplied_changes_dialog.glade:16
 msgid "Your changes will be lost."
 msgstr "Tus cambios se perderán."

--- a/python/locale/es/LC_MESSAGES/fapolicy_analyzer.po
+++ b/python/locale/es/LC_MESSAGES/fapolicy_analyzer.po
@@ -1,0 +1,171 @@
+#: fapolicy_analyzer/ui/ancillary_trust_database_admin.py:92
+#: fapolicy_analyzer/ui/system_trust_database_admin.py:69
+msgid ""
+"File: {trust.path}\n"
+"Size: {trust.size}\n"
+"SHA256: {trust.hash}"
+msgstr ""
+"Fichero: {trust.path}\n"
+"Tamaño: {trust.size}\n"
+"SHA256: {trust.hash}"
+
+#: fapolicy_analyzer/ui/ancillary_trust_database_admin.py:110
+#: fapolicy_analyzer/ui/system_trust_database_admin.py:85
+msgid "This file is trusted."
+msgstr "Este archivo es de confianza."
+
+#: fapolicy_analyzer/ui/ancillary_trust_database_admin.py:112
+#: fapolicy_analyzer/ui/system_trust_database_admin.py:87
+msgid "There is a discrepancy with this file."
+msgstr "Existe una discrepancia con este archivo."
+
+#: fapolicy_analyzer/ui/ancillary_trust_database_admin.py:114
+#: fapolicy_analyzer/ui/system_trust_database_admin.py:89
+msgid "The trust status of this file is unknown."
+msgstr "Se desconoce el estado de confianza de este archivo."
+
+#: fapolicy_analyzer/ui/ancillary_trust_database_admin.py:126
+msgid "Deploy Ancillary Trust Changes?"
+msgstr "¿Implementar cambios de confianza complementarios?"
+
+#: fapolicy_analyzer/ui/ancillary_trust_database_admin.py:127
+msgid ""
+"Are you sure you wish to deploy your changes to the ancillary trust "
+"database? This will update the fapolicy trust and restart the service."
+msgstr ""
+"¿Está seguro de que desea implementar sus cambios en el fideicomiso auxiliar "
+"base de datos? Esto actualizará la confianza de fapolicy y reiniciará el servicio."
+
+#: fapolicy_analyzer/ui/database_admin_page.py:22
+msgid "System Trust Database"
+msgstr "Base de datos de confianza del sistema"
+
+#: fapolicy_analyzer/ui/database_admin_page.py:26
+msgid "Ancillary Trust Database"
+msgstr "Base de datos de confianza auxiliar"
+
+#: fapolicy_analyzer/ui/deploy_confirm_dialog.py:30
+msgid "Reverting to previous settings in {i+1} seconds"
+msgstr "Volviendo a la configuración anterior en {i+1} segundos"
+
+
+#: fapolicy_analyzer/ui/trust_file_list.py:23
+msgid "File"
+msgstr "Fichero"
+
+#: fapolicy_analyzer/ui/trust_file_list.py:98
+msgid "Add File"
+msgstr "Agregar Fichero"
+
+#: fapolicy_analyzer/ui/trust_file_list.py:128
+msgid "File path(s) contains embedded whitespace."
+msgstr "Las rutas de fichero contienen espacios en blanco incrustados."
+
+#: fapolicy_analyzer/ui/trust_file_list.py:135
+msgid ""
+"  fapolicyd currently does not support paths containing\n"
+"    spaces. The following paths will not be added to the\n"
+"            Trusted Files List.(fapolicyd: V TBD)\n"
+"\n"
+msgstr ""
+"  fapolicyd actualmente no admite rutas que contengan\n"
+"    espacios. Las siguientes rutas no se agregarán a la\n"
+"            Lista de archivos de confianza (fapolicyd: V TBD)\n"
+"\n"
+
+#: glade/analyzer_selection_dialog.glade:25
+msgid "Scan System"
+msgstr "Sistema de escaneo"
+
+#: glade/analyzer_selection_dialog.glade:39
+msgid "Administer Trust Databases"
+msgstr "Administrar bases de datos de confianza"
+
+#: glade/analyzer_selection_dialog.glade:61
+msgid "Analyzer Selection"
+msgstr "Selección del analizador"
+
+#: glade/analyzer_selection_dialog.glade:94
+msgid "Analyze From Audit"
+msgstr "Analizar desde auditoría"
+
+#: fapolicy_analyzer/ui/trust_file_list.py:19
+#: glade/ancillary_trust_database_admin.glade:50
+msgid "Trust"
+msgstr "Confianza"
+
+#: glade/ancillary_trust_database_admin.glade:65
+msgid "Untrust"
+msgstr "Desconfianza"
+
+#: glade/ancillary_trust_database_admin.glade:102
+msgid "Deploy Ancillary Trust"
+msgstr "Implementar confianza auxiliar"
+
+#: glade/deploy_confirm_dialog.glade:10
+msgid "Keep these trust changes?"
+msgstr "¿Conservar estos cambios de confianza?"
+
+#: glade/deploy_confirm_dialog.glade:11
+msgid "Reverting to previous settings in 15 seconds."
+msgstr "Volviendo a la configuración anterior en 15 segundos."
+
+#: glade/main_window.glade:7
+msgid "About File Acccess Policy Analyzer"
+msgstr "Acerca del analizador de políticas de acceso a archivos"
+
+#: glade/main_window.glade:54
+msgid "File Access Policy Analyzer"
+msgstr "Analizador de políticas de acceso a archivos"
+
+#: glade/main_window.glade:73
+msgid "_File"
+msgstr "_Archivo"
+
+#: glade/main_window.glade:97
+msgid "_Help"
+msgstr "_Ayudar"
+
+#: glade/system_trust_database_admin.glade:44
+msgid "Add File To Ancillary Trust Database"
+msgstr "Agregar archivo a la base de datos de confianza auxiliar"
+
+#: glade/trust_file_details.glade:41
+msgid "In Database"
+msgstr "En base de datos"
+
+#: glade/trust_file_details.glade:81
+msgid "On File System"
+msgstr "En el sistema de archivos"
+
+#: glade/trust_file_details.glade:120
+msgid "File Trust Status"
+msgstr "Estado de confianza del archivo"
+
+#: glade/trust_file_list.glade:75
+msgid "page0"
+msgstr "página0"
+
+#: glade/trust_file_list.glade:102
+msgid "Loading..."
+msgstr "Cargando..."
+
+#: glade/trust_file_list.glade:117
+msgid "page1"
+msgstr "página1"
+
+#: glade/unapplied_changes_dialog.glade:8
+msgid "Unapplied Changes"
+msgstr "Cambios no aplicados"
+
+#: glade/unapplied_changes_dialog.glade:15
+msgid ""
+"\n"
+"There are unapplied changes."
+msgstr ""
+"\n"
+"Hay cambios sin aplicar."
+
+#: glade/unapplied_changes_dialog.glade:16
+msgid "Your changes will be lost."
+msgstr "Tus cambios se perderán."

--- a/python/locale/fapolicy_analyzer.pot
+++ b/python/locale/fapolicy_analyzer.pot
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: fapolicy-analyzer 0.0.4\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2021-05-25 10:59-0400\n"
+"POT-Creation-Date: 2021-05-26 11:27-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,80 +18,78 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.9.1\n"
 
-#: fapolicy_analyzer/ui/ancillary_trust_database_admin.py:92
-#: fapolicy_analyzer/ui/system_trust_database_admin.py:69
+#: fapolicy_analyzer/ui/ancillary_trust_database_admin.py:93
+#: fapolicy_analyzer/ui/system_trust_database_admin.py:70
 msgid ""
 "File: {trust.path}\n"
 "Size: {trust.size}\n"
 "SHA256: {trust.hash}"
 msgstr ""
 
-#: fapolicy_analyzer/ui/ancillary_trust_database_admin.py:102
-#: fapolicy_analyzer/ui/system_trust_database_admin.py:78
+#: fapolicy_analyzer/ui/ancillary_trust_database_admin.py:103
+#: fapolicy_analyzer/ui/system_trust_database_admin.py:79
 msgid ""
 "{fs.stat(trust.path)}\n"
 "SHA256: {fs.sha(trust.path)}"
-msgstr ""
-
-#: fapolicy_analyzer/ui/ancillary_trust_database_admin.py:110
-#: fapolicy_analyzer/ui/system_trust_database_admin.py:85
-msgid "This file is trusted."
-msgstr ""
-
-#: fapolicy_analyzer/ui/ancillary_trust_database_admin.py:112
-#: fapolicy_analyzer/ui/system_trust_database_admin.py:87
-msgid "There is a discrepancy with this file."
-msgstr ""
-
-#: fapolicy_analyzer/ui/ancillary_trust_database_admin.py:114
-#: fapolicy_analyzer/ui/system_trust_database_admin.py:89
-msgid "The trust status of this file is unknown."
-msgstr ""
-
-#: fapolicy_analyzer/ui/ancillary_trust_database_admin.py:135
-msgid "Deploy Ancillary Trust Changes?"
-msgstr ""
-
-#: fapolicy_analyzer/ui/ancillary_trust_database_admin.py:136
-msgid ""
-"Are you sure you wish to deploy your changes to the ancillary trust "
-"database? This will update the fapolicy trust and restart the service."
-msgstr ""
-
-#: fapolicy_analyzer/ui/database_admin_page.py:22
-msgid "System Trust Database"
-msgstr ""
-
-#: fapolicy_analyzer/ui/database_admin_page.py:26
-msgid "Ancillary Trust Database"
 msgstr ""
 
 #: fapolicy_analyzer/ui/deploy_confirm_dialog.py:32
 msgid "Reverting to previous settings in {i+1} seconds"
 msgstr ""
 
-#: fapolicy_analyzer/ui/trust_file_list.py:20
+#: fapolicy_analyzer/ui/strings.py:3
+msgid "Deploy Ancillary Trust Changes?"
+msgstr ""
+
+#: fapolicy_analyzer/ui/strings.py:4
+msgid ""
+"Are you sure you wish to deploy your changes to the ancillary trust "
+"database?\n"
+" This will update the fapolicy trust and restart the service."
+msgstr ""
+
+#: fapolicy_analyzer/ui/strings.py:9
+msgid "This file is trusted."
+msgstr ""
+
+#: fapolicy_analyzer/ui/strings.py:10
+msgid "There is a discrepancy with this file."
+msgstr ""
+
+#: fapolicy_analyzer/ui/strings.py:11
+msgid "The trust status of this file is unknown."
+msgstr ""
+
+#: fapolicy_analyzer/ui/strings.py:13
+msgid "System Trust Database"
+msgstr ""
+
+#: fapolicy_analyzer/ui/strings.py:14
+msgid "Ancillary Trust Database"
+msgstr ""
+
+#: fapolicy_analyzer/ui/strings.py:16
 #: glade/ancillary_trust_database_admin.glade:50
 msgid "Trust"
 msgstr ""
 
-#: fapolicy_analyzer/ui/trust_file_list.py:24
+#: fapolicy_analyzer/ui/strings.py:17
 msgid "File"
 msgstr ""
 
-#: fapolicy_analyzer/ui/trust_file_list.py:99
+#: fapolicy_analyzer/ui/strings.py:19
 msgid "Add File"
 msgstr ""
 
-#: fapolicy_analyzer/ui/trust_file_list.py:128
+#: fapolicy_analyzer/ui/strings.py:21
 msgid "File path(s) contains embedded whitespace."
 msgstr ""
 
-#: fapolicy_analyzer/ui/trust_file_list.py:135
+#: fapolicy_analyzer/ui/strings.py:22
 msgid ""
-"  fapolicyd currently does not support paths containing\n"
-"    spaces. The following paths will not be added to the\n"
-"            Trusted Files List.(fapolicyd: V TBD)\n"
+"fapolicyd currently does not support paths containing spaces. The "
+"following paths will not be added to the Trusted Files List.\n"
+"(fapolicyd: V TBD)\n"
 "\n"
 msgstr ""
 

--- a/python/locale/fapolicy_analyzer.pot
+++ b/python/locale/fapolicy_analyzer.pot
@@ -1,0 +1,187 @@
+# Translations template for fapolicy-analyzer.
+# Copyright (C) 2021 ORGANIZATION
+# This file is distributed under the same license as the fapolicy-analyzer
+# project.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2021.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: fapolicy-analyzer 0.0.4\n"
+"Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
+"POT-Creation-Date: 2021-05-25 10:59-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.9.1\n"
+
+#: fapolicy_analyzer/ui/ancillary_trust_database_admin.py:92
+#: fapolicy_analyzer/ui/system_trust_database_admin.py:69
+msgid ""
+"File: {trust.path}\n"
+"Size: {trust.size}\n"
+"SHA256: {trust.hash}"
+msgstr ""
+
+#: fapolicy_analyzer/ui/ancillary_trust_database_admin.py:102
+#: fapolicy_analyzer/ui/system_trust_database_admin.py:78
+msgid ""
+"{fs.stat(trust.path)}\n"
+"SHA256: {fs.sha(trust.path)}"
+msgstr ""
+
+#: fapolicy_analyzer/ui/ancillary_trust_database_admin.py:110
+#: fapolicy_analyzer/ui/system_trust_database_admin.py:85
+msgid "This file is trusted."
+msgstr ""
+
+#: fapolicy_analyzer/ui/ancillary_trust_database_admin.py:112
+#: fapolicy_analyzer/ui/system_trust_database_admin.py:87
+msgid "There is a discrepancy with this file."
+msgstr ""
+
+#: fapolicy_analyzer/ui/ancillary_trust_database_admin.py:114
+#: fapolicy_analyzer/ui/system_trust_database_admin.py:89
+msgid "The trust status of this file is unknown."
+msgstr ""
+
+#: fapolicy_analyzer/ui/ancillary_trust_database_admin.py:135
+msgid "Deploy Ancillary Trust Changes?"
+msgstr ""
+
+#: fapolicy_analyzer/ui/ancillary_trust_database_admin.py:136
+msgid ""
+"Are you sure you wish to deploy your changes to the ancillary trust "
+"database? This will update the fapolicy trust and restart the service."
+msgstr ""
+
+#: fapolicy_analyzer/ui/database_admin_page.py:22
+msgid "System Trust Database"
+msgstr ""
+
+#: fapolicy_analyzer/ui/database_admin_page.py:26
+msgid "Ancillary Trust Database"
+msgstr ""
+
+#: fapolicy_analyzer/ui/deploy_confirm_dialog.py:32
+msgid "Reverting to previous settings in {i+1} seconds"
+msgstr ""
+
+#: fapolicy_analyzer/ui/trust_file_list.py:20
+#: glade/ancillary_trust_database_admin.glade:50
+msgid "Trust"
+msgstr ""
+
+#: fapolicy_analyzer/ui/trust_file_list.py:24
+msgid "File"
+msgstr ""
+
+#: fapolicy_analyzer/ui/trust_file_list.py:99
+msgid "Add File"
+msgstr ""
+
+#: fapolicy_analyzer/ui/trust_file_list.py:128
+msgid "File path(s) contains embedded whitespace."
+msgstr ""
+
+#: fapolicy_analyzer/ui/trust_file_list.py:135
+msgid ""
+"  fapolicyd currently does not support paths containing\n"
+"    spaces. The following paths will not be added to the\n"
+"            Trusted Files List.(fapolicyd: V TBD)\n"
+"\n"
+msgstr ""
+
+#: glade/analyzer_selection_dialog.glade:25
+msgid "Scan System"
+msgstr ""
+
+#: glade/analyzer_selection_dialog.glade:39
+msgid "Administer Trust Databases"
+msgstr ""
+
+#: glade/analyzer_selection_dialog.glade:61
+msgid "Analyzer Selection"
+msgstr ""
+
+#: glade/analyzer_selection_dialog.glade:94
+msgid "Analyze From Audit"
+msgstr ""
+
+#: glade/ancillary_trust_database_admin.glade:65
+msgid "Untrust"
+msgstr ""
+
+#: glade/ancillary_trust_database_admin.glade:102
+msgid "Deploy Ancillary Trust"
+msgstr ""
+
+#: glade/deploy_confirm_dialog.glade:10
+msgid "Keep these trust changes?"
+msgstr ""
+
+#: glade/deploy_confirm_dialog.glade:11
+msgid "Reverting to previous settings in 15 seconds."
+msgstr ""
+
+#: glade/main_window.glade:7
+msgid "About File Acccess Policy Analyzer"
+msgstr ""
+
+#: glade/main_window.glade:54
+msgid "File Access Policy Analyzer"
+msgstr ""
+
+#: glade/main_window.glade:73
+msgid "_File"
+msgstr ""
+
+#: glade/main_window.glade:97
+msgid "_Help"
+msgstr ""
+
+#: glade/system_trust_database_admin.glade:44
+msgid "Add File To Ancillary Trust Database"
+msgstr ""
+
+#: glade/trust_file_details.glade:41
+msgid "In Database"
+msgstr ""
+
+#: glade/trust_file_details.glade:81
+msgid "On File System"
+msgstr ""
+
+#: glade/trust_file_details.glade:120
+msgid "File Trust Status"
+msgstr ""
+
+#: glade/trust_file_list.glade:75
+msgid "page0"
+msgstr ""
+
+#: glade/trust_file_list.glade:102
+msgid "Loading..."
+msgstr ""
+
+#: glade/trust_file_list.glade:117
+msgid "page1"
+msgstr ""
+
+#: glade/unapplied_changes_dialog.glade:8
+msgid "Unapplied Changes"
+msgstr ""
+
+#: glade/unapplied_changes_dialog.glade:15
+msgid ""
+"\n"
+"There are unapplied changes."
+msgstr ""
+
+#: glade/unapplied_changes_dialog.glade:16
+msgid "Your changes will be lost."
+msgstr ""
+

--- a/python/setup.cfg
+++ b/python/setup.cfg
@@ -1,0 +1,8 @@
+[extract_messages]
+mapping_file = babel.cfg
+output_file = ./locale/fapolicy_analyzer.pot
+input_dirs = ./fapolicy_analyzer/ui,./glade
+
+[compile_catalog]
+domain = fapolicy_analyzer
+directory = ./locale


### PR DESCRIPTION
This setups up localization of UI strings via the python `locale.gettext` method.  I also added a set of translations to ES.  I'm not 100% sure the translations are right, but it at least proves that things are working.  

I'm using the Babel tool to generate the template files.  With every change to the UI we'll need to run the tool with `pipenv run extract_messages` to update the template.

In order to run the app with translation you also need to compile the translation file with `pipenv run compile_catalog`.

To test things out for this PR:
1. `cd python`
2. `pipenv run compile_catalog` to compile ES translations
3. `cd fapolicy_analyzer`
4. `LANGUAGE=es python -m ui` to run app with ES locale

closes #62 