### PR TITLE
Restore PolicyKit integration

### DIFF
--- a/bin/fapolicy-analyzer
+++ b/bin/fapolicy-analyzer
@@ -1,3 +1,36 @@
 #!/usr/bin/env bash
 
-python3 -m fapolicy_analyzer.ui
+# Initialize globals
+pidAgent=0
+strCallbackFile=/tmp/fileCallback.txt
+exec {fdCallback}>$strCallbackFile
+
+# Start timestamp added to shell PID. See note in pkttyagent manpage
+timestamp=$(cat /proc/$$/stat | awk '{print $22}')
+
+# Determine if we are in a remote ssh session
+if [[ ! -v SSH_TTY ]]; then
+    # Note: The Gnome desktop starts its own dbus agent.
+    XAUTHORITY=$XAUTHORITY
+else
+    # Start the dbus service agent if ssh session with a remote DISPLAY
+    XAUTHORITY=$HOME/.Xauthority
+    pkttyagent --notify-fd $fdCallback --process $$,$timestamp & pidAgent=$!
+
+    # Delay if needed so that pkttyagent completes registration on the dbus.
+    while ls /proc/$pidAgent/fd | grep -q $fdCallback
+    do
+	echo pkttyagent registering on the dbus...
+        sleep 1
+    done
+fi
+
+# Execute the fapolicy-analyzer with heightened privileges
+pkexec  --disable-internal-agent env NO_AT_BRIDGE=1 DISPLAY=$DISPLAY XAUTHORITY=$XAUTHORITY python3 -m fapolicy_analyzer.ui
+
+# Terminate pkttyagent if started
+if [[ $pidAgent != 0 ]]; then
+    echo Terminating pkttyagent.
+    kill -SIGTERM $pidAgent
+fi
+rm -f $strCallbackFile


### PR DESCRIPTION
Added conditional delay between pkttyagent start up and pkexec that starts fapolicy-analyzer. pkttyagent must complete its registration on the dbus before pkexec is forked.