### PR TITLE
Implemented widget reference cleanup

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -22,6 +22,7 @@ flake8-i18n = "*"
 callee = "*"
 pytest-lazy-fixture = "*"
 flake8-quotes = "*"
+autoflake = "*"
 
 [packages]
 pycairo = "1.20.0"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "6459fbdafb696a9df9362173f54570e6c97e8c2bdc9db342236c591d2ace20cb"
+            "sha256": "e03f57591887611c49cc41d2ffb482c81d64cce8772e373b784b3ffd7052f67d"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -81,6 +81,13 @@
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
             "version": "==21.2.0"
         },
+        "autoflake": {
+            "hashes": [
+                "sha256:61a353012cff6ab94ca062823d1fb2f692c4acda51c76ff83a8d77915fba51ea"
+            ],
+            "index": "pypi",
+            "version": "==1.4"
+        },
         "babel": {
             "hashes": [
                 "sha256:ab49e12b91d937cd11f0b67cb259a57ab4ad2b59ac7a3b41d6c06c0ac5b0def9",
@@ -98,11 +105,11 @@
         },
         "black": {
             "hashes": [
-                "sha256:380f1b5da05e5a1429225676655dddb96f5ae8c75bdf91e53d798871b902a115",
-                "sha256:7de4cfc7eb6b710de325712d40125689101d21d25283eed7e9998722cf10eb91"
+                "sha256:0b1f66cbfadcd332ceeaeecf6373d9991d451868d2e2219ad0ac1213fb701117",
+                "sha256:83f3852301c8dcb229e9c444dd79f573c8d31c7c2dad9bbaaa94c808630e32aa"
             ],
             "index": "pypi",
-            "version": "==21.9b0"
+            "version": "==21.11b0"
         },
         "callee": {
             "hashes": [
@@ -132,42 +139,64 @@
                 "toml"
             ],
             "hashes": [
-                "sha256:04560539c19ec26995ecfb3d9307ff154fbb9a172cb57e3b3cfc4ced673103d1",
-                "sha256:1549e1d08ce38259de2bc3e9a0d5f3642ff4a8f500ffc1b2df73fd621a6cdfc0",
-                "sha256:1db67c497688fd4ba85b373b37cc52c50d437fd7267520ecd77bddbd89ea22c9",
-                "sha256:30922626ce6f7a5a30bdba984ad21021529d3d05a68b4f71ea3b16bda35b8895",
-                "sha256:36e9040a43d2017f2787b28d365a4bb33fcd792c7ff46a047a04094dc0e2a30d",
-                "sha256:381d773d896cc7f8ba4ff3b92dee4ed740fb88dfe33b6e42efc5e8ab6dfa1cfe",
-                "sha256:3bbda1b550e70fa6ac40533d3f23acd4f4e9cb4e6e77251ce77fdf41b3309fb2",
-                "sha256:3be1206dc09fb6298de3fce70593e27436862331a85daee36270b6d0e1c251c4",
-                "sha256:424c44f65e8be58b54e2b0bd1515e434b940679624b1b72726147cfc6a9fc7ce",
-                "sha256:4b34ae4f51bbfa5f96b758b55a163d502be3dcb24f505d0227858c2b3f94f5b9",
-                "sha256:4e28d2a195c533b58fc94a12826f4431726d8eb029ac21d874345f943530c122",
-                "sha256:53a294dc53cfb39c74758edaa6305193fb4258a30b1f6af24b360a6c8bd0ffa7",
-                "sha256:60e51a3dd55540bec686d7fff61b05048ca31e804c1f32cbb44533e6372d9cc3",
-                "sha256:61b598cbdbaae22d9e34e3f675997194342f866bb1d781da5d0be54783dce1ff",
-                "sha256:6807947a09510dc31fa86f43595bf3a14017cd60bf633cc746d52141bfa6b149",
-                "sha256:6a6a9409223a27d5ef3cca57dd7cd4dfcb64aadf2fad5c3b787830ac9223e01a",
-                "sha256:7092eab374346121805fb637572483270324407bf150c30a3b161fc0c4ca5164",
-                "sha256:77b1da5767ed2f44611bc9bc019bc93c03fa495728ec389759b6e9e5039ac6b1",
-                "sha256:8251b37be1f2cd9c0e5ccd9ae0380909c24d2a5ed2162a41fcdbafaf59a85ebd",
-                "sha256:9f1627e162e3864a596486774876415a7410021f4b67fd2d9efdf93ade681afc",
-                "sha256:a1b73c7c4d2a42b9d37dd43199c5711d91424ff3c6c22681bc132db4a4afec6f",
-                "sha256:a82d79586a0a4f5fd1cf153e647464ced402938fbccb3ffc358c7babd4da1dd9",
-                "sha256:abbff240f77347d17306d3201e14431519bf64495648ca5a49571f988f88dee9",
-                "sha256:ad9b8c1206ae41d46ec7380b78ba735ebb77758a650643e841dd3894966c31d0",
-                "sha256:bbffde2a68398682623d9dd8c0ca3f46fda074709b26fcf08ae7a4c431a6ab2d",
-                "sha256:bcae10fccb27ca2a5f456bf64d84110a5a74144be3136a5e598f9d9fb48c0caa",
-                "sha256:c9cd3828bbe1a40070c11fe16a51df733fd2f0cb0d745fb83b7b5c1f05967df7",
-                "sha256:cd1cf1deb3d5544bd942356364a2fdc8959bad2b6cf6eb17f47d301ea34ae822",
-                "sha256:d036dc1ed8e1388e995833c62325df3f996675779541f682677efc6af71e96cc",
-                "sha256:db42baa892cba723326284490283a68d4de516bfb5aaba369b4e3b2787a778b7",
-                "sha256:e4fb7ced4d9dec77d6cf533acfbf8e1415fe799430366affb18d69ee8a3c6330",
-                "sha256:e7a0b42db2a47ecb488cde14e0f6c7679a2c5a9f44814393b162ff6397fcdfbb",
-                "sha256:f2f184bf38e74f152eed7f87e345b51f3ab0b703842f447c22efe35e59942c24"
+                "sha256:046647b96969fda1ae0605f61288635209dd69dcd27ba3ec0bf5148bc157f954",
+                "sha256:06d009e8a29483cbc0520665bc46035ffe9ae0e7484a49f9782c2a716e37d0a0",
+                "sha256:0cde7d9fe2fb55ff68ebe7fb319ef188e9b88e0a3d1c9c5db7dd829cd93d2193",
+                "sha256:1de9c6f5039ee2b1860b7bad2c7bc3651fbeb9368e4c4d93e98a76358cdcb052",
+                "sha256:24ed38ec86754c4d5a706fbd5b52b057c3df87901a8610d7e5642a08ec07087e",
+                "sha256:27a3df08a855522dfef8b8635f58bab81341b2fb5f447819bc252da3aa4cf44c",
+                "sha256:310c40bed6b626fd1f463e5a83dba19a61c4eb74e1ac0d07d454ebbdf9047e9d",
+                "sha256:3348865798c077c695cae00da0924136bb5cc501f236cfd6b6d9f7a3c94e0ec4",
+                "sha256:35b246ae3a2c042dc8f410c94bcb9754b18179cdb81ff9477a9089dbc9ecc186",
+                "sha256:3f546f48d5d80a90a266769aa613bc0719cb3e9c2ef3529d53f463996dd15a9d",
+                "sha256:586d38dfc7da4a87f5816b203ff06dd7c1bb5b16211ccaa0e9788a8da2b93696",
+                "sha256:5d3855d5d26292539861f5ced2ed042fc2aa33a12f80e487053aed3bcb6ced13",
+                "sha256:610c0ba11da8de3a753dc4b1f71894f9f9debfdde6559599f303286e70aeb0c2",
+                "sha256:62646d98cf0381ffda301a816d6ac6c35fc97aa81b09c4c52d66a15c4bef9d7c",
+                "sha256:66af99c7f7b64d050d37e795baadf515b4561124f25aae6e1baa482438ecc388",
+                "sha256:675adb3b3380967806b3cbb9c5b00ceb29b1c472692100a338730c1d3e59c8b9",
+                "sha256:6e5a8c947a2a89c56655ecbb789458a3a8e3b0cbf4c04250331df8f647b3de59",
+                "sha256:7a39590d1e6acf6a3c435c5d233f72f5d43b585f5be834cff1f21fec4afda225",
+                "sha256:80cb70264e9a1d04b519cdba3cd0dc42847bf8e982a4d55c769b9b0ee7cdce1e",
+                "sha256:82fdcb64bf08aa5db881db061d96db102c77397a570fbc112e21c48a4d9cb31b",
+                "sha256:8492d37acdc07a6eac6489f6c1954026f2260a85a4c2bb1e343fe3d35f5ee21a",
+                "sha256:94f558f8555e79c48c422045f252ef41eb43becdd945e9c775b45ebfc0cbd78f",
+                "sha256:958ac66272ff20e63d818627216e3d7412fdf68a2d25787b89a5c6f1eb7fdd93",
+                "sha256:95a58336aa111af54baa451c33266a8774780242cab3704b7698d5e514840758",
+                "sha256:96129e41405887a53a9cc564f960d7f853cc63d178f3a182fdd302e4cab2745b",
+                "sha256:97ef6e9119bd39d60ef7b9cd5deea2b34869c9f0b9777450a7e3759c1ab09b9b",
+                "sha256:98d44a8136eebbf544ad91fef5bd2b20ef0c9b459c65a833c923d9aa4546b204",
+                "sha256:9d2c2e3ce7b8cc932a2f918186964bd44de8c84e2f9ef72dc616f5bb8be22e71",
+                "sha256:a300b39c3d5905686c75a369d2a66e68fd01472ea42e16b38c948bd02b29e5bd",
+                "sha256:a34fccb45f7b2d890183a263578d60a392a1a218fdc12f5bce1477a6a68d4373",
+                "sha256:a4d48e42e17d3de212f9af44f81ab73b9378a4b2b8413fd708d0d9023f2bbde4",
+                "sha256:af45eea024c0e3a25462fade161afab4f0d9d9e0d5a5d53e86149f74f0a35ecc",
+                "sha256:ba6125d4e55c0b8e913dad27b22722eac7abdcb1f3eab1bd090eee9105660266",
+                "sha256:bc1ee1318f703bc6c971da700d74466e9b86e0c443eb85983fb2a1bd20447263",
+                "sha256:c18725f3cffe96732ef96f3de1939d81215fd6d7d64900dcc4acfe514ea4fcbf",
+                "sha256:c8e9c4bcaaaa932be581b3d8b88b677489975f845f7714efc8cce77568b6711c",
+                "sha256:cc799916b618ec9fd00135e576424165691fec4f70d7dc12cfaef09268a2478c",
+                "sha256:cd2d11a59afa5001ff28073ceca24ae4c506da4355aba30d1e7dd2bd0d2206dc",
+                "sha256:d0a595a781f8e186580ff8e3352dd4953b1944289bec7705377c80c7e36c4d6c",
+                "sha256:d3c5f49ce6af61154060640ad3b3281dbc46e2e0ef2fe78414d7f8a324f0b649",
+                "sha256:d9a635114b88c0ab462e0355472d00a180a5fbfd8511e7f18e4ac32652e7d972",
+                "sha256:e5432d9c329b11c27be45ee5f62cf20a33065d482c8dec1941d6670622a6fb8f",
+                "sha256:eab14fdd410500dae50fd14ccc332e65543e7b39f6fc076fe90603a0e5d2f929",
+                "sha256:ebcc03e1acef4ff44f37f3c61df478d6e469a573aa688e5a162f85d7e4c3860d",
+                "sha256:fae3fe111670e51f1ebbc475823899524e3459ea2db2cb88279bbfb2a0b8a3de",
+                "sha256:fd92ece726055e80d4e3f01fff3b91f54b18c9c357c48fcf6119e87e2461a091",
+                "sha256:ffa545230ca2ad921ad066bf8fd627e7be43716b6e0fcf8e32af1b8188ccb0ab"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==6.0.2"
+            "version": "==6.1.2"
+        },
+        "dataclasses": {
+            "hashes": [
+                "sha256:0201d89fa866f68c8ebd9d08ee6ff50c0b255f8ec63a71c16fda7af82bb887bf",
+                "sha256:8479067f342acf957dc82ec415d355ab5edb7e7646b90dc6e2fd1d96ad084c97"
+            ],
+            "markers": "python_version < '3.7'",
+            "version": "==0.8"
         },
         "docopt": {
             "hashes": [
@@ -192,10 +221,18 @@
         },
         "flake8-quotes": {
             "hashes": [
-                "sha256:f1dd87830ed77ff2ce47fc0ee0fd87ae20e8f045355354ffbf4dcaa18d528217"
+                "sha256:633adca6fb8a08131536af0d750b44d6985b9aba46f498871e21588c3e6f525a"
             ],
             "index": "pypi",
-            "version": "==3.3.0"
+            "version": "==3.3.1"
+        },
+        "importlib-metadata": {
+            "hashes": [
+                "sha256:057e92c15bc8d9e8109738a48db0ccb31b4d9d5cfbee5a8670879a30be66304b",
+                "sha256:b7e52a1f8dec14a75ea73e0891f3060099ca1d8e6a462a4dff11c3e119ea1b31"
+            ],
+            "markers": "python_version < '3.8'",
+            "version": "==4.2.0"
         },
         "iniconfig": {
             "hashes": [
@@ -220,11 +257,11 @@
         },
         "packaging": {
             "hashes": [
-                "sha256:7dc96269f53a4ccec5c0670940a4281106dd0bb343f47b7471f779df49c2fbe7",
-                "sha256:c86254f9220d55e31cc94d69bade760f0847da8000def4dfe1c6b872fd14ff14"
+                "sha256:096d689d78ca690e4cd8a89568ba06d07ca097e3306a4381635073ca91479966",
+                "sha256:14317396d1e8cdb122989b916fa2c7e9ca8e2be9e8060a6eff75b6b7b4d8a7e0"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==21.0"
+            "version": "==21.2"
         },
         "pathspec": {
             "hashes": [
@@ -251,11 +288,11 @@
         },
         "py": {
             "hashes": [
-                "sha256:21b81bda15b66ef5e1a777a21c4dcd9c20ad3efd0b3f817e7a809035269e1bd3",
-                "sha256:3b80836aa6d1feeaa108e046da6423ab8f6ceda6468545ae8d02d9d58d18818a"
+                "sha256:51c75c4126074b472f746a24399ad32f6053d1b34b68d2fa41e558e6f4a98719",
+                "sha256:607c53218732647dff4acdfcd50cb62615cedf612e72d1724fb1a0cc6405b378"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==1.10.0"
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
+            "version": "==1.11.0"
         },
         "pycodestyle": {
             "hashes": [
@@ -315,10 +352,10 @@
         },
         "pytest-testmon": {
             "hashes": [
-                "sha256:2c61ae6185ea7dc07ea0d4db3984be62f1a176a5c16615fd208c5945aa411599"
+                "sha256:e69d5aeac4e371986f94e8ad06e56d70633870d026f2306fca44051f02fcb688"
             ],
             "index": "pypi",
-            "version": "==1.2.0"
+            "version": "==1.2.2"
         },
         "pytest-watch": {
             "hashes": [
@@ -336,55 +373,57 @@
         },
         "regex": {
             "hashes": [
-                "sha256:094a905e87a4171508c2a0e10217795f83c636ccc05ddf86e7272c26e14056ae",
-                "sha256:09e1031e2059abd91177c302da392a7b6859ceda038be9e015b522a182c89e4f",
-                "sha256:176796cb7f82a7098b0c436d6daac82f57b9101bb17b8e8119c36eecf06a60a3",
-                "sha256:19b8f6d23b2dc93e8e1e7e288d3010e58fafed323474cf7f27ab9451635136d9",
-                "sha256:1abbd95cbe9e2467cac65c77b6abd9223df717c7ae91a628502de67c73bf6838",
-                "sha256:1ce02f420a7ec3b2480fe6746d756530f69769292eca363218c2291d0b116a01",
-                "sha256:1f51926db492440e66c89cd2be042f2396cf91e5b05383acd7372b8cb7da373f",
-                "sha256:26895d7c9bbda5c52b3635ce5991caa90fbb1ddfac9c9ff1c7ce505e2282fb2a",
-                "sha256:2efd47704bbb016136fe34dfb74c805b1ef5c7313aef3ce6dcb5ff844299f432",
-                "sha256:36c98b013273e9da5790ff6002ab326e3f81072b4616fd95f06c8fa733d2745f",
-                "sha256:39079ebf54156be6e6902f5c70c078f453350616cfe7bfd2dd15bdb3eac20ccc",
-                "sha256:3d52c5e089edbdb6083391faffbe70329b804652a53c2fdca3533e99ab0580d9",
-                "sha256:45cb0f7ff782ef51bc79e227a87e4e8f24bc68192f8de4f18aae60b1d60bc152",
-                "sha256:4786dae85c1f0624ac77cb3813ed99267c9adb72e59fdc7297e1cf4d6036d493",
-                "sha256:51feefd58ac38eb91a21921b047da8644155e5678e9066af7bcb30ee0dca7361",
-                "sha256:55ef044899706c10bc0aa052f2fc2e58551e2510694d6aae13f37c50f3f6ff61",
-                "sha256:5e5796d2f36d3c48875514c5cd9e4325a1ca172fc6c78b469faa8ddd3d770593",
-                "sha256:5f199419a81c1016e0560c39773c12f0bd924c37715bffc64b97140d2c314354",
-                "sha256:5f55c4804797ef7381518e683249310f7f9646da271b71cb6b3552416c7894ee",
-                "sha256:6dcf53d35850ce938b4f044a43b33015ebde292840cef3af2c8eb4c860730fff",
-                "sha256:74e55f8d66f1b41d44bc44c891bcf2c7fad252f8f323ee86fba99d71fd1ad5e3",
-                "sha256:7f125fce0a0ae4fd5c3388d369d7a7d78f185f904c90dd235f7ecf8fe13fa741",
-                "sha256:82cfb97a36b1a53de32b642482c6c46b6ce80803854445e19bc49993655ebf3b",
-                "sha256:88dc3c1acd3f0ecfde5f95c32fcb9beda709dbdf5012acdcf66acbc4794468eb",
-                "sha256:924079d5590979c0e961681507eb1773a142553564ccae18d36f1de7324e71ca",
-                "sha256:951be934dc25d8779d92b530e922de44dda3c82a509cdb5d619f3a0b1491fafa",
-                "sha256:973499dac63625a5ef9dfa4c791aa33a502ddb7615d992bdc89cf2cc2285daa3",
-                "sha256:981c786293a3115bc14c103086ae54e5ee50ca57f4c02ce7cf1b60318d1e8072",
-                "sha256:9c070d5895ac6aeb665bd3cd79f673775caf8d33a0b569e98ac434617ecea57d",
-                "sha256:9e3e2cea8f1993f476a6833ef157f5d9e8c75a59a8d8b0395a9a6887a097243b",
-                "sha256:9e527ab1c4c7cf2643d93406c04e1d289a9d12966529381ce8163c4d2abe4faf",
-                "sha256:a37305eb3199d8f0d8125ec2fb143ba94ff6d6d92554c4b8d4a8435795a6eccd",
-                "sha256:aa0ab3530a279a3b7f50f852f1bab41bc304f098350b03e30a3876b7dd89840e",
-                "sha256:b04e512eb628ea82ed86eb31c0f7fc6842b46bf2601b66b1356a7008327f7700",
-                "sha256:b09d3904bf312d11308d9a2867427479d277365b1617e48ad09696fa7dfcdf59",
-                "sha256:b0f2f874c6a157c91708ac352470cb3bef8e8814f5325e3c5c7a0533064c6a24",
-                "sha256:b8b6ee6555b6fbae578f1468b3f685cdfe7940a65675611365a7ea1f8d724991",
-                "sha256:b9b5c215f3870aa9b011c00daeb7be7e1ae4ecd628e9beb6d7e6107e07d81287",
-                "sha256:c6569ba7b948c3d61d27f04e2b08ebee24fec9ff8e9ea154d8d1e975b175bfa7",
-                "sha256:e2ec1c106d3f754444abf63b31e5c4f9b5d272272a491fa4320475aba9e8157c",
-                "sha256:e4204708fa116dd03436a337e8e84261bc8051d058221ec63535c9403a1582a1",
-                "sha256:ea8de658d7db5987b11097445f2b1f134400e2232cb40e614e5f7b6f5428710e",
-                "sha256:f540f153c4f5617bc4ba6433534f8916d96366a08797cbbe4132c37b70403e92",
-                "sha256:fab3ab8aedfb443abb36729410403f0fe7f60ad860c19a979d47fb3eb98ef820",
-                "sha256:fb2baff66b7d2267e07ef71e17d01283b55b3cc51a81b54cc385e721ae172ba4",
-                "sha256:fe6ce4f3d3c48f9f402da1ceb571548133d3322003ce01b20d960a82251695d2",
-                "sha256:ff24897f6b2001c38a805d53b6ae72267025878d35ea225aa24675fbff2dba7f"
+                "sha256:05b7d6d7e64efe309972adab77fc2af8907bb93217ec60aa9fe12a0dad35874f",
+                "sha256:0617383e2fe465732af4509e61648b77cbe3aee68b6ac8c0b6fe934db90be5cc",
+                "sha256:07856afef5ffcc052e7eccf3213317fbb94e4a5cd8177a2caa69c980657b3cb4",
+                "sha256:162abfd74e88001d20cb73ceaffbfe601469923e875caf9118333b1a4aaafdc4",
+                "sha256:2207ae4f64ad3af399e2d30dde66f0b36ae5c3129b52885f1bffc2f05ec505c8",
+                "sha256:30ab804ea73972049b7a2a5c62d97687d69b5a60a67adca07eb73a0ddbc9e29f",
+                "sha256:3b5df18db1fccd66de15aa59c41e4f853b5df7550723d26aa6cb7f40e5d9da5a",
+                "sha256:3c5fb32cc6077abad3bbf0323067636d93307c9fa93e072771cf9a64d1c0f3ef",
+                "sha256:416c5f1a188c91e3eb41e9c8787288e707f7d2ebe66e0a6563af280d9b68478f",
+                "sha256:432bd15d40ed835a51617521d60d0125867f7b88acf653e4ed994a1f8e4995dc",
+                "sha256:4aaa4e0705ef2b73dd8e36eeb4c868f80f8393f5f4d855e94025ce7ad8525f50",
+                "sha256:537ca6a3586931b16a85ac38c08cc48f10fc870a5b25e51794c74df843e9966d",
+                "sha256:53db2c6be8a2710b359bfd3d3aa17ba38f8aa72a82309a12ae99d3c0c3dcd74d",
+                "sha256:5537f71b6d646f7f5f340562ec4c77b6e1c915f8baae822ea0b7e46c1f09b733",
+                "sha256:6650f16365f1924d6014d2ea770bde8555b4a39dc9576abb95e3cd1ff0263b36",
+                "sha256:666abff54e474d28ff42756d94544cdfd42e2ee97065857413b72e8a2d6a6345",
+                "sha256:68a067c11463de2a37157930d8b153005085e42bcb7ad9ca562d77ba7d1404e0",
+                "sha256:780b48456a0f0ba4d390e8b5f7c661fdd218934388cde1a974010a965e200e12",
+                "sha256:788aef3549f1924d5c38263104dae7395bf020a42776d5ec5ea2b0d3d85d6646",
+                "sha256:7ee1227cf08b6716c85504aebc49ac827eb88fcc6e51564f010f11a406c0a667",
+                "sha256:7f301b11b9d214f83ddaf689181051e7f48905568b0c7017c04c06dfd065e244",
+                "sha256:83ee89483672b11f8952b158640d0c0ff02dc43d9cb1b70c1564b49abe92ce29",
+                "sha256:85bfa6a5413be0ee6c5c4a663668a2cad2cbecdee367630d097d7823041bdeec",
+                "sha256:9345b6f7ee578bad8e475129ed40123d265464c4cfead6c261fd60fc9de00bcf",
+                "sha256:93a5051fcf5fad72de73b96f07d30bc29665697fb8ecdfbc474f3452c78adcf4",
+                "sha256:962b9a917dd7ceacbe5cd424556914cb0d636001e393b43dc886ba31d2a1e449",
+                "sha256:98ba568e8ae26beb726aeea2273053c717641933836568c2a0278a84987b2a1a",
+                "sha256:a3feefd5e95871872673b08636f96b61ebef62971eab044f5124fb4dea39919d",
+                "sha256:b43c2b8a330a490daaef5a47ab114935002b13b3f9dc5da56d5322ff218eeadb",
+                "sha256:b483c9d00a565633c87abd0aaf27eb5016de23fed952e054ecc19ce32f6a9e7e",
+                "sha256:ba05430e819e58544e840a68b03b28b6d328aff2e41579037e8bab7653b37d83",
+                "sha256:ca5f18a75e1256ce07494e245cdb146f5a9267d3c702ebf9b65c7f8bd843431e",
+                "sha256:d5ca078bb666c4a9d1287a379fe617a6dccd18c3e8a7e6c7e1eb8974330c626a",
+                "sha256:da1a90c1ddb7531b1d5ff1e171b4ee61f6345119be7351104b67ff413843fe94",
+                "sha256:dba70f30fd81f8ce6d32ddeef37d91c8948e5d5a4c63242d16a2b2df8143aafc",
+                "sha256:dd33eb9bdcfbabab3459c9ee651d94c842bc8a05fabc95edf4ee0c15a072495e",
+                "sha256:e0538c43565ee6e703d3a7c3bdfe4037a5209250e8502c98f20fea6f5fdf2965",
+                "sha256:e1f54b9b4b6c53369f40028d2dd07a8c374583417ee6ec0ea304e710a20f80a0",
+                "sha256:e32d2a2b02ccbef10145df9135751abea1f9f076e67a4e261b05f24b94219e36",
+                "sha256:e71255ba42567d34a13c03968736c5d39bb4a97ce98188fafb27ce981115beec",
+                "sha256:ed2e07c6a26ed4bea91b897ee2b0835c21716d9a469a96c3e878dc5f8c55bb23",
+                "sha256:eef2afb0fd1747f33f1ee3e209bce1ed582d1896b240ccc5e2697e3275f037c7",
+                "sha256:f23222527b307970e383433daec128d769ff778d9b29343fb3496472dc20dabe",
+                "sha256:f341ee2df0999bfdf7a95e448075effe0db212a59387de1a70690e4acb03d4c6",
+                "sha256:f7f325be2804246a75a4f45c72d4ce80d2443ab815063cdf70ee8fb2ca59ee1b",
+                "sha256:f8af619e3be812a2059b212064ea7a640aff0568d972cd1b9e920837469eb3cb",
+                "sha256:fa8c626d6441e2d04b6ee703ef2d1e17608ad44c7cb75258c09dd42bacdfc64b",
+                "sha256:fbb9dc00e39f3e6c0ef48edee202f9520dafb233e8b51b06b8428cfcb92abd30",
+                "sha256:fff55f3ce50a3ff63ec8e2a8d3dd924f1941b250b0aac3d3d42b687eeff07a8e"
             ],
-            "version": "==2021.10.8"
+            "version": "==2021.11.10"
         },
         "semantic-version": {
             "hashes": [
@@ -412,20 +451,44 @@
         },
         "tomli": {
             "hashes": [
-                "sha256:8dd0e9524d6f386271a36b41dbf6c57d8e32fd96fd22b6584679dc569d20899f",
-                "sha256:a5b75cb6f3968abb47af1b40c1819dc519ea82bcc065776a866e8d74c5ca9442"
+                "sha256:c6ce0015eb38820eaf32b5db832dbc26deb3dd427bd5f6556cf0acac2c214fee",
+                "sha256:f04066f68f5554911363063a30b108d2b5a5b1a010aa8b6132af78489fe3aade"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==1.2.1"
+            "version": "==1.2.2"
+        },
+        "typed-ast": {
+            "hashes": [
+                "sha256:14fed8820114a389a2b7e91624db5f85f3f6682fda09fe0268a59aabd28fe5f5",
+                "sha256:155b74b078be842d2eb630dd30a280025eca0a5383c7d45853c27afee65f278f",
+                "sha256:224afecb8b39739f5c9562794a7c98325cb9d972712e1a98b6989a4720219541",
+                "sha256:361b9e5d27bd8e3ccb6ea6ad6c4f3c0be322a1a0f8177db6d56264fa0ae40410",
+                "sha256:37ba2ab65a0028b1a4f2b61a8fe77f12d242731977d274a03d68ebb751271508",
+                "sha256:49af5b8f6f03ed1eb89ee06c1d7c2e7c8e743d720c3746a5857609a1abc94c94",
+                "sha256:51040bf45aacefa44fa67fb9ebcd1f2bec73182b99a532c2394eea7dabd18e24",
+                "sha256:52ca2b2b524d770bed7a393371a38e91943f9160a190141e0df911586066ecda",
+                "sha256:618912cbc7e17b4aeba86ffe071698c6e2d292acbd6d1d5ec1ee724b8c4ae450",
+                "sha256:65c81abbabda7d760df7304d843cc9dbe7ef5d485504ca59a46ae2d1731d2428",
+                "sha256:7b310a207ee9fde3f46ba327989e6cba4195bc0c8c70a158456e7b10233e6bed",
+                "sha256:7e6731044f748340ef68dcadb5172a4b1f40847a2983fe3983b2a66445fbc8e6",
+                "sha256:806e0c7346b9b4af8c62d9a29053f484599921a4448c37fbbcbbf15c25138570",
+                "sha256:a67fd5914603e2165e075f1b12f5a8356bfb9557e8bfb74511108cfbab0f51ed",
+                "sha256:e4374a76e61399a173137e7984a1d7e356038cf844f24fd8aea46c8029a2f712",
+                "sha256:e8a9b9c87801cecaad3b4c2b8876387115d1a14caa602c1618cedbb0cb2a14e6",
+                "sha256:ea517c2bb11c5e4ba7a83a91482a2837041181d57d3ed0749a6c382a2b6b7086",
+                "sha256:ec184dfb5d3d11e82841dbb973e7092b75f306b625fad7b2e665b64c5d60ab3f",
+                "sha256:ff4ad88271aa7a55f19b6a161ed44e088c393846d954729549e3cde8257747bb"
+            ],
+            "markers": "python_version < '3.8' and implementation_name == 'cpython'",
+            "version": "==1.5.0"
         },
         "typing-extensions": {
             "hashes": [
-                "sha256:49f75d16ff11f1cd258e1b988ccff82a3ca5570217d7ad8c5f48205dd99a677e",
-                "sha256:d8226d10bc02a29bcc81df19a26e56a9647f8b0a6d4a83924139f4a8b01f17b7",
-                "sha256:f1d25edafde516b146ecd0613dabcc61409817af4766fbbcfb8d1ad4ec441a34"
+                "sha256:2cdf80e4e04866a9b3689a51869016d36db0814d84b8d8a568d22781d45d27ed",
+                "sha256:829704698b22e13ec9eaf959122315eabb370b0884400e9818334d8b677023d9"
             ],
             "markers": "python_version < '3.8'",
-            "version": "==3.10.0.2"
+            "version": "==4.0.0"
         },
         "watchdog": {
             "hashes": [
@@ -455,6 +518,14 @@
             ],
             "markers": "python_version >= '3.6'",
             "version": "==2.1.6"
+        },
+        "zipp": {
+            "hashes": [
+                "sha256:71c644c5369f4a6e07636f0aa966270449561fcea2e3d6747b8d23efaa9d7832",
+                "sha256:9fe5ea21568a0a70e50f273397638d39b03353731e6cbbb3fd8502a33fec40bc"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==3.6.0"
         }
     }
 }

--- a/fapolicy_analyzer/tests/test_ui_widget.py
+++ b/fapolicy_analyzer/tests/test_ui_widget.py
@@ -1,0 +1,100 @@
+import gi
+import pytest
+
+import context  # noqa: F401
+
+gi.require_version("Gtk", "3.0")
+from unittest.mock import MagicMock
+
+from gi.repository import Gtk
+from ui.ui_widget import UIBuilderWidget, UIConnectedWidget, UIWidget
+
+
+class concrete_UIBuilderWidget(UIBuilderWidget):
+    pass
+
+
+class concrete_UIConnectedWidget(UIConnectedWidget):
+    pass
+
+
+@pytest.fixture
+def mockWidget():
+    return MagicMock(spec=Gtk.Widget)
+
+
+@pytest.fixture
+def uiWidget(mockWidget):
+    class concrete(UIWidget):
+        pass
+
+    return concrete(mockWidget)
+
+
+@pytest.fixture
+def mockBuilder(mocker):
+    mock = MagicMock(get_object=MagicMock(), add_from_file=MagicMock())
+    mocker.patch("ui.ui_widget.Gtk.Builder", return_value=mock)
+    return mock
+
+
+@pytest.fixture
+def mockResource(mocker):
+    mock = mocker.patch("ui.ui_widget.resources.path")
+    mock.return_value.__enter__.return_value.as_posix.return_value = "foo"
+    return mock
+
+
+@pytest.fixture
+def mockFeature():
+    return MagicMock(subscribe=MagicMock())
+
+
+def test_calls_widget_destroy(uiWidget, mockWidget):
+    mockWidget.destroy = MagicMock()
+    uiWidget.dispose()
+    mockWidget.destroy.assert_called_once()
+
+
+def test_calls_uiwidget_destroy(uiWidget):
+    uiWidget._dispose = MagicMock()
+    uiWidget.dispose()
+    uiWidget._dispose.assert_called_once()
+
+
+def test_loads_default_glade_file(mockBuilder, mockResource):
+    concrete_UIBuilderWidget()
+    mockResource.assert_called_once_with(
+        "fapolicy_analyzer.glade", "test_ui_widget.glade"
+    )
+    mockBuilder.add_from_file.assert_called_once_with("foo")
+    mockBuilder.get_object.assert_called_once_with("testUiWidget")
+
+
+def test_loads_named_glade_file(mockBuilder, mockResource):
+    concrete_UIBuilderWidget("fooWidget")
+    mockResource.assert_called_once_with("fapolicy_analyzer.glade", "fooWidget.glade")
+    mockBuilder.add_from_file.assert_called_once_with("foo")
+    mockBuilder.get_object.assert_called_once_with("fooWidget")
+
+
+@pytest.mark.usefixtures("mockBuilder", "mockResource")
+def test_runs_post_init(mockFeature):
+    concrete_UIConnectedWidget(
+        mockFeature,
+        on_next="foo_next",
+        on_error="foo_error",
+        on_completed="foo_completed",
+    )
+    mockFeature.subscribe.assert_called_once_with(
+        on_next="foo_next", on_error="foo_error", on_completed="foo_completed"
+    )
+
+
+@pytest.mark.usefixtures("mockBuilder", "mockResource")
+def test_disposes_subscription(mockFeature):
+    mockDispose = MagicMock()
+    mockFeature.subscribe.return_value = MagicMock(dispose=mockDispose)
+    widget = concrete_UIConnectedWidget(mockFeature)
+    widget.dispose()
+    mockDispose.assert_called_once()

--- a/fapolicy_analyzer/ui/add_file_button.py
+++ b/fapolicy_analyzer/ui/add_file_button.py
@@ -6,14 +6,14 @@ gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk
 from events import Events
 from os import path
-from .ui_widget import UIWidget
+from .ui_widget import UIBuilderWidget
 
 
-class AddFileButton(UIWidget, Events):
+class AddFileButton(UIBuilderWidget, Events):
     __events__ = ["files_added"]
 
     def __init__(self):
-        UIWidget.__init__(self)
+        UIBuilderWidget.__init__(self)
         Events.__init__(self)
         self.dialog = self.get_object("fileChooserDialog")
 

--- a/fapolicy_analyzer/ui/analyzer_selection_dialog.py
+++ b/fapolicy_analyzer/ui/analyzer_selection_dialog.py
@@ -5,7 +5,7 @@ from gi.repository import Gtk
 from enum import Enum
 from os import path
 from .strings import OPEN_FILE_LABEL
-from .ui_widget import UIWidget
+from .ui_widget import UIBuilderWidget
 
 
 class ANALYZER_SELECTION(Enum):
@@ -14,7 +14,7 @@ class ANALYZER_SELECTION(Enum):
     ANALYZE_FROM_AUDIT = 2
 
 
-class AnalyzerSelectionDialog(UIWidget):
+class AnalyzerSelectionDialog(UIBuilderWidget):
     def __init__(self, parent=None):
         super().__init__()
         if parent:

--- a/fapolicy_analyzer/ui/ancillary_trust_database_admin.py
+++ b/fapolicy_analyzer/ui/ancillary_trust_database_admin.py
@@ -23,12 +23,12 @@ from .confirm_info_dialog import ConfirmInfoDialog
 from .deploy_confirm_dialog import DeployConfirmDialog
 from .store import dispatch, get_system_feature
 from .trust_file_details import TrustFileDetails
-from .ui_widget import UIWidget
+from .ui_widget import UIConnectedWidget
 
 
-class AncillaryTrustDatabaseAdmin(UIWidget):
+class AncillaryTrustDatabaseAdmin(UIConnectedWidget):
     def __init__(self):
-        super().__init__()
+        super().__init__(get_system_feature(), on_next=self.on_next_system)
         self._changesets = []
         self._trust = []
         self._deploying = False
@@ -49,8 +49,6 @@ class AncillaryTrustDatabaseAdmin(UIWidget):
         )
 
         self._deployBtn = self.get_object("deployBtn")
-
-        get_system_feature().subscribe(on_next=self.on_next_system)
 
     def __load_trust(self):
         self._loading = True

--- a/fapolicy_analyzer/ui/database_admin_page.py
+++ b/fapolicy_analyzer/ui/database_admin_page.py
@@ -5,11 +5,13 @@ gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk
 from .ancillary_trust_database_admin import AncillaryTrustDatabaseAdmin
 from .system_trust_database_admin import SystemTrustDatabaseAdmin
+from .ui_widget import UIWidget
 
 
-class DatabaseAdminPage:
+class DatabaseAdminPage(UIWidget):
     def __init__(self):
-        self.notebook = Gtk.Notebook()
+        notebook = Gtk.Notebook()
+        super().__init__(notebook)
 
         self.ancillaryTrustDbAdmin = AncillaryTrustDatabaseAdmin()
         self.systemTrustDbAdmin = SystemTrustDatabaseAdmin()
@@ -17,20 +19,21 @@ class DatabaseAdminPage:
             self.on_added_to_ancillary_trust
         )
 
-        self.notebook.append_page(
+        notebook.append_page(
             self.systemTrustDbAdmin.get_ref(),
             Gtk.Label(label=strings.SYSTEM_TRUST_TAB_LABEL),
         )
-        self.notebook.append_page(
+        notebook.append_page(
             self.ancillaryTrustDbAdmin.get_ref(),
             Gtk.Label(label=strings.ANCILLARY_TRUST_TAB_LABEL),
         )
 
-        self.notebook.set_current_page(1)
-        self.notebook.show_all()
-
-    def get_ref(self):
-        return self.notebook
+        notebook.set_current_page(1)
+        notebook.show_all()
 
     def on_added_to_ancillary_trust(self, file):
         self.ancillaryTrustDbAdmin.add_trusted_files(file)
+
+    def _dispose(self):
+        self.ancillaryTrustDbAdmin.dispose()
+        self.systemTrustDbAdmin.dispose()

--- a/fapolicy_analyzer/ui/deploy_confirm_dialog.py
+++ b/fapolicy_analyzer/ui/deploy_confirm_dialog.py
@@ -5,11 +5,11 @@ from gi.repository import Gtk, GLib
 from threading import Thread
 from time import sleep
 from locale import gettext as _
-from .ui_widget import UIWidget
+from .ui_widget import UIBuilderWidget
 from fapolicy_analyzer.util.format import f
 
 
-class DeployConfirmDialog(UIWidget):
+class DeployConfirmDialog(UIBuilderWidget):
     def __init__(self, parent=None, cancel_time=30):
         super().__init__()
         if parent:

--- a/fapolicy_analyzer/ui/loader.py
+++ b/fapolicy_analyzer/ui/loader.py
@@ -4,10 +4,10 @@ gi.require_version("Gtk", "3.0")
 from gi.repository import GdkPixbuf
 from importlib import resources
 from .strings import LOADER_MESSAGE
-from .ui_widget import UIWidget
+from .ui_widget import UIBuilderWidget
 
 
-class Loader(UIWidget):
+class Loader(UIBuilderWidget):
     def __init__(self, message=LOADER_MESSAGE):
         super().__init__()
         with resources.path(

--- a/fapolicy_analyzer/ui/notification.py
+++ b/fapolicy_analyzer/ui/notification.py
@@ -5,13 +5,15 @@ from gi.repository import Gtk, Gio
 from importlib import resources
 from threading import Timer
 from .actions import NotificationType, remove_notification
-from .ui_widget import UIWidget
+from .ui_widget import UIConnectedWidget
 from .store import dispatch, get_notifications_feature
 
 
-class Notification(UIWidget):
+class Notification(UIConnectedWidget):
     def __init__(self, timer_duration=10):
-        super().__init__()
+        super().__init__(
+            get_notifications_feature(), on_next=self.on_next_notifications
+        )
         self.message = self.get_object("message")
         self.container = self.get_object("container")
         self.closeBtn = self.get_object("closeBtn")
@@ -28,7 +30,6 @@ class Notification(UIWidget):
         self.closeBtn.get_style_context().add_provider(
             styleProvider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION
         )
-        get_notifications_feature().subscribe(on_next=self.on_next_notifications)
 
     def __start_timer(self):
         self.timer = Timer(self.timerDuration, self.closeBtn.clicked)

--- a/fapolicy_analyzer/ui/policy_rules_admin_page.py
+++ b/fapolicy_analyzer/ui/policy_rules_admin_page.py
@@ -24,13 +24,13 @@ from .strings import (
     USERS_LABEL,
 )
 from .subject_list import SubjectList
-from .ui_widget import UIWidget
+from .ui_widget import UIConnectedWidget
 from fapolicy_analyzer.util import acl, fs
 
 
-class PolicyRulesAdminPage(UIWidget):
+class PolicyRulesAdminPage(UIConnectedWidget):
     def __init__(self, auditFile=None):
-        super().__init__()
+        super().__init__(get_system_feature(), on_next=self.on_next_system)
         self._log = None
         self._eventsLoading = False
         self._users = []
@@ -101,8 +101,6 @@ class PolicyRulesAdminPage(UIWidget):
         ]
         for s in self.switchers:
             s.buttonClicked += self.on_switcher_button_clicked
-
-        get_system_feature().subscribe(on_next=self.on_next_system)
 
         if auditFile:
             self._usersLoading = True

--- a/fapolicy_analyzer/ui/searchable_list.py
+++ b/fapolicy_analyzer/ui/searchable_list.py
@@ -4,10 +4,10 @@ gi.require_version("Gtk", "3.0")
 from events import Events
 from gi.repository import Gtk
 from .loader import Loader
-from .ui_widget import UIWidget
+from .ui_widget import UIBuilderWidget
 
 
-class SearchableList(UIWidget, Events):
+class SearchableList(UIBuilderWidget, Events):
     __events__ = ["selection_changed"]
 
     def __init__(
@@ -19,7 +19,7 @@ class SearchableList(UIWidget, Events):
         defaultSortDirection=Gtk.SortType.DESCENDING,
         view_headers_visible=True,
     ):
-        UIWidget.__init__(self, "searchable_list")
+        UIBuilderWidget.__init__(self, "searchable_list")
         Events.__init__(self)
 
         self.searchColumnIndex = searchColumnIndex

--- a/fapolicy_analyzer/ui/splash_screen.py
+++ b/fapolicy_analyzer/ui/splash_screen.py
@@ -4,24 +4,21 @@ gi.require_version("Gtk", "3.0")
 from gi.repository import GLib
 from .main_window import MainWindow
 from .store import get_system_feature
-from .ui_widget import UIWidget
+from .ui_widget import UIConnectedWidget
 
 
-class SplashScreen(UIWidget):
+class SplashScreen(UIConnectedWidget):
     def __init__(self):
-        super().__init__()
+        super().__init__(get_system_feature(), on_next=self.on_next_system)
         self.progressBar = self.get_object("progressBar")
         self.window = self.get_ref()
         self.window.show_all()
-
-        self.subscription = get_system_feature().subscribe(on_next=self.on_next_system)
         self.timeout_id = GLib.timeout_add(100, self.on_timeout, None)
         self.progressBar.pulse()
 
     def on_next_system(self, system):
         if system.get("initialized", False):
-            self.subscription.dispose()
-            self.window.destroy()
+            self.dispose()
             MainWindow()
 
     def on_timeout(self, *args):

--- a/fapolicy_analyzer/ui/system_trust_database_admin.py
+++ b/fapolicy_analyzer/ui/system_trust_database_admin.py
@@ -13,15 +13,17 @@ from .configs import Colors
 from .store import dispatch, get_system_feature
 from .trust_file_list import TrustFileList
 from .trust_file_details import TrustFileDetails
-from .ui_widget import UIWidget
+from .ui_widget import UIConnectedWidget
 
 
-class SystemTrustDatabaseAdmin(UIWidget, Events):
+class SystemTrustDatabaseAdmin(UIConnectedWidget, Events):
     __events__ = ["file_added_to_ancillary_trust"]
     selectedFile = None
 
     def __init__(self):
-        UIWidget.__init__(self)
+        UIConnectedWidget.__init__(
+            self, get_system_feature(), on_next=self.on_next_system
+        )
         Events.__init__(self)
         self._trust = []
         self._error = None
@@ -39,8 +41,6 @@ class SystemTrustDatabaseAdmin(UIWidget, Events):
         self.get_object("rightBox").pack_start(
             self.trustFileDetails.get_ref(), True, True, 0
         )
-
-        get_system_feature().subscribe(on_next=self.on_next_system)
 
     def __status_markup(self, status):
         return (

--- a/fapolicy_analyzer/ui/trust_file_details.py
+++ b/fapolicy_analyzer/ui/trust_file_details.py
@@ -1,7 +1,7 @@
-from .ui_widget import UIWidget
+from .ui_widget import UIBuilderWidget
 
 
-class TrustFileDetails(UIWidget):
+class TrustFileDetails(UIBuilderWidget):
     def clear(self):
         self.set_in_database_view("")
         self.set_on_file_system_view("")

--- a/fapolicy_analyzer/ui/ui_widget.py
+++ b/fapolicy_analyzer/ui/ui_widget.py
@@ -1,13 +1,18 @@
 import locale
+import logging
+
 import gi
 import pkg_resources
 
 gi.require_version("Gtk", "3.0")
-from gi.repository import Gtk
-from abc import ABC
+from abc import ABC, ABCMeta
+from dataclasses import dataclass
 from importlib import resources
-from fapolicy_analyzer.util.format import snake_to_camelcase
+from typing import Callable
 
+from fapolicy_analyzer.util.format import snake_to_camelcase
+from gi.repository import Gtk
+from rx.core.typing import Observable
 
 DOMAIN = "fapolicy_analyzer"
 locale.setlocale(locale.LC_ALL, locale.getlocale())
@@ -16,7 +21,58 @@ locale.bindtextdomain(DOMAIN, locale_path)
 locale.textdomain(DOMAIN)
 
 
+class _PostInitCaller(type):
+    """
+    Meta class used to run the __post_init__ method after normal __init__ is run.
+    This allows for initialization code to run that would require the class to be
+    full initialized first.
+    """
+
+    def __call__(cls, *args, **kwargs):
+        logging.debug(f"{__class__.__name__}.__call__({args}, {kwargs})")
+        obj = type.__call__(cls, *args, **kwargs)
+        obj.__post_init__(*args, **kwargs)
+        return obj
+
+
+class _combinedMeta(_PostInitCaller, ABCMeta):
+    """
+    Meta class used to combine the _PostInitCaller meta class with ABCMeta
+    for Abract Base Classes
+    """
+
+
 class UIWidget(ABC):
+    """
+    Abstract Base Class for any UI Widget.
+    """
+
+    def __init__(self, ref):
+        self._ref = ref
+
+    def get_ref(self):
+        return self._ref
+
+    def dispose(self):
+        if self._ref and isinstance(self._ref, Gtk.Widget):
+            logging.debug(
+                "distroying widget from class {}".format(self.__class__.__name__)
+            )
+            self._ref.destroy()
+        self._dispose()
+
+    def _dispose(self):
+        """Implemented by inheriting classes to allow for extra clean code to be run."""
+
+
+class UIBuilderWidget(UIWidget, ABC):
+    """
+    Abstract Base Class for any UI Widget that uses a glade file to load it structure.
+    This class expects the glade file to be have the same file name as the widgets
+    python file but with a .glade extension, and for the glade file to be located under
+    the fapolicy_analyzer/glade directory.
+    """
+
     def __init__(self, name=None):
         def gladeFile():
             filename = f"{name}.glade"
@@ -24,14 +80,53 @@ class UIWidget(ABC):
                 return path.as_posix()
 
         name = name or self.__module__.split(".")[-1]
-        self.builder = Gtk.Builder()
-        self.builder.set_translation_domain(DOMAIN)
-        self.builder.add_from_file(gladeFile())
-        self.builder.connect_signals(self)
-        self.ref = self.get_object(snake_to_camelcase(name))
+        self._builder = Gtk.Builder()
+        self._builder.set_translation_domain(DOMAIN)
+        self._builder.add_from_file(gladeFile())
+        self._builder.connect_signals(self)
+        UIWidget.__init__(self, self.get_object(snake_to_camelcase(name)))
 
     def get_object(self, name):
-        return self.builder.get_object(name)
+        return self._builder.get_object(name)
 
-    def get_ref(self):
-        return self.ref
+
+@dataclass
+class UIConnectedWidget(UIBuilderWidget, metaclass=_combinedMeta):
+    """
+    Abstract base class for any glade based UI widgets that are connected
+    to redux to retrieve state.
+    """
+
+    def __init__(
+        self,
+        feature: Observable,
+        on_next: Callable = None,
+        on_error: Callable = None,
+        on_completed: Callable = None,
+    ):
+        UIBuilderWidget.__init__(self)
+        self._feature = feature
+        self._on_next = on_next
+        self._on_error = on_error
+        self._on_completed = on_completed
+        self._subscription = None
+
+    def __post_init__(
+        self,
+        feature: Observable = None,
+        on_next: Callable = None,
+        on_error: Callable = None,
+        on_completed: Callable = None,
+    ):
+        self._subscription = self._feature.subscribe(
+            on_next=self._on_next,
+            on_error=self._on_error,
+            on_completed=self._on_completed,
+        )
+
+    def _dispose(self):
+        if self._subscription:
+            logging.debug(
+                "disposing of subscription for class {}".format(self.__class__.__name__)
+            )
+            self._subscription.dispose()

--- a/fapolicy_analyzer/ui/unapplied_changes_dialog.py
+++ b/fapolicy_analyzer/ui/unapplied_changes_dialog.py
@@ -1,7 +1,7 @@
-from .ui_widget import UIWidget
+from .ui_widget import UIBuilderWidget
 
 
-class UnappliedChangesDialog(UIWidget):
+class UnappliedChangesDialog(UIBuilderWidget):
     def __init__(self, parent=None):
         super().__init__()
         if parent:


### PR DESCRIPTION
Should fix the errors and warnings that you sometime see when switching between tool in the application.  To test this you need to start the app, then before the System Trust Database Admin page has time to fully load, switch to the Policy Event Analysis tool.  Also try switch back and forth a few times.

To allow for customizable cleanup and disposing of references, I implemented a couple new UI widget abstract base classes what we can use.
* `UIWidget` is the root base class can can be used for any widget class, with or without glade
* `UIBuilderWidget` inherits from `UIWidget` and should be used as the base class for any glade based widgets
* `UIConnectedWidget` inherits from `UIBuilderWidget` and should be used for any widgets that also need to be connected to redux.

closes #319 