### PR TITLE
Add change column to ancillary trust view:

### DIFF
--- a/python/fapolicy_analyzer/tests/test_ancillary_trust_file_list.py
+++ b/python/fapolicy_analyzer/tests/test_ancillary_trust_file_list.py
@@ -1,0 +1,121 @@
+import context  # noqa: F401
+import pytest
+import gi
+
+gi.require_version("Gtk", "3.0")
+from gi.repository import Gtk
+from unittest.mock import MagicMock
+from ui.ancillary_trust_file_list import AncillaryTrustFileList
+from ui.configs import Colors
+from ui.strings import CHANGESET_ACTION_ADD, CHANGESET_ACTION_DEL
+from ui.state_manager import stateManager
+
+_trust = [
+    MagicMock(status="d", path="/tmp/foo"),
+    MagicMock(status="t", path="/tmp/baz"),
+    MagicMock(status="u", path="/tmp/bar"),
+]
+
+
+def _trust_func(callback):
+    callback(_trust)
+
+
+@pytest.fixture
+def widget():
+    widget = AncillaryTrustFileList(trust_func=_trust_func)
+    return widget
+
+
+@pytest.fixture
+def state():
+    stateManager.del_changeset_q()
+    yield stateManager
+    stateManager.del_changeset_q()
+
+
+def test_creates_widget(widget):
+    assert type(widget.get_ref()) is Gtk.Box
+
+
+def test_uses_custom_trust_func():
+    trust_func = MagicMock()
+    AncillaryTrustFileList(trust_func=trust_func)
+    trust_func.assert_called()
+
+
+def test_uses_custom_markup_func(widget):
+    AncillaryTrustFileList(trust_func=_trust_func)
+    view = widget.get_object("treeView")
+    assert ["T/<b><u>D</u></b>", "<b><u>T</u></b>/D", "T/D"] == [
+        x[0] for x in view.get_model()
+    ]
+    assert [Colors.LIGHT_RED, Colors.LIGHT_GREEN, Colors.LIGHT_YELLOW] == [
+        x[3] for x in view.get_model()
+    ]
+
+
+def test_fires_files_added(widget, mocker):
+    mocker.patch(
+        "ui.ancillary_trust_file_list.Gtk.FileChooserDialog.run",
+        return_value=Gtk.ResponseType.OK,
+    )
+    mocker.patch(
+        "ui.ancillary_trust_file_list.Gtk.FileChooserDialog.get_filenames",
+        return_value=["foo"],
+    )
+    mocker.patch("ui.ancillary_trust_file_list.path.isfile", return_value=True)
+    mockHandler = MagicMock()
+    widget.files_added += mockHandler
+    parent = Gtk.Window()
+    widget.get_ref().set_parent(parent)
+    addBtn = widget.get_object("actionButtons").get_children()[0]
+    addBtn.clicked()
+    mockHandler.assert_called_with(["foo"])
+
+
+def test_fires_files_w_spaces_added(widget, mocker):
+    mocker.patch(
+        "ui.ancillary_trust_file_list.Gtk.FileChooserDialog.run",
+        return_value=Gtk.ResponseType.OK,
+    )
+    mocker.patch(
+        "ui.ancillary_trust_file_list.Gtk.FileChooserDialog.get_filenames",
+        return_value=["/tmp/a file name with spaces"],
+    )
+    mocker.patch("ui.ancillary_trust_file_list.path.isfile", return_value=True)
+    mocker.patch(
+        "ui.ancillary_trust_file_list.Gtk.MessageDialog.run",
+        return_value=Gtk.ResponseType.OK,
+    )
+    mockHandler = MagicMock()
+    widget.files_added += mockHandler
+    parent = Gtk.Window()
+    widget.get_ref().set_parent(parent)
+    addBtn = widget.get_object("actionButtons").get_children()[0]
+    addBtn.clicked()
+    assert (
+        not mockHandler.called
+    ), "Callback should not be invoked; Filepath w/spaces should be filtered out"
+
+
+def test_trust_add_actions_in_view(widget, state):
+    mockChangeset = MagicMock(
+        get_path_action_map=MagicMock(return_value=({"/tmp/foo": "Add"}))
+    )
+    state.add_changeset_q(mockChangeset)
+    widget.load_trust(_trust)
+    model = widget.get_object("treeView").get_model()
+    row = next(iter([x for x in model if x[1] == "/tmp/foo"]))
+    assert CHANGESET_ACTION_ADD == row[4]
+
+
+def test_trust_delete_actions_in_view(widget, state):
+    mockChangeset = MagicMock(
+        get_path_action_map=MagicMock(return_value=({"/tmp/foz": "Del"}))
+    )
+    state.add_changeset_q(mockChangeset)
+    widget.load_trust(_trust)
+    model = widget.get_object("treeView").get_model()
+    row = next(iter([x for x in model if x[1] == "/tmp/foz"]))
+    assert CHANGESET_ACTION_DEL == row[4]

--- a/python/fapolicy_analyzer/tests/test_confirm_info_dialog.py
+++ b/python/fapolicy_analyzer/tests/test_confirm_info_dialog.py
@@ -5,6 +5,7 @@ gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk
 from helpers import delayed_gui_action
 from ui.confirm_info_dialog import ConfirmInfoDialog
+from ui.strings import CHANGESET_ACTION_ADD, CHANGESET_ACTION_DEL
 
 
 def test_creates_widget():
@@ -28,11 +29,18 @@ def test_dialog_actions_responses():
 
 
 def test_load_path_action_list():
-    widget = ConfirmInfoDialog(parent=Gtk.Window())
     path_action_list = [("/tmp/fu.txt", "Add"), ("/tmp/bar.txt", "Del")]
-    widget.load_path_action_list(path_action_list)
+    widget = ConfirmInfoDialog(Gtk.Window(), path_action_list)
 
-    # Verify the contents of the ConfirmInfoDialog.ListStore
-    for i, j in zip(widget.changeStore, range(2)):
-        # Note: tuples are reversed when loading Gtk.ListStore for display
-        assert (i[1], i[0]) == path_action_list[j]
+    scrollWindow = next(
+        iter(
+            filter(
+                lambda x: isinstance(x, Gtk.ScrolledWindow),
+                widget.get_content_area().get_children(),
+            )
+        )
+    )
+    view = scrollWindow.get_children()[0]
+    rows = [x for x in view.get_model()]
+    assert (CHANGESET_ACTION_ADD, path_action_list[0][0]) == (rows[0][0], rows[0][1])
+    assert (CHANGESET_ACTION_DEL, path_action_list[1][0]) == (rows[1][0], rows[1][1])

--- a/python/fapolicy_analyzer/tests/test_database_admin_page.py
+++ b/python/fapolicy_analyzer/tests/test_database_admin_page.py
@@ -4,19 +4,18 @@ import pytest
 
 gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk
-from unittest.mock import MagicMock
 from ui.database_admin_page import DatabaseAdminPage
 
 
 @pytest.fixture
 def widget(mocker):
     mocker.patch(
-        "ui.database_admin_page.AncillaryTrustDatabaseAdmin",
-        return_value=MagicMock(get_ref=MagicMock(return_value=Gtk.Box())),
+        "ui.database_admin_page.AncillaryTrustDatabaseAdmin.get_ref",
+        return_value=Gtk.Box(),
     )
     mocker.patch(
-        "ui.database_admin_page.SystemTrustDatabaseAdmin",
-        return_value=MagicMock(get_ref=MagicMock(return_value=Gtk.Box())),
+        "ui.database_admin_page.SystemTrustDatabaseAdmin.get_ref",
+        return_value=Gtk.Box(),
     )
     return DatabaseAdminPage()
 
@@ -37,3 +36,9 @@ def test_appends_ancillary_db_admin_tab(widget):
     page = content.get_nth_page(1)
     assert type(page) is Gtk.Box
     assert content.get_tab_label_text(page) == "Ancillary Trust Database"
+
+
+def test_handles_system_trust_file_add(widget, mocker):
+    mocker.patch.object(widget.ancillaryTrustDbAdmin, "add_trusted_files")
+    widget.systemTrustDbAdmin.file_added_to_ancillary_trust("foo")
+    widget.ancillaryTrustDbAdmin.add_trusted_files.assert_called_with("foo")

--- a/python/fapolicy_analyzer/tests/test_system_trust_database_admin.py
+++ b/python/fapolicy_analyzer/tests/test_system_trust_database_admin.py
@@ -43,3 +43,20 @@ def test_updates_trust_details(widget, mocker):
         "stat: cannot stat '/tmp/foo': No such file or directory\nSHA256: abc"
     )
     widget.trustFileDetails.set_trust_status.assert_called_with("This file is trusted.")
+
+
+def test_disables_add_button(widget):
+    addBtn = widget.get_object("addBtn")
+    addBtn.set_sensitive(True)
+    assert addBtn.get_sensitive()
+    widget.on_trust_selection_changed(None)
+    assert not addBtn.get_sensitive()
+
+
+def test_fires_file_added_to_ancillary_trust(widget):
+    handler = MagicMock()
+    widget.file_added_to_ancillary_trust += handler
+    widget.selectedFile = MagicMock(path="foo")
+    addBtn = widget.get_object("addBtn")
+    addBtn.clicked()
+    handler.assert_called_with("foo")

--- a/python/fapolicy_analyzer/tests/test_trust_file_list.py
+++ b/python/fapolicy_analyzer/tests/test_trust_file_list.py
@@ -41,49 +41,15 @@ def test_uses_custom_markup_func():
 
 
 def test_loads_trust_store(widget):
-    widget.load_store(_trust)
+    widget.load_trust(_trust)
     view = widget.get_object("treeView")
     assert [t.status for t in _trust] == [x[0] for x in view.get_model()]
     assert [t.path for t in _trust] == [x[1] for x in view.get_model()]
 
 
-def test_fires_files_added(widget, mocker):
-    mocker.patch(
-        "ui.trust_file_list.Gtk.FileChooserDialog.run",
-        return_value=Gtk.ResponseType.OK,
-    )
-    mocker.patch(
-        "ui.trust_file_list.Gtk.FileChooserDialog.get_filenames",
-        return_value=["foo"],
-    )
-    mocker.patch("ui.trust_file_list.path.isfile", return_value=True)
+def test_fires_trust_selection_changed(widget):
     mockHandler = MagicMock()
-    widget.files_added += mockHandler
-    parent = Gtk.Window()
-    widget.get_ref().set_parent(parent)
-    addBtn = widget.get_object("actionButtons").get_children()[0]
-    addBtn.clicked()
-    mockHandler.assert_called_with(["foo"])
-
-
-def test_fires_files_w_spaces_added(widget, mocker):
-    mocker.patch(
-        "ui.trust_file_list.Gtk.FileChooserDialog.run",
-        return_value=Gtk.ResponseType.OK,
-    )
-    mocker.patch(
-        "ui.trust_file_list.Gtk.FileChooserDialog.get_filenames",
-        return_value=["/tmp/a file name with spaces"],
-    )
-    mocker.patch("ui.trust_file_list.path.isfile", return_value=True)
-    mocker.patch(
-        "ui.trust_file_list.Gtk.MessageDialog.run",
-        return_value=Gtk.ResponseType.OK,
-    )
-    mockHandler = MagicMock()
-    widget.files_added += mockHandler
-    parent = Gtk.Window()
-    widget.get_ref().set_parent(parent)
-    addBtn = widget.get_object("actionButtons").get_children()[0]
-    addBtn.clicked()
-    assert not mockHandler.called, "Callback should not be invoked; Filepath w/spaces should be filtered out"
+    widget.trust_selection_changed += mockHandler
+    view = widget.get_object("treeView")
+    view.get_selection().select_path(Gtk.TreePath.new_first())
+    mockHandler.assert_called_with(_trust[0])

--- a/python/fapolicy_analyzer/ui/ancillary_trust_file_list.py
+++ b/python/fapolicy_analyzer/ui/ancillary_trust_file_list.py
@@ -1,0 +1,128 @@
+import gi
+import re
+import ui.strings as strings
+
+gi.require_version("Gtk", "3.0")
+from functools import reduce
+from gi.repository import Gtk
+from os import path
+from types import SimpleNamespace
+from .configs import Colors
+from .state_manager import stateManager
+from .strings import CHANGESET_ACTION_ADD, CHANGESET_ACTION_DEL
+from .trust_file_list import TrustFileList
+
+
+class AncillaryTrustFileList(TrustFileList):
+    def __init__(self, trust_func):
+        addBtn = Gtk.Button(
+            label="Add",
+            image=Gtk.Image.new_from_icon_name("list-add", 0),
+            always_show_image=True,
+        )
+        addBtn.connect("clicked", self.on_addBtn_clicked)
+
+        super().__init__(trust_func, self.__status_markup, addBtn)
+
+    def __status_markup(self, status):
+        s = status.lower()
+        return (
+            ("<b><u>T</u></b>/D", Colors.LIGHT_GREEN)
+            if s == "t"
+            else ("T/<b><u>D</u></b>", Colors.LIGHT_RED)
+            if s == "d"
+            else ("T/D", Colors.LIGHT_YELLOW)
+        )
+
+    def _changesets_to_map(self):
+        def reducer(map, path):
+            map.get(changesetMap[path], []).append(path)
+            return map
+
+        # map change path to action, the action for the last change in the queue wins
+        changesetMap = {
+            path: action
+            for e in stateManager.get_changeset_q() or []
+            for (path, action) in e.get_path_action_map().items()
+        }
+        return reduce(
+            reducer,
+            changesetMap,
+            {"Add": [], "Del": []},
+        )
+
+    def _columns(self):
+        statusColumn = Gtk.TreeViewColumn(
+            strings.FILE_LIST_CHANGES_HEADER,
+            Gtk.CellRendererText(background="light gray"),
+            text=4,
+        )
+        statusColumn.set_sort_column_id(4)
+        return [statusColumn, *super()._columns()]
+
+    def load_trust(self, trust):
+        changesetMap = self._changesets_to_map()
+
+        store = Gtk.ListStore(str, str, object, str, str)
+        for i, data in enumerate(trust):
+            status, *rest = self.markup_func(data.status)
+            bgColor = rest[0] if rest else "white"
+            changes = CHANGESET_ACTION_ADD if data.path in changesetMap["Add"] else ""
+            store.append([status, data.path, data, bgColor, changes])
+
+        for pth in changesetMap["Del"]:
+            store.append(
+                ["T/D", pth, SimpleNamespace(path=pth), "white", CHANGESET_ACTION_DEL]
+            )
+
+        self.load_store(store)
+
+    def on_addBtn_clicked(self, *args):
+        fcd = Gtk.FileChooserDialog(
+            title=strings.ADD_FILE_BUTTON_LABEL,
+            transient_for=self.get_ref().get_toplevel(),
+            action=Gtk.FileChooserAction.OPEN,
+        )
+        fcd.add_buttons(
+            Gtk.STOCK_CANCEL,
+            Gtk.ResponseType.CANCEL,
+            Gtk.STOCK_ADD,
+            Gtk.ResponseType.OK,
+        )
+        fcd.set_select_multiple(True)
+        response = fcd.run()
+        fcd.hide()
+        if response == Gtk.ResponseType.OK:
+            files = [f for f in fcd.get_filenames() if path.isfile(f)]
+
+            # -- Filter to address fapolicyd embeded whitspace in path issue
+            #     Current fapolicyd VT.B.D. When fixed remove this block
+            #
+            # Detect and remove file paths w/embedded spaces. Alert user w/dlg
+            print("Filtering out paths with embedded whitespace")
+            listAccepted = [e for e in files if not re.search(r"\s", e)]
+            listRejected = [e for e in files if re.search(r"\s", e)]
+            if listRejected:
+                dlgWhitespaceInfo = Gtk.MessageDialog(
+                    transient_for=self.get_ref().get_toplevel(),
+                    flags=0,
+                    message_type=Gtk.MessageType.INFO,
+                    buttons=Gtk.ButtonsType.OK,
+                    text=strings.WHITESPACE_WARNING_DIALOG_TITLE,
+                )
+
+                # Convert list of paths to a single string
+                strListRejected = "\n".join(listRejected)
+
+                dlgWhitespaceInfo.format_secondary_text(
+                    strings.WHITESPACE_WARNING_DIALOG_TEXT + strListRejected
+                )
+                dlgWhitespaceInfo.run()
+                dlgWhitespaceInfo.destroy()
+            files = listAccepted
+            #     Remove this filter block if fapolicyd bug #TBD is fixed
+            # ----------------------------------------------------------------
+
+            if files:
+                self.files_added(files)
+        fcd.destroy()

--- a/python/fapolicy_analyzer/ui/confirm_info_dialog.py
+++ b/python/fapolicy_analyzer/ui/confirm_info_dialog.py
@@ -2,14 +2,21 @@ import gi
 
 gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk
-import ui.strings as strings
+from .strings import (
+    CHANGESET_ACTION_ADD,
+    CHANGESET_ACTION_DEL,
+    DEPLOY_ANCILLARY_CONFIRM_DIALOG_TEXT,
+    DEPLOY_ANCILLARY_CONFIRM_DIALOG_TITLE,
+    DEPLOY_ANCILLARY_CONFIRM_DLG_ACTION_COL_HDR,
+    DEPLOY_ANCILLARY_CONFIRM_DLG_PATH_COL_HDR,
+)
 
 
 class ConfirmInfoDialog(Gtk.Dialog):
-    def __init__(self, parent=None):
+    def __init__(self, parent=None, listPathActionPairs=[]):
         Gtk.Dialog.__init__(
             self,
-            title=strings.DEPLOY_ANCILLARY_CONFIRM_DIALOG_TITLE,
+            title=DEPLOY_ANCILLARY_CONFIRM_DIALOG_TITLE,
             transient_for=parent,
             flags=0,
         )
@@ -20,38 +27,44 @@ class ConfirmInfoDialog(Gtk.Dialog):
 
         self.set_default_size(-1, 200)
 
-        label = Gtk.Label(label=strings.DEPLOY_ANCILLARY_CONFIRM_DIALOG_TEXT)
+        changeStore = Gtk.ListStore(str, str)
+        self.__load_path_action_list(changeStore, listPathActionPairs)
+        tree_view = Gtk.TreeView(model=changeStore)
+        tree_view.get_selection().set_mode(Gtk.SelectionMode.NONE)
 
-        self.scrolled_window = Gtk.ScrolledWindow()
-        self.changeStore = Gtk.ListStore(str, str)
-        self.tree_view = Gtk.TreeView(model=self.changeStore)
-
-        cellAction = Gtk.CellRendererText()
-        cellAction.set_property("background", "light gray")
         columnAction = Gtk.TreeViewColumn(
-            strings.DEPLOY_ANCILLARY_CONFIRM_DLG_ACTION_COL_HDR, cellAction, markup=0
+            DEPLOY_ANCILLARY_CONFIRM_DLG_ACTION_COL_HDR,
+            Gtk.CellRendererText(background="light gray"),
+            text=0,
         )
-        self.tree_view.append_column(columnAction)
         columnAction.set_sort_column_id(0)
+        tree_view.append_column(columnAction)
 
-        cellFile = Gtk.CellRendererText()
         columnFile = Gtk.TreeViewColumn(
-            strings.DEPLOY_ANCILLARY_CONFIRM_DLG_PATH_COL_HDR, cellFile, text=1
+            DEPLOY_ANCILLARY_CONFIRM_DLG_PATH_COL_HDR, Gtk.CellRendererText(), text=1
         )
-
-        self.tree_view.append_column(columnFile)
         columnFile.set_sort_column_id(1)
-        self.scrolled_window.add(self.tree_view)
-        self.scrolled_window.set_policy(Gtk.PolicyType.NEVER, Gtk.PolicyType.ALWAYS)
+        tree_view.append_column(columnFile)
+
+        scrolled_window = Gtk.ScrolledWindow()
+        scrolled_window.add(tree_view)
+        scrolled_window.set_policy(Gtk.PolicyType.NEVER, Gtk.PolicyType.ALWAYS)
 
         box = self.get_content_area()
-        box.add(label)
-        box.pack_start(self.scrolled_window, True, True, 0)
+        box.add(Gtk.Label(label=DEPLOY_ANCILLARY_CONFIRM_DIALOG_TEXT))
+        box.pack_start(scrolled_window, True, True, 0)
 
         self.show_all()
 
-    def load_path_action_list(self, listPathActionPairs):
+    def __load_path_action_list(self, store, listPathActionPairs):
         if listPathActionPairs:
             for e in listPathActionPairs:
                 # tuples are in (path,action) order, displayed as (action,path)
-                self.changeStore.append(e[::-1])
+                action = (
+                    CHANGESET_ACTION_ADD
+                    if e[-1] == "Add"
+                    else CHANGESET_ACTION_DEL
+                    if e[-1] == "Del"
+                    else ""
+                )
+                store.append((action, e[0]))

--- a/python/fapolicy_analyzer/ui/strings.py
+++ b/python/fapolicy_analyzer/ui/strings.py
@@ -17,6 +17,10 @@ ANCILLARY_TRUST_TAB_LABEL = _("Ancillary Trust Database")
 
 FILE_LIST_TRUST_HEADER = _("Trust")
 FILE_LIST_FILE_HEADER = _("File")
+FILE_LIST_CHANGES_HEADER = _("Changes")
+
+CHANGESET_ACTION_ADD = _("Add")
+CHANGESET_ACTION_DEL = _("Delete")
 
 ADD_FILE_BUTTON_LABEL = _("Add File")
 

--- a/python/fapolicy_analyzer/ui/system_trust_database_admin.py
+++ b/python/fapolicy_analyzer/ui/system_trust_database_admin.py
@@ -26,9 +26,7 @@ class SystemTrustDatabaseAdmin(UIWidget, Events):
         self.executor = ThreadPoolExecutor(max_workers=1)
 
         self.trustFileList = TrustFileList(
-            trust_func=self.__load_trust,
-            markup_func=self.__status_markup,
-            read_only=True,
+            trust_func=self.__load_trust, markup_func=self.__status_markup
         )
         self.trustFileList.trust_selection_changed += self.on_trust_selection_changed
         self.get_object("leftBox").pack_start(

--- a/python/fapolicy_analyzer/ui/trust_file_list.py
+++ b/python/fapolicy_analyzer/ui/trust_file_list.py
@@ -1,45 +1,37 @@
 import gi
-import re
 import ui.strings as strings
 
 gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk
-from os import path
 from .searchable_list import SearchableList
 
 
 class TrustFileList(SearchableList):
-    def __init__(self, trust_func, markup_func=None, read_only=False):
+    def __init__(self, trust_func, markup_func=None, *args):
         self.__events__ = [
             *super().__events__,
             "files_added",
             "files_deleted",
             "trust_selection_changed",
         ]
-        buttons = [] if read_only else [self.__addButton()]
 
-        super().__init__(self.__columns(), *buttons, searchColumnIndex=1)
+        super().__init__(self._columns(), *args, searchColumnIndex=1)
         self.trust_func = trust_func
         self.markup_func = markup_func
-        self.__load_data()
+        self.refresh()
         self.selection_changed += self.__handle_selection_changed
 
-    def __addButton(self):
-        addBtn = Gtk.Button(
-            label="Add",
-            image=Gtk.Image.new_from_icon_name("list-add", 0),
-            always_show_image=True,
-        )
-        addBtn.connect("clicked", self.on_addBtn_clicked)
-        return addBtn
+    def __handle_selection_changed(self, data):
+        trust = data[2] if data else None
+        self.trust_selection_changed(trust)
 
-    def __columns(self):
-        trustCell = Gtk.CellRendererText()
-        trustCell.set_property("background", "light gray")
+    def _columns(self):
         trustColumn = Gtk.TreeViewColumn(
-            strings.FILE_LIST_TRUST_HEADER, trustCell, markup=0
+            strings.FILE_LIST_TRUST_HEADER,
+            Gtk.CellRendererText(background="light gray"),
+            markup=0,
         )
-        trustColumn.set_sort_column_id(0)
+        trustColumn.set_sort_column_id(0),
         fileColumn = Gtk.TreeViewColumn(
             strings.FILE_LIST_FILE_HEADER,
             Gtk.CellRendererText(),
@@ -49,74 +41,17 @@ class TrustFileList(SearchableList):
         fileColumn.set_sort_column_id(1)
         return [trustColumn, fileColumn]
 
-    def __handle_selection_changed(self, data):
-        trust = data[2] if data else None
-        self.trust_selection_changed(trust)
-
-    def __load_data(self):
-        super().set_loading(True)
-        self.trust_func(self.load_store)
-
     def refresh(self):
-        self.__load_data()
+        super().set_loading(True)
+        self.trust_func(self.load_trust)
 
-    def load_store(self, trust):
+    def load_trust(self, trust):
         store = Gtk.ListStore(str, str, object, str)
-        for i, t in enumerate(trust):
+        for i, data in enumerate(trust):
             status, *rest = (
-                self.markup_func(t.status) if self.markup_func else (t.status,)
+                self.markup_func(data.status) if self.markup_func else (data.status,)
             )
             bgColor = rest[0] if rest else "white"
-            store.append([status, t.path, t, bgColor])
+            store.append([status, data.path, data, bgColor])
 
-        super().load_store(store)
-
-    def on_addBtn_clicked(self, *args):
-        fcd = Gtk.FileChooserDialog(
-            title=strings.ADD_FILE_BUTTON_LABEL,
-            transient_for=self.get_ref().get_toplevel(),
-            action=Gtk.FileChooserAction.OPEN,
-        )
-        fcd.add_buttons(
-            Gtk.STOCK_CANCEL,
-            Gtk.ResponseType.CANCEL,
-            Gtk.STOCK_ADD,
-            Gtk.ResponseType.OK,
-        )
-        fcd.set_select_multiple(True)
-        response = fcd.run()
-        fcd.hide()
-        if response == Gtk.ResponseType.OK:
-            files = [f for f in fcd.get_filenames() if path.isfile(f)]
-
-            # -- Filter to address fapolicyd embeded whitspace in path issue
-            #     Current fapolicyd VT.B.D. When fixed remove this block
-            #
-            # Detect and remove file paths w/embedded spaces. Alert user w/dlg
-            print("Filtering out paths with embedded whitespace")
-            listAccepted = [e for e in files if not re.search(r"\s", e)]
-            listRejected = [e for e in files if re.search(r"\s", e)]
-            if listRejected:
-                dlgWhitespaceInfo = Gtk.MessageDialog(
-                    transient_for=self.get_ref().get_toplevel(),
-                    flags=0,
-                    message_type=Gtk.MessageType.INFO,
-                    buttons=Gtk.ButtonsType.OK,
-                    text=strings.WHITESPACE_WARNING_DIALOG_TITLE,
-                )
-
-                # Convert list of paths to a single string
-                strListRejected = "\n".join(listRejected)
-
-                dlgWhitespaceInfo.format_secondary_text(
-                    strings.WHITESPACE_WARNING_DIALOG_TEXT + strListRejected
-                )
-                dlgWhitespaceInfo.run()
-                dlgWhitespaceInfo.destroy()
-            files = listAccepted
-            #     Remove this filter block if fapolicyd bug #TBD is fixed
-            # ----------------------------------------------------------------
-
-            if files:
-                self.files_added(files)
-        fcd.destroy()
+        self.load_store(store)


### PR DESCRIPTION
Adds a "Changes" column to the Ancillary Trust DB Admin View's file list component.  This column will show the last action taken for a file, either "Add" or "Delete".  It shows nothing if the file hasn't been modified in the current session.

* Subclassed TrustFileList specifically for Ancillary Trust
* Updated ConfirmInfoDialog
* testing and lint

closes #162 