### PR TITLE
Fixed bug with reloading the Policy Event Analysis Tool with a new file

### DIFF
--- a/fapolicy_analyzer/tests/reducers/test_ancillary_trust_reducer.py
+++ b/fapolicy_analyzer/tests/reducers/test_ancillary_trust_reducer.py
@@ -9,41 +9,50 @@ from ui.reducers.ancillary_trust_reducer import (
     handle_error_ancillary_trust,
     handle_error_deploying_ancillary_trust,
     handle_received_ancillary_trust,
+    handle_request_ancillary_trust,
 )
 
 
 @pytest.fixture()
 def initial_state():
-    return TrustState(error=None, trust=[], deployed=False)
+    return TrustState(error=None, trust=[], deployed=False, loading=False)
+
+
+def test_handle_request_ancillary_trust(initial_state):
+    result = handle_request_ancillary_trust(initial_state, MagicMock())
+    print(result)
+    assert result == TrustState(error=None, trust=[], deployed=False, loading=True)
 
 
 def test_handle_received_ancillary_trust(initial_state):
     result = handle_received_ancillary_trust(initial_state, MagicMock(payload=["foo"]))
-    assert result == TrustState(error=None, trust=["foo"], deployed=False)
+    assert result == TrustState(
+        error=None, trust=["foo"], deployed=False, loading=False
+    )
 
 
 def test_handle_error_ancillary_trust(initial_state):
     result = handle_error_ancillary_trust(initial_state, MagicMock(payload="foo"))
-    assert result == TrustState(error="foo", trust=[], deployed=False)
+    assert result == TrustState(error="foo", trust=[], deployed=False, loading=False)
 
 
 def test_handle_ancillary_trust_deployed(initial_state):
     result = handle_ancillary_trust_deployed(initial_state, MagicMock())
-    assert result == TrustState(error=None, trust=[], deployed=True)
+    assert result == TrustState(error=None, trust=[], deployed=True, loading=False)
 
 
 def test_handle_error_deploying_ancillary_trust(initial_state):
     result = handle_error_deploying_ancillary_trust(
         initial_state, MagicMock(payload="foo")
     )
-    assert result == TrustState(error="foo", trust=[], deployed=False)
+    assert result == TrustState(error="foo", trust=[], deployed=False, loading=False)
 
 
 def test_handle_add_changesets(initial_state):
     result = handle_add_changesets(initial_state, MagicMock())
-    assert result == TrustState(error=None, trust=[], deployed=False)
+    assert result == TrustState(error=None, trust=[], deployed=False, loading=False)
 
 
 def test_handle_clear_changesets(initial_state):
     result = handle_clear_changesets(initial_state, MagicMock())
-    assert result == TrustState(error=None, trust=[], deployed=True)
+    assert result == TrustState(error=None, trust=[], deployed=True, loading=False)

--- a/fapolicy_analyzer/tests/reducers/test_event_reducer.py
+++ b/fapolicy_analyzer/tests/reducers/test_event_reducer.py
@@ -5,19 +5,25 @@ from ui.reducers.event_reducer import (
     EventState,
     handle_error_events,
     handle_received_events,
+    handle_request_events,
 )
 
 
 @pytest.fixture()
 def initial_state():
-    return EventState(error=None, log=[])
+    return EventState(error=None, log=[], loading=False)
+
+
+def test_handle_request_events(initial_state):
+    result = handle_request_events(initial_state, MagicMock())
+    assert result == EventState(error=None, log=[], loading=True)
 
 
 def test_handle_received_events(initial_state):
     result = handle_received_events(initial_state, MagicMock(payload=["foo"]))
-    assert result == EventState(error=None, log=["foo"])
+    assert result == EventState(error=None, log=["foo"], loading=False)
 
 
 def test_handle_error_events(initial_state):
     result = handle_error_events(initial_state, MagicMock(payload="foo"))
-    assert result == EventState(error="foo", log=[])
+    assert result == EventState(error="foo", log=[], loading=False)

--- a/fapolicy_analyzer/tests/reducers/test_group_reducer.py
+++ b/fapolicy_analyzer/tests/reducers/test_group_reducer.py
@@ -5,19 +5,25 @@ from ui.reducers.group_reducer import (
     GroupState,
     handle_error_groups,
     handle_received_groups,
+    handle_request_groups,
 )
 
 
 @pytest.fixture()
 def initial_state():
-    return GroupState(error=None, groups=[])
+    return GroupState(error=None, groups=[], loading=False)
+
+
+def test_handle_request_groups(initial_state):
+    result = handle_request_groups(initial_state, MagicMock())
+    assert result == GroupState(error=None, groups=[], loading=True)
 
 
 def test_handle_received_groups(initial_state):
     result = handle_received_groups(initial_state, MagicMock(payload=["foo"]))
-    assert result == GroupState(error=None, groups=["foo"])
+    assert result == GroupState(error=None, groups=["foo"], loading=False)
 
 
 def test_handle_error_groups(initial_state):
     result = handle_error_groups(initial_state, MagicMock(payload="foo"))
-    assert result == GroupState(error="foo", groups=[])
+    assert result == GroupState(error="foo", groups=[], loading=False)

--- a/fapolicy_analyzer/tests/reducers/test_system_trust_reducer.py
+++ b/fapolicy_analyzer/tests/reducers/test_system_trust_reducer.py
@@ -5,19 +5,25 @@ from ui.reducers.system_trust_reducer import (
     TrustState,
     handle_error_system_trust,
     handle_received_system_trust,
+    handle_request_system_trust,
 )
 
 
 @pytest.fixture()
 def initial_state():
-    return TrustState(error=None, trust=[])
+    return TrustState(error=None, trust=[], loading=False)
+
+
+def test_handle_request_system_trust(initial_state):
+    result = handle_request_system_trust(initial_state, MagicMock())
+    assert result == TrustState(error=None, trust=[], loading=True)
 
 
 def test_handle_received_system_trust(initial_state):
     result = handle_received_system_trust(initial_state, MagicMock(payload=["foo"]))
-    assert result == TrustState(error=None, trust=["foo"])
+    assert result == TrustState(error=None, trust=["foo"], loading=False)
 
 
 def test_handle_error_system_trust(initial_state):
     result = handle_error_system_trust(initial_state, MagicMock(payload="foo"))
-    assert result == TrustState(error="foo", trust=[])
+    assert result == TrustState(error="foo", trust=[], loading=False)

--- a/fapolicy_analyzer/tests/reducers/test_user_reducer.py
+++ b/fapolicy_analyzer/tests/reducers/test_user_reducer.py
@@ -5,19 +5,25 @@ from ui.reducers.user_reducer import (
     UserState,
     handle_error_users,
     handle_received_users,
+    handle_request_users,
 )
 
 
 @pytest.fixture()
 def initial_state():
-    return UserState(error=None, users=[])
+    return UserState(error=None, users=[], loading=False)
+
+
+def test_handle_request_users(initial_state):
+    result = handle_request_users(initial_state, MagicMock())
+    assert result == UserState(error=None, users=[], loading=True)
 
 
 def test_handle_received_users(initial_state):
     result = handle_received_users(initial_state, MagicMock(payload=["foo"]))
-    assert result == UserState(error=None, users=["foo"])
+    assert result == UserState(error=None, users=["foo"], loading=False)
 
 
 def test_handle_error_users(initial_state):
     result = handle_error_users(initial_state, MagicMock(payload="foo"))
-    assert result == UserState(error="foo", users=[])
+    assert result == UserState(error="foo", users=[], loading=False)

--- a/fapolicy_analyzer/tests/test_ancillary_trust_database_admin.py
+++ b/fapolicy_analyzer/tests/test_ancillary_trust_database_admin.py
@@ -154,7 +154,9 @@ def test_on_deployment_w_exception(mock_dispatch, mocker):
     system_features_mock.on_next(
         {
             "changesets": [],
-            "ancillary_trust": MagicMock(trust=[mock_trust()], error=None),
+            "ancillary_trust": MagicMock(
+                trust=[mock_trust()], error=None, loading=False
+            ),
         }
     )
     widget.get_object("deployBtn").clicked()

--- a/fapolicy_analyzer/tests/test_policy_rules_admin_page.py
+++ b/fapolicy_analyzer/tests/test_policy_rules_admin_page.py
@@ -415,7 +415,9 @@ def test_clears_selection_when_switching_acl_tabs(widget, userListView, groupLis
 def test_event_loading_w_exception(mock_system_features, states, mock_dispatch):
     init_store(mock_System())
     PolicyRulesAdminPage(_mock_file)
-    mock_system_features.on_next({**states[0], **{"events": MagicMock(error="foo")}})
+    mock_system_features.on_next(
+        {**states[0], **{"events": MagicMock(error="foo", loading=False)}}
+    )
     mock_dispatch.assert_called_with(
         InstanceOf(Action)
         & Attrs(
@@ -428,7 +430,9 @@ def test_event_loading_w_exception(mock_system_features, states, mock_dispatch):
 def test_users_loading_w_exception(mock_system_features, states, mock_dispatch):
     init_store(mock_System())
     PolicyRulesAdminPage(_mock_file)
-    mock_system_features.on_next({**states[0], **{"users": MagicMock(error="foo")}})
+    mock_system_features.on_next(
+        {**states[0], **{"users": MagicMock(error="foo", loading=False)}}
+    )
     mock_dispatch.assert_called_with(
         InstanceOf(Action)
         & Attrs(
@@ -441,7 +445,9 @@ def test_users_loading_w_exception(mock_system_features, states, mock_dispatch):
 def test_groups_loading_w_exception(mock_system_features, states, mock_dispatch):
     init_store(mock_System())
     PolicyRulesAdminPage(_mock_file)
-    mock_system_features.on_next({**states[0], **{"groups": MagicMock(error="foo")}})
+    mock_system_features.on_next(
+        {**states[0], **{"groups": MagicMock(error="foo", loading=False)}}
+    )
     mock_dispatch.assert_called_with(
         InstanceOf(Action)
         & Attrs(

--- a/fapolicy_analyzer/tests/test_system_trust_database_admin.py
+++ b/fapolicy_analyzer/tests/test_system_trust_database_admin.py
@@ -95,7 +95,10 @@ def test_load_trust(mock_dispatch, mock_system_feature, mocker):
 
     mockTrust = [mock_trust()]
     mock_system_feature.on_next(
-        {"changesets": [], "system_trust": MagicMock(error=None, trust=mockTrust)}
+        {
+            "changesets": [],
+            "system_trust": MagicMock(error=None, trust=mockTrust, loading=False),
+        }
     )
     mockTrustListLoad.assert_called_with(mockTrust)
 

--- a/fapolicy_analyzer/ui/ancillary_trust_database_admin.py
+++ b/fapolicy_analyzer/ui/ancillary_trust_database_admin.py
@@ -200,7 +200,7 @@ SHA256: {fs.sha(trust.path)}"""
                 )
 
         # if not loading and the trust changes reload the view
-        if self._loading and self._trust != trustState.trust:
+        if self._loading and not trustState.loading and self._trust != trustState.trust:
             self._loading = False
             self._trust = trustState.trust
             self.trustFileList.load_trust(self._trust)

--- a/fapolicy_analyzer/ui/policy_rules_admin_page.py
+++ b/fapolicy_analyzer/ui/policy_rules_admin_page.py
@@ -226,7 +226,7 @@ class PolicyRulesAdminPage(UIWidget):
         groupState = system.get("groups")
         userState = system.get("users")
 
-        if eventsState.error and self._eventsLoading:
+        if eventsState.error and not eventsState.loading and self._eventsLoading:
             self._eventsLoading = False
             dispatch(
                 add_notification(
@@ -234,12 +234,16 @@ class PolicyRulesAdminPage(UIWidget):
                     NotificationType.ERROR,
                 )
             )
-        elif self._eventsLoading and self._log != eventsState.log:
+        elif (
+            self._eventsLoading
+            and not eventsState.loading
+            and self._log != eventsState.log
+        ):
             self._eventsLoading = False
             self._log = eventsState.log
             self.__populate_acls()
 
-        if userState.error and self._usersLoading:
+        if userState.error and not userState.loading and self._usersLoading:
             self._usersLoading = False
             dispatch(
                 add_notification(
@@ -247,12 +251,16 @@ class PolicyRulesAdminPage(UIWidget):
                     NotificationType.ERROR,
                 )
             )
-        elif self._usersLoading and self._users != userState.users:
+        elif (
+            self._usersLoading
+            and not userState.loading
+            and self._users != userState.users
+        ):
             self._usersLoading = False
             self._users = userState.users
             self.__populate_acls()
 
-        if groupState.error and self._groupsLoading:
+        if groupState.error and not groupState.loading and self._groupsLoading:
             self._groupsLoading = False
             dispatch(
                 add_notification(
@@ -260,7 +268,11 @@ class PolicyRulesAdminPage(UIWidget):
                     NotificationType.ERROR,
                 )
             )
-        elif self._groupsLoading and self._groups != groupState.groups:
+        elif (
+            self._groupsLoading
+            and not groupState.loading
+            and self._groups != groupState.groups
+        ):
             self._groupsLoading = False
             self._groups = groupState.groups
             self.__populate_acls()

--- a/fapolicy_analyzer/ui/reducers/ancillary_trust_reducer.py
+++ b/fapolicy_analyzer/ui/reducers/ancillary_trust_reducer.py
@@ -8,11 +8,13 @@ from fapolicy_analyzer.ui.actions import (
     ANCILLARY_TRUST_DEPLOYED,
     ADD_CHANGESETS,
     CLEAR_CHANGESETS,
+    REQUEST_ANCILLARY_TRUST,
 )
 
 
 class TrustState(NamedTuple):
     error: str
+    loading: bool
     trust: Sequence[Trust]
     deployed: bool
 
@@ -21,14 +23,18 @@ def _create_state(state: TrustState, **kwargs: Optional[Any]) -> TrustState:
     return TrustState(**{**state._asdict(), **kwargs})
 
 
+def handle_request_ancillary_trust(state: TrustState, action: Action) -> TrustState:
+    return _create_state(state, loading=True, error=None)
+
+
 def handle_received_ancillary_trust(state: TrustState, action: Action) -> TrustState:
     payload = cast(Sequence[Trust], action.payload)
-    return _create_state(state, trust=payload, error=None)
+    return _create_state(state, trust=payload, error=None, loading=False)
 
 
 def handle_error_ancillary_trust(state: TrustState, action: Action) -> TrustState:
     payload = cast(str, action.payload)
-    return _create_state(state, error=payload)
+    return _create_state(state, error=payload, loading=False)
 
 
 def handle_ancillary_trust_deployed(state: TrustState, action: Action) -> TrustState:
@@ -52,6 +58,7 @@ def handle_clear_changesets(state: TrustState, action: Action) -> TrustState:
 
 ancillary_trust_reducer: Reducer = handle_actions(
     {
+        REQUEST_ANCILLARY_TRUST: handle_request_ancillary_trust,
         RECEIVED_ANCILLARY_TRUST: handle_received_ancillary_trust,
         ERROR_ANCILLARY_TRUST: handle_error_ancillary_trust,
         ANCILLARY_TRUST_DEPLOYED: handle_ancillary_trust_deployed,
@@ -59,5 +66,5 @@ ancillary_trust_reducer: Reducer = handle_actions(
         ADD_CHANGESETS: handle_add_changesets,
         CLEAR_CHANGESETS: handle_clear_changesets,
     },
-    TrustState(error=None, trust=[], deployed=True),
+    TrustState(error=None, trust=[], deployed=True, loading=False),
 )

--- a/fapolicy_analyzer/ui/reducers/event_reducer.py
+++ b/fapolicy_analyzer/ui/reducers/event_reducer.py
@@ -1,6 +1,7 @@
 from fapolicy_analyzer.ui.actions import (
     ERROR_EVENTS,
     RECEIVED_EVENTS,
+    REQUEST_EVENTS,
 )
 from fapolicy_analyzer import EventLog
 from redux import Action, Reducer, handle_actions
@@ -9,6 +10,7 @@ from typing import Any, NamedTuple, Optional, Sequence, cast
 
 class EventState(NamedTuple):
     error: str
+    loading: bool
     log: Sequence[EventLog]
 
 
@@ -16,20 +18,25 @@ def _create_state(state: EventState, **kwargs: Optional[Any]) -> EventState:
     return EventState(**{**state._asdict(), **kwargs})
 
 
+def handle_request_events(state: EventState, action: Action) -> EventState:
+    return _create_state(state, loading=True, error=None)
+
+
 def handle_received_events(state: EventState, action: Action) -> EventState:
     payload = cast(Sequence[EventLog], action.payload)
-    return _create_state(state, log=payload, error=None)
+    return _create_state(state, log=payload, error=None, loading=False)
 
 
 def handle_error_events(state: EventState, action: Action) -> EventState:
     payload = cast(str, action.payload)
-    return _create_state(state, error=payload)
+    return _create_state(state, error=payload, loading=False)
 
 
 event_reducer: Reducer = handle_actions(
     {
+        REQUEST_EVENTS: handle_request_events,
         RECEIVED_EVENTS: handle_received_events,
         ERROR_EVENTS: handle_error_events,
     },
-    EventState(error=None, log=None),
+    EventState(error=None, log=None, loading=False),
 )

--- a/fapolicy_analyzer/ui/reducers/group_reducer.py
+++ b/fapolicy_analyzer/ui/reducers/group_reducer.py
@@ -1,4 +1,4 @@
-from fapolicy_analyzer.ui.actions import ERROR_GROUPS, RECEIVED_GROUPS
+from fapolicy_analyzer.ui.actions import ERROR_GROUPS, RECEIVED_GROUPS, REQUEST_GROUPS
 from fapolicy_analyzer import Group
 from redux import Action, Reducer, handle_actions
 from typing import Any, NamedTuple, Optional, Sequence, cast
@@ -6,6 +6,7 @@ from typing import Any, NamedTuple, Optional, Sequence, cast
 
 class GroupState(NamedTuple):
     error: str
+    loading: bool
     groups: Sequence[Group]
 
 
@@ -13,20 +14,25 @@ def _create_state(state: GroupState, **kwargs: Optional[Any]) -> GroupState:
     return GroupState(**{**state._asdict(), **kwargs})
 
 
+def handle_request_groups(state: GroupState, action: Action) -> GroupState:
+    return _create_state(state, loading=True, error=None)
+
+
 def handle_received_groups(state: GroupState, action: Action) -> GroupState:
     payload = cast(Sequence[Group], action.payload)
-    return _create_state(state, groups=payload, error=None)
+    return _create_state(state, groups=payload, error=None, loading=False)
 
 
 def handle_error_groups(state: GroupState, action: Action) -> GroupState:
     payload = cast(str, action.payload)
-    return _create_state(state, error=payload)
+    return _create_state(state, error=payload, loading=False)
 
 
 group_reducer: Reducer = handle_actions(
     {
+        REQUEST_GROUPS: handle_request_groups,
         RECEIVED_GROUPS: handle_received_groups,
         ERROR_GROUPS: handle_error_groups,
     },
-    GroupState(error=None, groups=[]),
+    GroupState(error=None, groups=[], loading=False),
 )

--- a/fapolicy_analyzer/ui/reducers/system_trust_reducer.py
+++ b/fapolicy_analyzer/ui/reducers/system_trust_reducer.py
@@ -4,11 +4,13 @@ from typing import Any, NamedTuple, Optional, Sequence, cast
 from fapolicy_analyzer.ui.actions import (
     RECEIVED_SYSTEM_TRUST,
     ERROR_SYSTEM_TRUST,
+    REQUEST_SYSTEM_TRUST,
 )
 
 
 class TrustState(NamedTuple):
     error: str
+    loading: bool
     trust: Sequence[Trust]
 
 
@@ -16,20 +18,25 @@ def _create_state(state: TrustState, **kwargs: Optional[Any]) -> TrustState:
     return TrustState(**{**state._asdict(), **kwargs})
 
 
+def handle_request_system_trust(state: TrustState, action: Action) -> TrustState:
+    return _create_state(state, loading=True, error=None)
+
+
 def handle_received_system_trust(state: TrustState, action: Action) -> TrustState:
     payload = cast(Sequence[Trust], action.payload)
-    return _create_state(state, trust=payload, error=None)
+    return _create_state(state, trust=payload, error=None, loading=False)
 
 
 def handle_error_system_trust(state: TrustState, action: Action) -> TrustState:
     payload = cast(str, action.payload)
-    return _create_state(state, error=payload)
+    return _create_state(state, error=payload, loading=False)
 
 
 system_trust_reducer: Reducer = handle_actions(
     {
+        REQUEST_SYSTEM_TRUST: handle_request_system_trust,
         RECEIVED_SYSTEM_TRUST: handle_received_system_trust,
         ERROR_SYSTEM_TRUST: handle_error_system_trust,
     },
-    TrustState(error=None, trust=[]),
+    TrustState(error=None, trust=[], loading=False),
 )

--- a/fapolicy_analyzer/ui/reducers/user_reducer.py
+++ b/fapolicy_analyzer/ui/reducers/user_reducer.py
@@ -1,6 +1,7 @@
 from fapolicy_analyzer.ui.actions import (
     ERROR_USERS,
     RECEIVED_USERS,
+    REQUEST_USERS,
 )
 from fapolicy_analyzer import User
 from redux import Action, Reducer, handle_actions
@@ -9,6 +10,7 @@ from typing import Any, NamedTuple, Optional, Sequence, cast
 
 class UserState(NamedTuple):
     error: str
+    loading: bool
     users: Sequence[User]
 
 
@@ -16,20 +18,25 @@ def _create_state(state: UserState, **kwargs: Optional[Any]) -> UserState:
     return UserState(**{**state._asdict(), **kwargs})
 
 
+def handle_request_users(state: UserState, action: Action) -> UserState:
+    return _create_state(state, loading=True, error=None)
+
+
 def handle_received_users(state: UserState, action: Action) -> UserState:
     payload = cast(Sequence[User], action.payload)
-    return _create_state(state, users=payload, error=None)
+    return _create_state(state, users=payload, error=None, loading=False)
 
 
 def handle_error_users(state: UserState, action: Action) -> UserState:
     payload = cast(str, action.payload)
-    return _create_state(state, error=payload)
+    return _create_state(state, error=payload, loading=False)
 
 
 user_reducer: Reducer = handle_actions(
     {
+        REQUEST_USERS: handle_request_users,
         RECEIVED_USERS: handle_received_users,
         ERROR_USERS: handle_error_users,
     },
-    UserState(error=None, users=[]),
+    UserState(error=None, users=[], loading=False),
 )

--- a/fapolicy_analyzer/ui/system_trust_database_admin.py
+++ b/fapolicy_analyzer/ui/system_trust_database_admin.py
@@ -56,7 +56,7 @@ class SystemTrustDatabaseAdmin(UIWidget, Events):
     def on_next_system(self, system):
         trustState = system.get("system_trust")
 
-        if self._error != trustState.error:
+        if not trustState.loading and self._error != trustState.error:
             self._error = trustState.error
             self._loading = False
             logging.error("%s: %s", strings.SYSTEM_TRUST_LOAD_ERROR, self._error)
@@ -65,7 +65,9 @@ class SystemTrustDatabaseAdmin(UIWidget, Events):
                     strings.SYSTEM_TRUST_LOAD_ERROR, NotificationType.ERROR
                 )
             )
-        elif self._loading and self._trust != trustState.trust:
+        elif (
+            self._loading and not trustState.loading and self._trust != trustState.trust
+        ):
             self._error = None
             self._loading = False
             self._trust = trustState.trust


### PR DESCRIPTION
I had to add a 'loading' value to the assorted states that are populated via redux so the value can be checked during the system feature events.

**To Test:**
1. goto Action->Analyze from Audit Log
2. select an event file to load
3. without navigating way from the tool, goto Action->Analyze from Audit Log again
4. select a different event file to load
5. verify the tool is update with the correct data from the new file

NOTE: you might see some errors and warning in the console, but the tool should still load and reload properly.  I believe these errors are related to #319

closes #315 