### PR TITLE
Cache resolved trust

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -256,7 +256,6 @@ dependencies = [
  "fapolicy-daemon",
  "fapolicy-trust",
  "pyo3",
- "rayon",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -280,6 +280,7 @@ dependencies = [
  "fapolicy-api",
  "fapolicy-util",
  "lmdb-rkv",
+ "rayon",
  "serde",
  "thiserror",
 ]

--- a/crates/pyo3/Cargo.toml
+++ b/crates/pyo3/Cargo.toml
@@ -10,7 +10,6 @@ crate-type = ["cdylib"]
 
 [dependencies]
 pyo3 = "0.14.2"
-rayon = "1.5"
 
 fapolicy-api = { version = "0.3.0", path = "../api" }
 fapolicy-analyzer = { version = "0.3", path = "../analyzer" }

--- a/crates/pyo3/src/app.rs
+++ b/crates/pyo3/src/app.rs
@@ -1,6 +1,5 @@
 use pyo3::prelude::*;
 use pyo3::{exceptions, PyResult};
-use rayon::prelude::*;
 
 use fapolicy_analyzer::log::Event;
 use fapolicy_app::app::State;
@@ -55,21 +54,12 @@ impl PySystem {
         self.state
             .trust_db
             .values()
-            .par_iter()
+            .iter()
             .filter(|r| r.is_system())
             .map(|r| r.status.clone())
             .flatten()
             .map(PyTrust::from)
             .collect()
-    }
-
-    /// Obtain a list of trusted files sourced from the system trust database.
-    /// The system trust is generated from the contents of the RPM database.
-    /// This represents state in the current fapolicyd database, not necessarily
-    /// matching what is currently in the RPM database.
-    /// This call will not block other threads from executing.
-    fn system_trust_async(&self, py: Python) -> Vec<PyTrust> {
-        py.allow_threads(|| self.system_trust())
     }
 
     /// Obtain a list of trusted files sourced from the ancillary trust database.
@@ -79,20 +69,12 @@ impl PySystem {
         self.state
             .trust_db
             .values()
-            .par_iter()
+            .iter()
             .filter(|r| r.is_ancillary())
             .map(|r| r.status.clone())
             .flatten()
             .map(PyTrust::from)
             .collect()
-    }
-
-    /// Obtain a list of trusted files sourced from the ancillary trust database.
-    /// This represents state in the current fapolicyd database, not necessarily
-    /// matching what is currently in the ancillary trust file.
-    /// This call will not block other threads from executing.
-    fn ancillary_trust_async(&self, py: Python) -> Vec<PyTrust> {
-        py.allow_threads(|| self.ancillary_trust())
     }
 
     /// Apply the changeset to the state of this System generating a new System

--- a/crates/pyo3/src/app.rs
+++ b/crates/pyo3/src/app.rs
@@ -54,7 +54,7 @@ impl PySystem {
         self.state
             .trust_db
             .values()
-            .par_iter()
+            .iter()
             .filter(|r| r.is_system())
             .map(|r| check(&r.trusted))
             .flatten()

--- a/crates/trust/Cargo.toml
+++ b/crates/trust/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2018"
 
 [dependencies]
 lmdb-rkv = "0.14.0"
+rayon = "1.5"
 serde = { version = "1.0", features = ["derive"] }
 thiserror = "1.0"
 

--- a/crates/trust/src/db.rs
+++ b/crates/trust/src/db.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 use fapolicy_api::trust::Trust;
 
 use crate::source::TrustSource;
-use crate::stat::Actual;
+use crate::stat::{Actual, Status};
 
 /// Trust Database
 /// A container for tracking trust entries and their metadata
@@ -71,6 +71,7 @@ impl DB {
 #[derive(PartialEq, Eq, Clone, Debug)]
 pub struct Rec {
     pub trusted: Trust,
+    pub status: Option<Status>,
     actual: Option<Actual>,
     source: Option<TrustSource>,
 }
@@ -81,6 +82,7 @@ impl Rec {
         Rec {
             trusted: t,
             actual: None,
+            status: None,
             source: None,
         }
     }
@@ -90,6 +92,7 @@ impl Rec {
         Rec {
             trusted: t,
             actual: None,
+            status: None,
             source: Some(source),
         }
     }
@@ -103,6 +106,8 @@ impl Rec {
     pub fn is_ancillary(&self) -> bool {
         matches!(&self.source, Some(TrustSource::Ancillary))
     }
+
+    pub fn status(&self) -> Result<Status> {}
 }
 
 #[cfg(test)]

--- a/crates/trust/src/db.rs
+++ b/crates/trust/src/db.rs
@@ -3,8 +3,9 @@ use std::collections::HashMap;
 
 use fapolicy_api::trust::Trust;
 
+use crate::error::Error;
 use crate::source::TrustSource;
-use crate::stat::{Actual, Status};
+use crate::stat::{check, Actual, Status};
 
 /// Trust Database
 /// A container for tracking trust entries and their metadata
@@ -107,7 +108,14 @@ impl Rec {
         matches!(&self.source, Some(TrustSource::Ancillary))
     }
 
-    pub fn status(&self) -> Result<Status> {}
+    /// Check a Rec into a Rec with updated status
+    pub fn status_check(rec: Rec) -> Result<Rec, Error> {
+        let status = check(&rec.trusted)?;
+        Ok(Rec {
+            status: Some(status),
+            ..rec
+        })
+    }
 }
 
 #[cfg(test)]

--- a/crates/trust/src/read.rs
+++ b/crates/trust/src/read.rs
@@ -1,3 +1,4 @@
+use rayon::prelude::*;
 use std::collections::HashMap;
 use std::path::Path;
 
@@ -61,6 +62,12 @@ pub fn load_trust_db(path: &str) -> Result<DB, Error> {
         .unwrap()
         .map_err(LmdbReadFail)
         .unwrap();
+
+    // check
+    let lookup: HashMap<String, Rec> = lookup
+        .par_iter()
+        .flat_map(|(p, r)| Rec::status_check(r.clone()).map(|r| (p.clone(), r)))
+        .collect();
 
     Ok(DB::from(lookup))
 }

--- a/crates/trust/src/stat.rs
+++ b/crates/trust/src/stat.rs
@@ -18,7 +18,7 @@ pub struct Actual {
 }
 
 /// Trust status tag
-#[derive(Debug)]
+#[derive(PartialEq, Eq, Clone, Debug)]
 pub enum Status {
     /// Filesystem matches trust
     Trusted(Trust, Actual),

--- a/fapolicy_analyzer/tests/mocks.py
+++ b/fapolicy_analyzer/tests/mocks.py
@@ -7,13 +7,7 @@ class mock_System:
     def ancillary_trust(self):
         return [self.mock_trust]
 
-    def ancillary_trust_async(self):
-        return [self.mock_trust]
-
     def system_trust(self):
-        return [self.mock_trust]
-
-    def system_trust_async(self):
         return [self.mock_trust]
 
     def deploy(self):

--- a/fapolicy_analyzer/ui/ancillary_trust_database_admin.py
+++ b/fapolicy_analyzer/ui/ancillary_trust_database_admin.py
@@ -54,7 +54,7 @@ class AncillaryTrustDatabaseAdmin(UIWidget):
 
     def __load_trust(self, callback):
         def get_trust():
-            trust = self.system.ancillary_trust_async()
+            trust = self.system.ancillary_trust()
             GLib.idle_add(callback, trust)
 
         self.executor.submit(get_trust)

--- a/fapolicy_analyzer/ui/system_trust_database_admin.py
+++ b/fapolicy_analyzer/ui/system_trust_database_admin.py
@@ -47,7 +47,7 @@ class SystemTrustDatabaseAdmin(UIWidget, Events):
 
     def __load_trust(self, callback):
         def get_trust():
-            trust = self.system.system_trust_async()
+            trust = self.system.system_trust()
             GLib.idle_add(callback, trust)
 
         self.executor.submit(get_trust)


### PR DESCRIPTION
Moves resolution of trust status to system boot time, caching it for reuse.

This eliminates the need for async fetches in the bindings.