### PR TITLE
Add File manu items to Open/Restore/Save edit sessions

### DIFF
--- a/python/fapolicy_analyzer/glade/main_window.glade
+++ b/python/fapolicy_analyzer/glade/main_window.glade
@@ -81,6 +81,45 @@
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
                         <child>
+                          <object class="GtkImageMenuItem" id="openMenu">
+                            <property name="label">gtk-open</property>
+                            <property name="visible">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="use-underline">True</property>
+                            <property name="use-stock">True</property>
+                            <signal name="activate" handler="on_openMenu_activate" swapped="no"/>
+                          </object>
+                        </child>
+                        <child>
+                          <object class="GtkMenuItem" id="restoreMenu">
+                            <property name="visible">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="label" translatable="yes" comments="Presents option to load prior sessions tmp file (if it exists.)">Restore</property>
+                            <property name="use-underline">True</property>
+                            <signal name="activate" handler="on_restoreMenu_activate" swapped="no"/>
+                          </object>
+                        </child>
+                        <child>
+                          <object class="GtkImageMenuItem" id="saveMenu">
+                            <property name="label">gtk-save</property>
+                            <property name="visible">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="use-underline">True</property>
+                            <property name="use-stock">True</property>
+                            <signal name="activate" handler="on_saveMenu_activate" swapped="no"/>
+                          </object>
+                        </child>
+                        <child>
+                          <object class="GtkImageMenuItem" id="saveAsMenu">
+                            <property name="label">gtk-save-as</property>
+                            <property name="visible">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="use-underline">True</property>
+                            <property name="use-stock">True</property>
+                            <signal name="activate" handler="on_saveAsMenu_activate" swapped="no"/>
+                          </object>
+                        </child>
+                        <child>
                           <object class="GtkImageMenuItem" id="quitMenu">
                             <property name="label">gtk-quit</property>
                             <property name="visible">True</property>

--- a/python/fapolicy_analyzer/tests/test_main_window.py
+++ b/python/fapolicy_analyzer/tests/test_main_window.py
@@ -115,22 +115,27 @@ def test_localization(es_locale):
     assert type(window) is Gtk.Window
     assert window.get_title() == "Analizador de políticas de acceso a archivos"
 
+
 def test_on_delete_event(mainWindow):
     window = mainWindow
     bReturn = window.on_delete_event(None)
     assert not bReturn
 
+
 def test_on_openMenu_activate(mainWindow):
     window = mainWindow
     window.on_openMenu_activate(None)
+
 
 def test_on_restoreMenu_activate(mainWindow):
     window = mainWindow
     window.on_restoreMenu_activate(None)
 
+
 def test_on_saveMenu_activate(mainWindow):
     window = mainWindow
     window.on_saveMenu_activate(None)
+
 
 def test_on_saveAsMenu_activate(mainWindow):
     window = mainWindow

--- a/python/fapolicy_analyzer/tests/test_main_window.py
+++ b/python/fapolicy_analyzer/tests/test_main_window.py
@@ -114,3 +114,24 @@ def test_localization(es_locale):
     window = mainWindow.get_ref()
     assert type(window) is Gtk.Window
     assert window.get_title() == "Analizador de políticas de acceso a archivos"
+
+def test_on_delete_event(mainWindow):
+    window = mainWindow
+    bReturn = window.on_delete_event(None)
+    assert not bReturn
+
+def test_on_openMenu_activate(mainWindow):
+    window = mainWindow
+    window.on_openMenu_activate(None)
+
+def test_on_restoreMenu_activate(mainWindow):
+    window = mainWindow
+    window.on_restoreMenu_activate(None)
+
+def test_on_saveMenu_activate(mainWindow):
+    window = mainWindow
+    window.on_saveMenu_activate(None)
+
+def test_on_saveAsMenu_activate(mainWindow):
+    window = mainWindow
+    window.on_saveAsMenu_activate(None)

--- a/python/fapolicy_analyzer/tests/test_trust_file_list.py
+++ b/python/fapolicy_analyzer/tests/test_trust_file_list.py
@@ -64,3 +64,26 @@ def test_fires_files_added(widget, mocker):
     addBtn = widget.get_object("actionButtons").get_children()[0]
     addBtn.clicked()
     mockHandler.assert_called_with(["foo"])
+
+
+def test_fires_files_w_spaces_added(widget, mocker):
+    mocker.patch(
+        "ui.trust_file_list.Gtk.FileChooserDialog.run",
+        return_value=Gtk.ResponseType.OK,
+    )
+    mocker.patch(
+        "ui.trust_file_list.Gtk.FileChooserDialog.get_filenames",
+        return_value=["/tmp/a file name with spaces"],
+    )
+    mocker.patch("ui.trust_file_list.path.isfile", return_value=True)
+    mocker.patch(
+        "ui.trust_file_list.Gtk.MessageDialog.run",
+        return_value=Gtk.ResponseType.OK,
+    )
+    mockHandler = MagicMock()
+    widget.files_added += mockHandler
+    parent = Gtk.Window()
+    widget.get_ref().set_parent(parent)
+    addBtn = widget.get_object("actionButtons").get_children()[0]
+    addBtn.clicked()
+    assert not mockHandler.called, "Callback should not be invoked; Filepath w/spaces should be filtered out"

--- a/python/fapolicy_analyzer/ui/__main__.py
+++ b/python/fapolicy_analyzer/ui/__main__.py
@@ -7,9 +7,6 @@ gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk
 from .main_window import MainWindow
 
-# Globals
-gbVerbose = False
-
 
 def parse_cmdline():
     global gbVerbose
@@ -20,8 +17,7 @@ def parse_cmdline():
     args = parser.parse_args()
 
     # Set Verbosity Level
-    gbVerbose = args.verbose
-    if gbVerbose:
+    if args.verbose:
         logging.root.setLevel(logging.DEBUG)
         logging.debug("Verbosity enabled.")
 

--- a/python/fapolicy_analyzer/ui/__main__.py
+++ b/python/fapolicy_analyzer/ui/__main__.py
@@ -9,8 +9,6 @@ from .main_window import MainWindow
 
 
 def parse_cmdline():
-    global gbVerbose
-
     parser = argparse.ArgumentParser()
     parser.add_argument("-v", "--verbose", action="store_true",
                         help="Enable verbose mode")

--- a/python/fapolicy_analyzer/ui/__main__.py
+++ b/python/fapolicy_analyzer/ui/__main__.py
@@ -28,7 +28,7 @@ def parse_cmdline():
 
 def main():
     parse_cmdline()
-    main = MainWindow()
+    MainWindow()
     Gtk.main()
 
 

--- a/python/fapolicy_analyzer/ui/__main__.py
+++ b/python/fapolicy_analyzer/ui/__main__.py
@@ -9,12 +9,9 @@ from .main_window import MainWindow
 
 # Globals
 gbVerbose = False
-gstrEditSessionTmpFile = "/tmp/FAPolicyToolSession.tmp"
 
-
-def parse_args():
+def parse_cmdline():
     global gbVerbose
-    global gstrEditSessionTmpFile
 
     parser = argparse.ArgumentParser()
     parser.add_argument("-v", "--verbose", action="store_true",
@@ -27,8 +24,10 @@ def parse_args():
         logging.root.setLevel(logging.DEBUG)
         logging.debug("Verbosity enabled.")
 
-
-if __name__ == "__main__":
-    parse_args()
+def main():
+    parse_cmdline()
     main = MainWindow()
     Gtk.main()
+
+if __name__ == "__main__":
+    main()

--- a/python/fapolicy_analyzer/ui/__main__.py
+++ b/python/fapolicy_analyzer/ui/__main__.py
@@ -1,14 +1,15 @@
-import gi
 import logging
 logging.basicConfig(level=logging.WARNING)
 import argparse
 
+import gi
 gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk
 from .main_window import MainWindow
 
 # Globals
 gbVerbose = False
+
 
 def parse_cmdline():
     global gbVerbose
@@ -24,10 +25,12 @@ def parse_cmdline():
         logging.root.setLevel(logging.DEBUG)
         logging.debug("Verbosity enabled.")
 
+
 def main():
     parse_cmdline()
     main = MainWindow()
     Gtk.main()
+
 
 if __name__ == "__main__":
     main()

--- a/python/fapolicy_analyzer/ui/__main__.py
+++ b/python/fapolicy_analyzer/ui/__main__.py
@@ -1,10 +1,32 @@
 import gi
+import logging
+logging.basicConfig(level=logging.WARNING)
+import argparse
 
 gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk
 from .main_window import MainWindow
 
+# Globals
+gbVerbose=False
+gstrEditSessionTmpFile="/tmp/FAPolicyToolSession.tmp"
+
+def parse_args():
+    global gbVerbose
+    global gstrEditSessionTmpFile
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-v","--verbose", action="store_true",
+                        help="Enable verbose mode")
+    args = parser.parse_args()
+
+    # Set Verbosity Level
+    gbVerbose = args.verbose
+    if gbVerbose:
+        logging.root.setLevel(logging.DEBUG)
+        logging.debug("Verbosity enabled.")
 
 if __name__ == "__main__":
+    parse_args()
     main = MainWindow()
     Gtk.main()

--- a/python/fapolicy_analyzer/ui/__main__.py
+++ b/python/fapolicy_analyzer/ui/__main__.py
@@ -8,15 +8,16 @@ from gi.repository import Gtk
 from .main_window import MainWindow
 
 # Globals
-gbVerbose=False
-gstrEditSessionTmpFile="/tmp/FAPolicyToolSession.tmp"
+gbVerbose = False
+gstrEditSessionTmpFile = "/tmp/FAPolicyToolSession.tmp"
+
 
 def parse_args():
     global gbVerbose
     global gstrEditSessionTmpFile
 
     parser = argparse.ArgumentParser()
-    parser.add_argument("-v","--verbose", action="store_true",
+    parser.add_argument("-v", "--verbose", action="store_true",
                         help="Enable verbose mode")
     args = parser.parse_args()
 
@@ -25,6 +26,7 @@ def parse_args():
     if gbVerbose:
         logging.root.setLevel(logging.DEBUG)
         logging.debug("Verbosity enabled.")
+
 
 if __name__ == "__main__":
     parse_args()

--- a/python/fapolicy_analyzer/ui/ancillary_trust_database_admin.py
+++ b/python/fapolicy_analyzer/ui/ancillary_trust_database_admin.py
@@ -128,12 +128,6 @@ SHA256: {fs.sha(trust.path)}"""
             self.delete_trusted_files(self.selectedFile)
 
     def on_deployBtn_clicked(self, *args):
-        # Get list of human-readable undeployed path/operation pairs
-        listPathActionTuples = stateManager.get_path_action_list()
-
-        # TODO: 20210607 tpa Functional verification. Pls leave in until ui
-        # element integration
-        print(listPathActionTuples)
         parent = self.get_ref().get_toplevel()
         dlgDeployList = ConfirmInfoDialog(parent)
         dlgDeployList.load_path_action_list(stateManager.get_path_action_list())

--- a/python/fapolicy_analyzer/ui/main_window.py
+++ b/python/fapolicy_analyzer/ui/main_window.py
@@ -1,3 +1,4 @@
+import logging
 import gi
 
 gi.require_version("Gtk", "3.0")
@@ -51,6 +52,22 @@ class MainWindow(UIWidget):
     def on_delete_event(self, *args):
         return self.__unapplied_changes()
 
+    def on_openMenu_activate(self, menuitem, data=None):
+        logging.debug("Callback entered: MainWindow::on_openMenu_activate()")
+        pass
+
+    def on_restoreMenu_activate(self, menuitem, data=None):
+        logging.debug("Callback entered: MainWindow::on_restoreMenu_activate()")
+        pass
+
+    def on_saveMenu_activate(self, menuitem, data=None):
+        logging.debug("Callback entered: MainWindow::on_saveMenu_activate()")
+        pass
+        
+    def on_saveAsMenu_activate(self, menuitem, data=None):
+        logging.debug("Callback entered: MainWindow::on_saveAsMenu_activate()")
+        pass
+        
     def on_aboutMenu_activate(self, menuitem, data=None):
         aboutDialog = self.get_object("aboutDialog")
         aboutDialog.set_transient_for(self.window)

--- a/python/fapolicy_analyzer/ui/main_window.py
+++ b/python/fapolicy_analyzer/ui/main_window.py
@@ -29,6 +29,12 @@ class MainWindow(UIWidget):
         toaster = Notification()
         self.get_object("overlay").add_overlay(toaster.get_ref())
 
+        # Disable 'File' menu items until backend support is available
+        self.get_object("openMenu").set_sensitive(False)
+        self.get_object("restoreMenu").set_sensitive(False)
+        self.get_object("saveMenu").set_sensitive(False)
+        self.get_object("saveAsMenu").set_sensitive(False)
+
         self.window.show_all()
 
     def __unapplied_changes(self):
@@ -63,11 +69,11 @@ class MainWindow(UIWidget):
     def on_saveMenu_activate(self, menuitem, data=None):
         logging.debug("Callback entered: MainWindow::on_saveMenu_activate()")
         pass
-        
+
     def on_saveAsMenu_activate(self, menuitem, data=None):
         logging.debug("Callback entered: MainWindow::on_saveAsMenu_activate()")
         pass
-        
+
     def on_aboutMenu_activate(self, menuitem, data=None):
         aboutDialog = self.get_object("aboutDialog")
         aboutDialog.set_transient_for(self.window)


### PR DESCRIPTION
This PR addresses a subtask of issue-56 Persist unapplied changes. This PR adds the 'File' menu items to Save, Save As, Open, and Restore un-deployed Ancillary Trust Database Admin edits.