### PR TITLE
Allow empty user comment

### DIFF
--- a/crates/analyzer/src/users/parse.rs
+++ b/crates/analyzer/src/users/parse.rs
@@ -33,7 +33,7 @@ pub fn user(i: &str) -> nom::IResult<&str, User> {
         terminated(opt(tag("x")), tag(":")),
         terminated(digit1, tag(":")),
         terminated(digit1, tag(":")),
-        terminated(any, tag(":")),
+        terminated(opt(any), tag(":")),
         terminated(any, tag(":")),
         any,
     )))(i)

--- a/crates/analyzer/src/users/user.rs
+++ b/crates/analyzer/src/users/user.rs
@@ -65,4 +65,10 @@ mod tests {
         let actual = User::from_str("daemon:x:1:1:daemon:/usr/sbin:/usr/sbin/nologin").unwrap();
         assert_eq!(testuser(), actual);
     }
+
+    #[test]
+    fn without_comment_field() {
+        let actual = User::from_str("daemon:x:1:1::/usr/sbin:/usr/sbin/nologin").unwrap();
+        assert_eq!(testuser(), actual);
+    }
 }


### PR DESCRIPTION
A user entry in /etc/passwd can have an empty comment. Tthe user parser now optionally parses that field.


closes #203 