### PR TITLE
fixup: Actual metadata

### DIFF
--- a/crates/analyzer/src/error.rs
+++ b/crates/analyzer/src/error.rs
@@ -18,6 +18,9 @@ pub enum Error {
     #[error("RPM error: {0}")]
     RpmError(#[from] rpm::Error),
 
-    #[error("Hash error: {0}")]
-    MetaError(#[from] io::Error),
+    #[error("File IO Error: {0}")]
+    FileIoError(#[from] io::Error),
+
+    #[error("Error reading metadata: {0}")]
+    MetaError(String),
 }

--- a/crates/analyzer/src/error.rs
+++ b/crates/analyzer/src/error.rs
@@ -19,5 +19,5 @@ pub enum Error {
     RpmError(#[from] rpm::Error),
 
     #[error("Hash error: {0}")]
-    HashOpError(#[from] io::Error),
+    MetaError(#[from] io::Error),
 }

--- a/crates/analyzer/src/trust.rs
+++ b/crates/analyzer/src/trust.rs
@@ -31,18 +31,25 @@ pub enum Error {
     MalformattedTrustEntry(String),
 }
 
-/// Trust status tag
-/// T / U / unk
+/// Actual delivers metadata about the actual file that exists on the filesystem.
+/// This is used to identify discrepancies between the trusted and the actual files.
+#[derive(Clone)]
+pub struct Actual {
+    pub size: u64,
+    pub hash: String,
+    pub last_modified: String,
+}
+
+/// Trust status tag TDU
+/// Trusted / Discrepancy / Unknown
 #[derive(Clone)]
 pub enum Status {
-    /// No entry in database
-    Unknown(api::Trust),
-    /// filesystem matches database
-    Trusted(api::Trust),
-    /// filesystem does not match database
-    /// lhs expected, rhs actual
-    Discrepancy(api::Trust, String),
-    // todo;; what about file does not exist?
+    /// No trust entry in database
+    Unknown(Actual),
+    /// Filesystem matches trust
+    Trusted(api::Trust, Actual),
+    /// filesystem does not match trust
+    Discrepancy(api::Trust, Actual),
 }
 
 struct TrustPair {

--- a/crates/analyzer/src/trust.rs
+++ b/crates/analyzer/src/trust.rs
@@ -37,7 +37,7 @@ pub enum Error {
 pub struct Actual {
     pub size: u64,
     pub hash: String,
-    pub last_modified: String,
+    pub last_modified: u64,
 }
 
 /// Trust status tag

--- a/crates/analyzer/src/trust.rs
+++ b/crates/analyzer/src/trust.rs
@@ -40,12 +40,9 @@ pub struct Actual {
     pub last_modified: String,
 }
 
-/// Trust status tag TDU
-/// Trusted / Discrepancy / Unknown
+/// Trust status tag
 #[derive(Clone)]
 pub enum Status {
-    /// No trust entry in database
-    Unknown(Actual),
     /// Filesystem matches trust
     Trusted(api::Trust, Actual),
     /// filesystem does not match trust

--- a/crates/pyo3/src/trust.rs
+++ b/crates/pyo3/src/trust.rs
@@ -13,17 +13,20 @@ use fapolicy_analyzer::trust;
 #[derive(Clone)]
 pub struct PyTrust {
     pub trust: api::Trust,
+    pub actual: Option<trust::Actual>,
     pub status: String,
 }
 impl From<trust::Status> for PyTrust {
     fn from(status: trust::Status) -> Self {
-        let (trust, tag) = match status {
-            trust::Status::Trusted(t) => (t, "T"),
-            trust::Status::Discrepancy(t, _) => (t, "D"),
-            trust::Status::Unknown(t) => (t, "U"),
+        let (trust, actual, tag) = match status {
+            trust::Status::Trusted(t, act) => (t, act, "T"),
+            trust::Status::Discrepancy(t, act) => (t, act, "D"),
+            // todo;; hmmmmmmmmmmmmmmmmmmmm
+            trust::Status::Unknown(_) => panic!("shouldnt have got an unknown"), /*(t, "U")*/
         };
         Self {
             trust,
+            actual: Some(actual),
             status: tag.to_string(),
         }
     }
@@ -40,6 +43,7 @@ impl PyTrust {
                 hash: sha.to_string(),
                 source: TrustSource::Ancillary,
             },
+            actual: None,
             status: "U".to_string(),
         }
     }
@@ -57,6 +61,11 @@ impl PyTrust {
     #[getter]
     fn get_hash(&self) -> &str {
         &self.trust.hash
+    }
+
+    #[getter]
+    fn get_last_modified(&self) -> Option<String> {
+        self.actual.as_ref().map(|a| a.clone().last_modified)
     }
 
     /// Get a string representation of the TDU status

--- a/crates/pyo3/src/trust.rs
+++ b/crates/pyo3/src/trust.rs
@@ -47,8 +47,8 @@ impl PyTrust {
     }
 
     #[getter]
-    fn get_last_modified(&self) -> &str {
-        self.actual.last_modified.as_str()
+    fn get_last_modified(&self) -> u64 {
+        self.actual.last_modified
     }
 
     #[getter]

--- a/examples/show_trust.py
+++ b/examples/show_trust.py
@@ -1,0 +1,36 @@
+from fapolicy_analyzer import *
+import argparse
+import sys
+from datetime import datetime
+
+
+def main(*argv):
+    parser = argparse.ArgumentParser()
+    parser.add_argument("trust_type", nargs="+", choices=["system", "file"], help="trust type to show")
+    parser.add_argument("-c", "--count", action='store_true', help="only show the count")
+    parser.add_argument("-t", action='store_true', help="show last modified time")
+    args = parser.parse_args(argv)
+
+    # config is loaded from $HOME/.config/fapolicy-analyzer/fapolicy-analyzer.toml
+    s1 = System()
+
+    for tt in args.trust_type:
+        ts = []
+        if tt == "system":
+            ts = s1.system_trust()
+        else:
+            ts = s1.ancillary_trust()
+
+        if args.count:
+            print(len(ts))
+        else:
+            for t in ts:
+                print(f"{t.path} {t.size} {t.hash}")
+                if args.t:
+                    formatted = datetime.fromtimestamp(t.last_modified)
+                    print(f"\t-last modified: {formatted}")
+            print(f"found {len(ts)} {tt} trust entries")
+
+
+if __name__ == "__main__":
+    main(*sys.argv[1:])

--- a/examples/show_trust.py
+++ b/examples/show_trust.py
@@ -26,7 +26,7 @@ def main(*argv):
         else:
             for t in ts:
                 print(f"{t.path} {t.size} {t.hash}")
-                if args.t:
+                if args.time:
                     formatted = datetime.fromtimestamp(t.last_modified)
                     print(f"\t-last modified: {formatted}")
             print(f"found {len(ts)} {tt} trust entries")

--- a/examples/show_trust.py
+++ b/examples/show_trust.py
@@ -8,7 +8,7 @@ def main(*argv):
     parser = argparse.ArgumentParser()
     parser.add_argument("trust_type", nargs="+", choices=["system", "file"], help="trust type to show")
     parser.add_argument("-c", "--count", action='store_true', help="only show the count")
-    parser.add_argument("-t", action='store_true', help="show last modified time")
+    parser.add_argument("-t", "--time", action='store_true', help="show last modified time")
     args = parser.parse_args(argv)
 
     # config is loaded from $HOME/.config/fapolicy-analyzer/fapolicy-analyzer.toml


### PR DESCRIPTION
Tracking the actual metadata (meta from the fs) as a part of the trust status.

This is extensible beyond the sha and size, as this PR shows the last modified time as an example.

closes #215 