### PR TITLE
generate a deny event for dave the developer

### DIFF
--- a/scripts/demo/develop/tasks/main.yml
+++ b/scripts/demo/develop/tasks/main.yml
@@ -1,6 +1,6 @@
 # install development requirements, and create a build
 ---
-- name: install development requirements common to the RedHat 8 family
+- name: install development requirements common to the RedHat family
   yum:
     state: present
     name:

--- a/scripts/demo/events/tasks/main.yml
+++ b/scripts/demo/events/tasks/main.yml
@@ -66,6 +66,13 @@
     /usr/local/bin/dbadmin.py
   ignore_errors: yes
 
+- name: dave tries to run rustc
+  become: yes
+  become_user: dave
+  shell: |
+    /home/dave/.cargo/bin/rustc --version
+  ignore_errors: yes
+
 - name: capture events-1.txt
   become: yes
   shell: |

--- a/scripts/demo/filesystem/tasks/main.yml
+++ b/scripts/demo/filesystem/tasks/main.yml
@@ -1,5 +1,16 @@
 # initialize demonstration filesystem
 ---
+- name: check if fapolicyd service exists
+  stat: path=/etc/systemd/system/multi-user.target.wants/fapolicyd.service
+  register: fapolicyd_service_status
+
+- name: stop fapolicyd service
+  become: yes
+  systemd:
+    name: fapolicyd
+    state: stopped
+  when: fapolicyd_service_status.stat.exists
+
 - name: create demonstration directories
   file:
     path: "{{ item }}"
@@ -65,3 +76,16 @@
   loop:
     - { src: fapolicyd-readme.md, dest: /tmp }
     - { src: dbadmin.py, dest: /usr/local/bin }
+
+- name: dave installs rust in his home directory
+  become: yes
+  become_user: dave
+  shell: "curl https://sh.rustup.rs -sSf | sh -s -- -y"
+  changed_when: false
+
+- name: start fapolicyd service
+  become: yes
+  systemd:
+    name: fapolicyd
+    state: started
+  when: fapolicyd_service_status.stat.exists

--- a/scripts/demo/site.yml
+++ b/scripts/demo/site.yml
@@ -12,9 +12,9 @@
   gather_facts: no
   become: yes
   roles:
+    - users
     - fapolicyd
     - filesystem
-    - users
     - role: analyzer
       when: env != 'dev'
 

--- a/scripts/demo/system/tasks/main.yml
+++ b/scripts/demo/system/tasks/main.yml
@@ -27,7 +27,7 @@
     line: "export XAUTHORITY=/home/vagrant/.Xauthority"
     path: /etc/profile
 
-- name: "Add {{ vagrant_user }} to systemd-journal group"
+- name: "add {{ vagrant_user }} to systemd-journal group"
   user:
     name: "{{ vagrant_user }}"
     groups: systemd-journal

--- a/scripts/demo/system/tasks/main.yml
+++ b/scripts/demo/system/tasks/main.yml
@@ -1,6 +1,6 @@
 # install and initialize dependencies
 ---
-- name: install misc requirements
+- name: install misc requirements common to the RedHat family
   yum:
     state: present
     name:
@@ -9,7 +9,17 @@
       - xorg-x11-xauth
       - dbus-x11
       - dconf
+  when:
+    - ansible_facts['os_family'] == "RedHat"
+
+- name: install misc requirements that are Fedora 34 specific
+  yum:
+    state: present
+    name:
       - polkit-gnome
+  when:
+    - ansible_facts['distribution'] == "Fedora"
+    - ansible_facts['distribution_major_version'] == "34"
 
 - name: share vagrant user xauthority globally
   lineinfile:

--- a/scripts/demo/users/tasks/main.yml
+++ b/scripts/demo/users/tasks/main.yml
@@ -1,7 +1,6 @@
 # create demonstration users and groups
 ---
-
-- name: Create demo users
+- name: create demo users
   user:
     name: "{{ item.name }}"
     uid: "{{ item.uid }}"
@@ -16,7 +15,23 @@
     - { name: mallory, uid: 1006 }
     - { name: trudy, uid: 1007 }
 
-- name: create groups
-  debug:
-    msg: "todo"
-    verbosity: 0
+- name: create demo groups
+  group:
+    name: "{{ item.name }}"
+    state: present
+  loop:
+    - { name: accountant }
+    - { name: developer }
+    - { name: sysadmin }
+
+- name: add dave to developer group
+  user:
+    name: dave
+    groups: developer
+    append: yes
+
+- name: add trudy to sysadmin group
+  user:
+    name: trudy
+    groups: sysadmin
+    append: yes

--- a/scripts/vagrant/fc34/Vagrantfile
+++ b/scripts/vagrant/fc34/Vagrantfile
@@ -39,7 +39,8 @@ Vagrant.configure("2") do |config|
     end
     env = "dev"
     config.vbguest.auto_update = true
-    config.vm.synced_folder ".shared/", "/shared", type: "virtualbox"
+    Dir.mkdir './.shared/' unless File.exists?('./.shared/')
+    config.vm.synced_folder "./.shared/", "/shared", type: "virtualbox"
   end
   
   config.vm.provision "ansible" do |ansible|

--- a/scripts/vagrant/rhel8/Vagrantfile
+++ b/scripts/vagrant/rhel8/Vagrantfile
@@ -46,7 +46,8 @@ Vagrant.configure("2") do |config|
     end
     env = "dev"
     config.vbguest.auto_update = true
-    config.vm.synced_folder ".shared/", "/shared", type: "virtualbox"
+    Dir.mkdir './.shared/' unless File.exists?('./.shared/')
+    config.vm.synced_folder "./.shared/", "/shared", type: "virtualbox"
   end
   
   config.vm.provision "ansible" do |ansible|


### PR DESCRIPTION
Creates a deny event for "dave" the developer who is trying to use a rust compiler that was not installed by a trusted package repository.  The generated event log will look like this:

```{shell}
[vagrant@rhel8 ~]$ grep rustc events-1.txt
1:rule=4 dec=deny_syslog perm=execute uid=1004 gid=100,1002 pid=40358 exe=/usr/bin/bash : path=/home/dave/.cargo/bin/rustc ftype=application/x-executable trust=0
[vagrant@rhel8 ~]$
```
