### PR TITLE
Add Edit Session Json Serialization

### DIFF
--- a/python/fapolicy_analyzer/tests/test_ancillary_trust_database_admin.py
+++ b/python/fapolicy_analyzer/tests/test_ancillary_trust_database_admin.py
@@ -100,6 +100,18 @@ def test_on_confirm_deployment(widget, confirm_dialog, revert_dialog):
         instance.deploy.assert_called()
 
 
+@pytest.mark.parametrize("confirm_resp", [Gtk.ResponseType.YES])
+@pytest.mark.parametrize("revert_resp", [Gtk.ResponseType.NO])
+def test_on_confirm_deployment_w_exception(widget, mocker, confirm_dialog, revert_dialog):
+    mockFunc = mocker.patch("fapolicy_analyzer.System.deploy",
+                            side_effect=BaseException)
+
+    parent = Gtk.Window()
+    parent.add(widget.get_ref())
+    widget.on_deployBtn_clicked()
+    mockFunc.assert_called()
+
+
 @pytest.mark.parametrize("confirm_resp", [Gtk.ResponseType.NO])
 def test_on_neg_confirm_deployment(widget, confirm_dialog):
     parent = Gtk.Window()
@@ -201,7 +213,7 @@ def test_on_untrustBtn_clicked_empty(widget, state):
 def test_on_file_added(widget, state):
     assert len(state.get_changeset_q()) == 0
     tmpFile = tempfile.NamedTemporaryFile()
-    widget.trustFileList.files_added([tmpFile.name])
+    widget.on_files_added([tmpFile.name])
     assert len(state.get_changeset_q()) == 1
 
 
@@ -209,3 +221,39 @@ def test_on_file_added_empty(widget, state):
     assert len(state.get_changeset_q()) == 0
     widget.on_files_added(None)
     assert len(state.get_changeset_q()) == 0
+
+
+def test_on_file_deleted(widget, state):
+    assert len(state.get_changeset_q()) == 0
+    tmpFile = tempfile.NamedTemporaryFile()
+    widget.on_files_deleted([tmpFile.name])
+    assert len(state.get_changeset_q()) == 1
+
+
+def test_on_file_deleted_empty(widget, state):
+    assert len(state.get_changeset_q()) == 0
+    widget.on_files_deleted(None)
+    assert len(state.get_changeset_q()) == 0
+
+
+# ########################## Edit Session Related ####################
+def test_on_session_load(widget, mocker):
+    # Submit to flake8/linting - Line was too long
+    strModule = "ui.ancillary_trust_database_admin.AncillaryTrustDatabaseAdmin"
+    mockAdd = mocker.patch("{}.on_files_added".format(strModule),
+                           return_value=True)
+    mockDel = mocker.patch("{}.on_files_deleted".format(strModule),
+                           return_value=True)
+
+    listPaTuples = [("/data_space/man_from_mars.txt",
+                     "Add"),
+                    ("/data_space/this/is/a/longer/path/now_is_the_time.txt",
+                     "Del"),
+                    ("/data_space/Integration.json", "Add")]
+    listPaAddedExpected = ["/data_space/man_from_mars.txt",
+                           "/data_space/Integration.json"]
+    listPaDeletedExpected = ["/data_space/this/is/a/longer/path/now_is_the_time.txt"]
+
+    widget.on_session_load(listPaTuples)
+    mockAdd.assert_called_with(listPaAddedExpected)
+    mockDel.assert_called_with(listPaDeletedExpected)

--- a/python/fapolicy_analyzer/tests/test_ancillary_trust_database_admin.py
+++ b/python/fapolicy_analyzer/tests/test_ancillary_trust_database_admin.py
@@ -240,10 +240,8 @@ def test_on_file_deleted_empty(widget, state):
 def test_on_session_load(widget, mocker):
     # Submit to flake8/linting - Line was too long
     strModule = "ui.ancillary_trust_database_admin.AncillaryTrustDatabaseAdmin"
-    mockAdd = mocker.patch("{}.on_files_added".format(strModule),
-                           return_value=True)
-    mockDel = mocker.patch("{}.on_files_deleted".format(strModule),
-                           return_value=True)
+    mockAdd = mocker.patch("{}.on_files_added".format(strModule))
+    mockDel = mocker.patch("{}.on_files_deleted".format(strModule))
 
     listPaTuples = [("/data_space/man_from_mars.txt",
                      "Add"),

--- a/python/fapolicy_analyzer/tests/test_main_window.py
+++ b/python/fapolicy_analyzer/tests/test_main_window.py
@@ -122,21 +122,80 @@ def test_on_delete_event(mainWindow):
     assert not bReturn
 
 
-def test_on_openMenu_activate(mainWindow):
+def test_on_openMenu_activate(mainWindow, state, mocker):
+    # Mock the FileChooser dlg
+    mockDialog = MagicMock()
+    mockDialog.run.return_value = Gtk.ResponseType.OK
+    mockDialog.get_filename.return_value = "/tmp/open_tmp.json"
+    mocker.patch(
+        "ui.main_window.Gtk.FileChooserDialog",
+        return_value=mockDialog,
+    )
+
+    mocker.patch(
+        "ui.main_window.stateManager.open_edit_session",
+        return_value=True
+    )
+
+    mocker.patch(
+        "ui.main_window.path.isfile",
+        return_value=True
+    )
+    mainWindow.get_object("openMenu").activate()
+    stateManager.open_edit_session.assert_called_with("/tmp/open_tmp.json")
+
+
+def test_on_restoreMenu_activate(mainWindow, state, mocker):
+    # Invoke 'pass'ed function
+    mainWindow.get_object("restoreMenu").activate()
+
+
+def test_on_saveAsMenu_activate(mainWindow, state, mocker):
+    # Mock the FileChooser dlg
+    mockDialog = MagicMock()
+    mockDialog.run.return_value = Gtk.ResponseType.OK
+    mockDialog.get_filename.return_value = "/tmp/save_as_tmp.json"
+    mocker.patch(
+        "ui.main_window.Gtk.FileChooserDialog",
+        return_value=mockDialog,
+    )
+
+    # Mock the StateMgr interface
+    mockFunc = mocker.patch(
+        "ui.main_window.stateManager.save_edit_session",
+        return_value=True
+    )
+
+    mainWindow.get_object("saveAsMenu").activate()
+    mockFunc.assert_called_with("/tmp/save_as_tmp.json")
+
+
+def test_on_saveMenu_activate(mainWindow, state, mocker):
+    # Mock the on_saveAsMenu_activate() call
+    mockFunc = mocker.patch(
+        "ui.main_window.MainWindow.on_saveAsMenu_activate",
+        return_value=True
+    )
+
+    # Mock the StateMgr interface
+    mocker.patch(
+        "ui.main_window.stateManager.save_edit_session",
+        return_value=True
+    )
+
     window = mainWindow
-    window.on_openMenu_activate(None)
+    window.get_object("saveMenu").activate()
+    mockFunc.assert_called()
 
 
-def test_on_restoreMenu_activate(mainWindow):
-    window = mainWindow
-    window.on_restoreMenu_activate(None)
+def test_on_saveMenu_activate_w_set_filename(mainWindow, state, mocker):
+    mainWindow.strSessionFilename = "/tmp/save_w_filename_tmp.json"
 
+    # Mock the StateMgr interface
+    mocker.patch(
+        "ui.main_window.stateManager.save_edit_session",
+        return_value=True
+    )
 
-def test_on_saveMenu_activate(mainWindow):
-    window = mainWindow
-    window.on_saveMenu_activate(None)
-
-
-def test_on_saveAsMenu_activate(mainWindow):
-    window = mainWindow
-    window.on_saveAsMenu_activate(None)
+    mainWindow.get_object("saveMenu").activate()
+    stateManager.save_edit_session.assert_called_with("/tmp/save_w_filename_tmp.json")

--- a/python/fapolicy_analyzer/tests/test_state_manager.py
+++ b/python/fapolicy_analyzer/tests/test_state_manager.py
@@ -262,9 +262,9 @@ def test_path_action_dict_to_list(uut):
 
 
 def test_path_action_list_2_queue(uut):
-    """Test: The utility function, __path_action_list_2_queue() loads the 
+    """Test: The utility function, __path_action_list_2_queue() loads the
     internal queue with test data. The contents of the queue is then dumped
-    using  another utility, get_path_action_list(). Those input and output 
+    using  another utility, get_path_action_list(). Those input and output
     data lists are then compared.
 """
     listPaTuples = [

--- a/python/fapolicy_analyzer/ui/main_window.py
+++ b/python/fapolicy_analyzer/ui/main_window.py
@@ -72,7 +72,6 @@ class MainWindow(UIWidget):
         logging.debug("Callback entered: MainWindow::on_openMenu_activate()")
         # Display file chooser dialog
         fcd = Gtk.FileChooserDialog("Select An Edit Session File To Open",
-                                    # strings.ADD_FILE_BUTTON_LABEL,
                                     self.windowTopLevel,
                                     Gtk.FileChooserAction.OPEN,
                                     (
@@ -109,13 +108,12 @@ class MainWindow(UIWidget):
         logging.debug("Callback entered: MainWindow::on_saveAsMenu_activate()")
         # Display file chooser dialog
         fcd = Gtk.FileChooserDialog("Save As...",
-                                    # strings.ADD_FILE_BUTTON_LABEL,
                                     self.windowTopLevel,
                                     Gtk.FileChooserAction.SAVE,
                                     (
                                         Gtk.STOCK_CANCEL,
                                         Gtk.ResponseType.CANCEL,
-                                        Gtk.STOCK_ADD,
+                                        Gtk.STOCK_SAVE,
                                         Gtk.ResponseType.OK,
                                     ),
                                     )

--- a/python/fapolicy_analyzer/ui/main_window.py
+++ b/python/fapolicy_analyzer/ui/main_window.py
@@ -1,3 +1,4 @@
+from os import path
 import logging
 import gi
 
@@ -21,7 +22,8 @@ def router(selection):
 class MainWindow(UIWidget):
     def __init__(self):
         super().__init__()
-        stateManager.changeset_queue_updated += self.on_changeset_updated
+        self.strSessionFilename = None
+        stateManager.ev_changeset_queue_updated += self.on_changeset_updated
         self.window = self.get_ref()
         self.windowTopLevel = self.window.get_toplevel()
         self.strTopLevelTitle = self.windowTopLevel.get_title()
@@ -30,10 +32,7 @@ class MainWindow(UIWidget):
         self.get_object("overlay").add_overlay(toaster.get_ref())
 
         # Disable 'File' menu items until backend support is available
-        self.get_object("openMenu").set_sensitive(False)
         self.get_object("restoreMenu").set_sensitive(False)
-        self.get_object("saveMenu").set_sensitive(False)
-        self.get_object("saveAsMenu").set_sensitive(False)
 
         self.window.show_all()
 
@@ -58,9 +57,42 @@ class MainWindow(UIWidget):
     def on_delete_event(self, *args):
         return self.__unapplied_changes()
 
+    def __apply_file_filters(self, dialog):
+        fileFilterJson = Gtk.FileFilter()
+        fileFilterJson.set_name("FA Session files")
+        fileFilterJson.add_pattern("*.json")
+        dialog.add_filter(fileFilterJson)
+
+        fileFilterAny = Gtk.FileFilter()
+        fileFilterAny.set_name("Any files")
+        fileFilterAny.add_pattern("*")
+        dialog.add_filter(fileFilterAny)
+
     def on_openMenu_activate(self, menuitem, data=None):
         logging.debug("Callback entered: MainWindow::on_openMenu_activate()")
-        pass
+        # Display file chooser dialog
+        fcd = Gtk.FileChooserDialog("Select An Edit Session File To Open",
+                                    # strings.ADD_FILE_BUTTON_LABEL,
+                                    self.windowTopLevel,
+                                    Gtk.FileChooserAction.OPEN,
+                                    (
+                                        Gtk.STOCK_CANCEL,
+                                        Gtk.ResponseType.CANCEL,
+                                        Gtk.STOCK_OPEN,
+                                        Gtk.ResponseType.OK,
+                                    ),
+                                    )
+        self.__apply_file_filters(fcd)
+        response = fcd.run()
+        fcd.hide()
+
+        if response == Gtk.ResponseType.OK:
+            strFilename = fcd.get_filename()
+            if path.isfile(strFilename):
+                self.strSessionFilename = strFilename
+                stateManager.open_edit_session(self.strSessionFilename)
+                # ToDo: Exception handling
+        fcd.destroy()
 
     def on_restoreMenu_activate(self, menuitem, data=None):
         logging.debug("Callback entered: MainWindow::on_restoreMenu_activate()")
@@ -68,11 +100,37 @@ class MainWindow(UIWidget):
 
     def on_saveMenu_activate(self, menuitem, data=None):
         logging.debug("Callback entered: MainWindow::on_saveMenu_activate()")
-        pass
+        if not self.strSessionFilename:
+            self.on_saveAsMenu_activate(menuitem, None)
+        else:
+            stateManager.save_edit_session(self.strSessionFilename)
 
     def on_saveAsMenu_activate(self, menuitem, data=None):
         logging.debug("Callback entered: MainWindow::on_saveAsMenu_activate()")
-        pass
+        # Display file chooser dialog
+        fcd = Gtk.FileChooserDialog("Save As...",
+                                    # strings.ADD_FILE_BUTTON_LABEL,
+                                    self.windowTopLevel,
+                                    Gtk.FileChooserAction.SAVE,
+                                    (
+                                        Gtk.STOCK_CANCEL,
+                                        Gtk.ResponseType.CANCEL,
+                                        Gtk.STOCK_ADD,
+                                        Gtk.ResponseType.OK,
+                                    ),
+                                    )
+
+        self.__apply_file_filters(fcd)
+        fcd.set_do_overwrite_confirmation(True)
+        response = fcd.run()
+        fcd.hide()
+
+        if response == Gtk.ResponseType.OK:
+            strFilename = fcd.get_filename()
+            self.strSessionFilename = strFilename
+            stateManager.save_edit_session(self.strSessionFilename)
+            # Verify no exceptions
+        fcd.destroy()
 
     def on_aboutMenu_activate(self, menuitem, data=None):
         aboutDialog = self.get_object("aboutDialog")
@@ -97,5 +155,6 @@ class MainWindow(UIWidget):
 
     def on_changeset_updated(self):
         """The callback function invoked from the StateManager when
+        logging.debug("MainWindow::on_changeset_updated()")
         state changes."""
         self.set_modified_titlebar(stateManager.is_dirty_queue())

--- a/python/fapolicy_analyzer/ui/trust_file_list.py
+++ b/python/fapolicy_analyzer/ui/trust_file_list.py
@@ -13,6 +13,7 @@ class TrustFileList(SearchableList):
         self.__events__ = [
             *super().__events__,
             "files_added",
+            "files_deleted",
             "trust_selection_changed",
         ]
         buttons = [] if read_only else [self.__addButton()]


### PR DESCRIPTION
New serialization functionality bound to Open/Save/SaveAs UI elements. Open/loads of a Ancillary Trust Database Admin edit session file does not overwrite current session operations.