### PR TITLE
Add parsing support for debug log events

### DIFF
--- a/src/log.rs
+++ b/src/log.rs
@@ -1,58 +1,94 @@
-use std::collections::HashMap;
 use std::fs::File;
 use std::io::{prelude::*, BufReader};
 use std::iter::Iterator;
 use std::str::FromStr;
 
-use nom::alt;
-use nom::character::complete::alpha1;
-use nom::character::complete::line_ending as eol;
-use nom::character::is_alphanumeric;
-use nom::combinator::iterator;
-use nom::named;
-use nom::separated_pair;
-use nom::sequence::terminated;
-use nom::tag;
-use nom::take_while;
+use nom::bytes::complete::tag;
+use nom::character::complete::space0;
+use nom::character::complete::{digit1, space1};
+use nom::sequence::{preceded, terminated};
 
-pub struct LogObj {
-    pub path: String,
-    pub ftype: String,
+use crate::rules::*;
+
+#[derive(Debug)]
+pub struct Event {
+    pub rule_id: i32,
+    pub dec: Decision,
+    pub perm: Permission,
+    pub auid: i32,
+    pub pid: i32,
+    pub subj: Subject,
+    pub obj: Object,
 }
 
-impl LogObj {
-    pub fn from_file(path: &str) -> Vec<LogObj> {
+impl FromStr for Event {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match parse_event(s) {
+            Ok((_, s)) => Ok(s),
+            Err(_) => Err("Failed to parse Event from string".into()),
+        }
+    }
+}
+
+pub fn parse_event(i: &str) -> nom::IResult<&str, Event> {
+    match nom::combinator::complete(nom::sequence::tuple((
+        terminated(preceded(tag("rule="), digit1), space1),
+        terminated(preceded(tag("dec="), parse::decision), space1),
+        terminated(parse::permission, space1),
+        terminated(preceded(tag("auid="), digit1), space1),
+        terminated(preceded(tag("pid="), digit1), space1),
+        terminated(parse::subject, space1),
+        terminated(tag(":"), space0),
+        parse::object,
+    )))(i)
+    {
+        Ok((remaining_input, (id, dec, perm, auid, pid, subj, _, obj))) => Ok((
+            remaining_input,
+            Event {
+                rule_id: id.parse().unwrap(),
+                dec,
+                perm,
+                auid: auid.parse().unwrap(),
+                pid: pid.parse().unwrap(),
+                subj,
+                obj,
+            },
+        )),
+        Err(e) => {
+            println!("foo");
+            Err(e)
+        }
+    }
+}
+
+impl Event {
+    pub fn from_file(path: &str) -> Vec<Event> {
         let f = File::open(path).unwrap();
         let r = BufReader::new(f);
 
         r.lines()
             .map(|r| r.unwrap())
             .filter(|s| !s.is_empty() && !s.starts_with('#'))
-            .map(|l| LogObj::from_str(&l).unwrap())
+            .map(|l| parse_event(&l).unwrap().1)
             .collect()
     }
 }
 
-fn is_valid_value_char(chr: char) -> bool {
-    is_alphanumeric(chr as u8) || chr == '/' || chr == '-'
-}
+#[cfg(test)]
+mod tests {
+    use super::*;
 
-named!(end_of_line<&str, &str>, alt!(tag!(" ") | eol));
-named!(alphanumericslash1<&str, &str>, take_while!(is_valid_value_char));
-named!(kv_pair<&str, (&str, &str)>, separated_pair!(alpha1, nom::bytes::complete::tag("="), alphanumericslash1) );
-
-impl FromStr for LogObj {
-    type Err = String;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let clean = s.split(':').last().unwrap().trim_start();
-        let mut it = iterator(clean, terminated(kv_pair, end_of_line));
-        let map: HashMap<String, String> = it
-            .map(|(k, v)| (String::from(k), String::from(v)))
-            .collect();
-        Ok(LogObj {
-            path: map["path"].to_owned(),
-            ftype: map["ftype"].to_owned(),
-        })
+    #[test]
+    fn parse_log_event() {
+        let e = "rule=9 dec=allow perm=execute auid=1003 pid=5555 exe=/usr/bin/bash : path=/usr/bin/vi ftype=application/x-executable";
+        let (rem, e) = parse_event(e).ok().unwrap();
+        assert_eq!(9, e.rule_id);
+        assert!(rem.is_empty());
+        assert_eq!(e.dec, Decision::Allow);
+        assert_eq!(e.perm, Permission::Execute);
+        assert_eq!(e.auid, 1003);
+        assert_eq!(e.pid, 5555);
     }
 }

--- a/tests/log_parse.rs
+++ b/tests/log_parse.rs
@@ -1,0 +1,59 @@
+use crate::Line::AnEvent;
+use fapolicy_analyzer::log;
+use fapolicy_analyzer::log::Event;
+use nom::combinator::map;
+use std::fs::File;
+use std::io::{BufRead, BufReader};
+
+enum Line {
+    AnEvent(Event),
+}
+
+fn parser(i: &str) -> nom::IResult<&str, Line> {
+    map(log::parse_event, AnEvent)(i)
+}
+
+fn parse_lines(xs: Vec<String>) {
+    let lines: Vec<Line> = xs
+        .iter()
+        .map(|l| (l, parser(l)))
+        .flat_map(|(l, r)| match r {
+            Ok(("", rule)) => Some(rule),
+            Ok((rem, _)) => {
+                println!("[incomplete] {} [{}]", l, rem);
+                None
+            }
+            Err(_) => {
+                println!("[failure] {}", l);
+                None
+            }
+        })
+        .collect();
+
+    for (i, line) in lines.iter().enumerate() {
+        match line {
+            AnEvent(c) => println!("{}: {:?}", i, c),
+        }
+    }
+
+    println!(
+        "{}/{} - {:.2}%",
+        lines.len(),
+        xs.len(),
+        lines.len() as f32 / xs.len() as f32
+    );
+}
+
+#[test]
+fn test_parse_clean_1() {
+    let f = File::open("tests/data/full.log").expect("failed to open file");
+    let buff = BufReader::new(f);
+
+    let xs: Vec<String> = buff
+        .lines()
+        .map(|r| r.unwrap())
+        .filter(|s| s.starts_with("rule="))
+        .collect();
+
+    parse_lines(xs)
+}

--- a/tests/rule_file_parsing.rs
+++ b/tests/rule_file_parsing.rs
@@ -19,7 +19,7 @@ fn parser(i: &str) -> nom::IResult<&str, Line> {
     ))(i)
 }
 
-fn parse_clean(xs: Vec<String>) {
+fn parse_lines(xs: Vec<String>) {
     let lines: Vec<Line> = xs
         .iter()
         .map(|l| (l, parser(l)))
@@ -63,7 +63,7 @@ fn test_parse_all() {
         .filter(|s| !s.is_empty())
         .collect();
 
-    parse_clean(xs)
+    parse_lines(xs)
 }
 
 #[test]
@@ -77,7 +77,7 @@ fn test_parse_clean_1() {
         .filter(|s| !s.is_empty() && !s.starts_with('#'))
         .collect();
 
-    parse_clean(xs)
+    parse_lines(xs)
 }
 
 #[test]
@@ -91,5 +91,5 @@ fn test_parse_clean_2() {
         .filter(|s| !s.is_empty() && !s.starts_with('#'))
         .collect();
 
-    parse_clean(xs)
+    parse_lines(xs)
 }


### PR DESCRIPTION
Parse fapolicy log to produce events that will be used on the rule analysis screens.

The default logging format looks like
```
rule=9 dec=allow perm=execute auid=1003 pid=5555 exe=/usr/bin/bash : path=/usr/bin/vi ftype=application/x-executable
rule=17 dec=allow perm=open auid=1003 pid=5555 exe=/usr/bin/bash : path=/usr/bin/vi ftype=application/x-executable
rule=9 dec=allow perm=execute auid=1003 pid=5555 exe=/usr/bin/bash : path=/usr/lib64/ld-2.28.so ftype=application/x-sharedlib
rule=7 dec=allow perm=open auid=1003 pid=5555 exe=/usr/bin/bash : path=/usr/lib64/ld-2.28.so ftype=application/x-sharedlib
```

You can see the similarities to the fapolicyd rules schema, which allows us to leverage the Rule parsing combinators to parse the most complex portion of the log entries.

The logging format is configurable, according to the docs

>Also, in fapolicyd.conf, there is a configuration option, syslog_format, which
can be modified to output information the way you want to see it. So, if you
think auid in uninteresting you can delete it. If you want to see the device
information for the file being accessed, you can add it. You can also enable
this information to go to syslog by changing the rules to not say audit, but
instead have syslog or log appended to the allow or deny decision.

We are currently parsing the default format

`syslog_format = rule,dec,perm,auid,pid,exe,:,path,ftype,trust`