### PR TITLE
Issue 316 trust reconciliation dialog

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -31,6 +31,7 @@ events = "0.4"
 argparse = "1.4.0"
 redux-py = "*"
 rx = "*"
+more-itertools = "*"
 
 [pipenv]
 allow_prereleases = true

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "e03f57591887611c49cc41d2ffb482c81d64cce8772e373b784b3ffd7052f67d"
+            "sha256": "cccbd35357033246e1bc626e10c676c9c7c64677f34f2abae086c927e4eb3202"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -30,6 +30,14 @@
             ],
             "index": "pypi",
             "version": "==0.4"
+        },
+        "more-itertools": {
+            "hashes": [
+                "sha256:0a2fd25d343c08d7e7212071820e7e7ea2f41d8fb45d6bc8a00cd6ce3b7aab88",
+                "sha256:88afff98d83d08fe5e4049b81e2b54c06ebb6b3871a600040865c7a592061cbb"
+            ],
+            "index": "pypi",
+            "version": "==8.11.0"
         },
         "pycairo": {
             "hashes": [

--- a/fapolicy_analyzer/glade/trust_reconciliation_dialog.glade
+++ b/fapolicy_analyzer/glade/trust_reconciliation_dialog.glade
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated with glade 3.38.2 -->
+<interface>
+  <requires lib="gtk+" version="3.22"/>
+  <object class="GtkDialog" id="trustReconciliationDialog">
+    <property name="can-focus">False</property>
+    <property name="title" translatable="yes">Trust Reconsiliation</property>
+    <property name="modal">True</property>
+    <property name="window-position">center-on-parent</property>
+    <property name="default-width">500</property>
+    <property name="default-height">600</property>
+    <property name="type-hint">dialog</property>
+    <child internal-child="vbox">
+      <object class="GtkBox">
+        <property name="can-focus">False</property>
+        <property name="orientation">vertical</property>
+        <property name="spacing">2</property>
+        <child internal-child="action_area">
+          <object class="GtkButtonBox">
+            <property name="can-focus">False</property>
+            <property name="layout-style">end</property>
+            <child>
+              <object class="GtkButton" id="trustBtn">
+                <property name="label" translatable="yes">Trust</property>
+                <property name="visible">True</property>
+                <property name="can-focus">True</property>
+                <property name="receives-default">True</property>
+              </object>
+              <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkButton" id="untrustBtn">
+                <property name="label" translatable="yes">Untrust</property>
+                <property name="visible">True</property>
+                <property name="can-focus">True</property>
+                <property name="receives-default">True</property>
+              </object>
+              <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkButton" id="cancelBtn">
+                <property name="label" translatable="yes">Cancel</property>
+                <property name="visible">True</property>
+                <property name="can-focus">True</property>
+                <property name="receives-default">True</property>
+              </object>
+              <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
+                <property name="position">2</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">False</property>
+            <property name="position">1</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkScrolledWindow" id="content">
+            <property name="visible">True</property>
+            <property name="can-focus">True</property>
+            <property name="shadow-type">in</property>
+            <child>
+              <placeholder/>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">True</property>
+            <property name="fill">True</property>
+            <property name="position">1</property>
+          </packing>
+        </child>
+      </object>
+    </child>
+    <action-widgets>
+      <action-widget response="1">trustBtn</action-widget>
+      <action-widget response="0">untrustBtn</action-widget>
+      <action-widget response="-6">cancelBtn</action-widget>
+    </action-widgets>
+  </object>
+</interface>

--- a/fapolicy_analyzer/locale/fapolicy_analyzer.pot
+++ b/fapolicy_analyzer/locale/fapolicy_analyzer.pot
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: fapolicy-analyzer snapshot\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2021-10-22 14:33-0400\n"
+"POT-Creation-Date: 2021-11-23 13:18-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,7 +18,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.9.1\n"
 
-#: fapolicy_analyzer/ui/ancillary_trust_database_admin.py:103
+#: fapolicy_analyzer/ui/ancillary_trust_database_admin.py:100
 #: fapolicy_analyzer/ui/system_trust_database_admin.py:84
 msgid ""
 "File: {trust.path}\n"
@@ -26,7 +26,7 @@ msgid ""
 "SHA256: {trust.hash}"
 msgstr ""
 
-#: fapolicy_analyzer/ui/ancillary_trust_database_admin.py:113
+#: fapolicy_analyzer/ui/ancillary_trust_database_admin.py:110
 #: fapolicy_analyzer/ui/system_trust_database_admin.py:93
 msgid ""
 "{fs.stat(trust.path)}\n"
@@ -37,7 +37,7 @@ msgstr ""
 msgid "Reverting to previous settings in {i+1} seconds"
 msgstr ""
 
-#: fapolicy_analyzer/ui/main_window.py:186
+#: fapolicy_analyzer/ui/main_window.py:180
 msgid ""
 "An error occurred trying to open the session file, "
 "{self.strSessionFilename}"
@@ -48,126 +48,151 @@ msgid "Failed to load edit session from file {strJsonFile}"
 msgstr ""
 
 #: fapolicy_analyzer/ui/strings.py:3
-msgid "Error initializing System"
+msgid "FILE"
 msgstr ""
 
 #: fapolicy_analyzer/ui/strings.py:4
-msgid "Error loading Ancillary Trust"
+msgid "SIZE"
 msgstr ""
 
-#: fapolicy_analyzer/ui/strings.py:5
-msgid "Error loading System Trust"
+#: fapolicy_analyzer/ui/strings.py:6
+msgid "Error initializing System"
 msgstr ""
 
 #: fapolicy_analyzer/ui/strings.py:7
-msgid "Deploy Ancillary Trust Changes?"
+msgid "Error loading Ancillary Trust"
 msgstr ""
 
 #: fapolicy_analyzer/ui/strings.py:8
+msgid "Error loading System Trust"
+msgstr ""
+
+#: fapolicy_analyzer/ui/strings.py:10
+msgid "Deploy Ancillary Trust Changes?"
+msgstr ""
+
+#: fapolicy_analyzer/ui/strings.py:11
 msgid ""
 "Are you sure you wish to deploy your changes to the ancillary trust "
 "database?\n"
 " This will update the fapolicy trust and restart the service."
 msgstr ""
 
-#: fapolicy_analyzer/ui/strings.py:12
+#: fapolicy_analyzer/ui/strings.py:15
 msgid "Action"
 msgstr ""
 
-#: fapolicy_analyzer/ui/strings.py:13
+#: fapolicy_analyzer/ui/strings.py:16
 msgid "File Path"
 msgstr ""
 
-#: fapolicy_analyzer/ui/strings.py:14
+#: fapolicy_analyzer/ui/strings.py:17
 msgid "Changes successfully deployed."
 msgstr ""
 
-#: fapolicy_analyzer/ui/strings.py:15
+#: fapolicy_analyzer/ui/strings.py:18
 msgid "An error occurred trying to deploy the changes. Please try again."
 msgstr ""
 
-#: fapolicy_analyzer/ui/strings.py:19
-msgid "This file is trusted."
-msgstr ""
-
-#: fapolicy_analyzer/ui/strings.py:20
-msgid "There is a discrepancy with this file."
-msgstr ""
-
-#: fapolicy_analyzer/ui/strings.py:21
-msgid "The trust status of this file is unknown."
+#: fapolicy_analyzer/ui/strings.py:22
+msgid "This file is trusted in the System Trust Database."
 msgstr ""
 
 #: fapolicy_analyzer/ui/strings.py:23
+msgid "There is a discrepancy between this file and the System Trust Database."
+msgstr ""
+
+#: fapolicy_analyzer/ui/strings.py:26
+msgid "The trust status of this file is unknown in the System Trust Database."
+msgstr ""
+
+#: fapolicy_analyzer/ui/strings.py:30
+msgid "This file is trusted in the Ancillary Trust Database."
+msgstr ""
+
+#: fapolicy_analyzer/ui/strings.py:33
+msgid "There is a discrepancy between this file and the Ancillary Trust Database."
+msgstr ""
+
+#: fapolicy_analyzer/ui/strings.py:36
+msgid "The trust status of this file is unknown in the Ancillary Trust Database."
+msgstr ""
+
+#: fapolicy_analyzer/ui/strings.py:40
+msgid "The trust status of this file is unknown"
+msgstr ""
+
+#: fapolicy_analyzer/ui/strings.py:42
 msgid "System Trust Database"
 msgstr ""
 
-#: fapolicy_analyzer/ui/strings.py:24
+#: fapolicy_analyzer/ui/strings.py:43
 msgid "Ancillary Trust Database"
 msgstr ""
 
 #: fapolicy_analyzer/glade/ancillary_trust_database_admin.glade:50
-#: fapolicy_analyzer/ui/strings.py:26
+#: fapolicy_analyzer/glade/trust_reconciliation_dialog.glade:24
+#: fapolicy_analyzer/ui/strings.py:45
 msgid "Trust"
 msgstr ""
 
-#: fapolicy_analyzer/ui/strings.py:27
+#: fapolicy_analyzer/ui/strings.py:46
 msgid "File"
 msgstr ""
 
-#: fapolicy_analyzer/ui/strings.py:28
+#: fapolicy_analyzer/ui/strings.py:47
 msgid "MTime"
 msgstr ""
 
-#: fapolicy_analyzer/ui/strings.py:29
+#: fapolicy_analyzer/ui/strings.py:48
 msgid "Changes"
 msgstr ""
 
-#: fapolicy_analyzer/ui/strings.py:30
+#: fapolicy_analyzer/ui/strings.py:49
 msgid "Mode"
 msgstr ""
 
-#: fapolicy_analyzer/ui/strings.py:31
+#: fapolicy_analyzer/ui/strings.py:50
 msgid "Access"
 msgstr ""
 
-#: fapolicy_analyzer/ui/strings.py:33
+#: fapolicy_analyzer/ui/strings.py:52
 msgid "Add"
 msgstr ""
 
-#: fapolicy_analyzer/ui/strings.py:34
+#: fapolicy_analyzer/ui/strings.py:53
 msgid "Delete"
 msgstr ""
 
-#: fapolicy_analyzer/ui/strings.py:36
+#: fapolicy_analyzer/ui/strings.py:55
 msgid "Add File"
 msgstr ""
 
-#: fapolicy_analyzer/ui/strings.py:37
+#: fapolicy_analyzer/ui/strings.py:56
 msgid "Open File"
 msgstr ""
 
-#: fapolicy_analyzer/ui/strings.py:38
+#: fapolicy_analyzer/ui/strings.py:57
 msgid "Save As..."
 msgstr ""
 
-#: fapolicy_analyzer/ui/strings.py:39
+#: fapolicy_analyzer/ui/strings.py:58
 msgid "FA Session files"
 msgstr ""
 
-#: fapolicy_analyzer/ui/strings.py:40
+#: fapolicy_analyzer/ui/strings.py:59
 msgid "fapolicyd archive files"
 msgstr ""
 
-#: fapolicy_analyzer/ui/strings.py:41
+#: fapolicy_analyzer/ui/strings.py:60
 msgid "Any files"
 msgstr ""
 
-#: fapolicy_analyzer/ui/strings.py:43
+#: fapolicy_analyzer/ui/strings.py:62
 msgid "File path(s) contains embedded whitespace."
 msgstr ""
 
-#: fapolicy_analyzer/ui/strings.py:44
+#: fapolicy_analyzer/ui/strings.py:63
 msgid ""
 "fapolicyd currently does not support paths containing spaces. The "
 "following paths will not be added to the Trusted Files List.\n"
@@ -175,7 +200,7 @@ msgid ""
 "\n"
 msgstr ""
 
-#: fapolicy_analyzer/ui/strings.py:49
+#: fapolicy_analyzer/ui/strings.py:68
 msgid ""
 "\n"
 "        Restore your prior session now?\n"
@@ -192,49 +217,49 @@ msgid ""
 "        "
 msgstr ""
 
-#: fapolicy_analyzer/ui/strings.py:65
+#: fapolicy_analyzer/ui/strings.py:84
 msgid "An error occurred trying to restore a prior autosaved edit session"
 msgstr ""
 
-#: fapolicy_analyzer/glade/loader.glade:28 fapolicy_analyzer/ui/strings.py:69
+#: fapolicy_analyzer/glade/loader.glade:28 fapolicy_analyzer/ui/strings.py:88
 msgid "Loading..."
 msgstr ""
 
-#: fapolicy_analyzer/ui/strings.py:71
+#: fapolicy_analyzer/ui/strings.py:90
 msgid "file"
 msgstr ""
 
-#: fapolicy_analyzer/ui/strings.py:72
+#: fapolicy_analyzer/ui/strings.py:91
 msgid "files"
 msgstr ""
 
-#: fapolicy_analyzer/ui/strings.py:73
+#: fapolicy_analyzer/ui/strings.py:92
 msgid "user"
 msgstr ""
 
-#: fapolicy_analyzer/ui/strings.py:74
+#: fapolicy_analyzer/ui/strings.py:93
 msgid "users"
 msgstr ""
 
-#: fapolicy_analyzer/ui/strings.py:75
+#: fapolicy_analyzer/ui/strings.py:94
 msgid "group"
 msgstr ""
 
-#: fapolicy_analyzer/ui/strings.py:76
+#: fapolicy_analyzer/ui/strings.py:95
 msgid "groups"
 msgstr ""
 
-#: fapolicy_analyzer/ui/strings.py:77
+#: fapolicy_analyzer/ui/strings.py:96
 msgid ""
 "An error occurred trying to parse the event log file. Please try again or"
 " select a different file."
 msgstr ""
 
-#: fapolicy_analyzer/ui/strings.py:80
+#: fapolicy_analyzer/ui/strings.py:99
 msgid "An error occurred trying to retrieve the user list. Please try again."
 msgstr ""
 
-#: fapolicy_analyzer/ui/strings.py:83
+#: fapolicy_analyzer/ui/strings.py:102
 msgid "An error occurred trying to retrieve the group list. Please try again."
 msgstr ""
 
@@ -256,6 +281,7 @@ msgid "Analyze From Audit"
 msgstr ""
 
 #: fapolicy_analyzer/glade/ancillary_trust_database_admin.glade:65
+#: fapolicy_analyzer/glade/trust_reconciliation_dialog.glade:37
 msgid "Untrust"
 msgstr ""
 
@@ -331,6 +357,14 @@ msgstr ""
 
 #: fapolicy_analyzer/glade/trust_file_details.glade:120
 msgid "File Trust Status"
+msgstr ""
+
+#: fapolicy_analyzer/glade/trust_reconciliation_dialog.glade:7
+msgid "Trust Reconsiliation"
+msgstr ""
+
+#: fapolicy_analyzer/glade/trust_reconciliation_dialog.glade:50
+msgid "Cancel"
 msgstr ""
 
 #: fapolicy_analyzer/glade/unapplied_changes_dialog.glade:8

--- a/fapolicy_analyzer/tests/test_ancillary_trust_database_admin.py
+++ b/fapolicy_analyzer/tests/test_ancillary_trust_database_admin.py
@@ -1,33 +1,36 @@
-import context  # noqa: F401
-import pytest
 import gi
+import pytest
+
+import context  # noqa: F401
 
 gi.require_version("Gtk", "3.0")
-from gi.repository import Gtk
-from callee import InstanceOf, Attrs, Sequence
+from unittest.mock import MagicMock, patch
+
+from callee import Attrs, InstanceOf, Sequence
 from fapolicy_analyzer import Changeset, Trust
-from mocks import mock_System, mock_trust
+from gi.repository import Gtk
 from redux import Action
 from rx.subject import Subject
-from unittest.mock import MagicMock, patch
 from ui.actions import (
     ADD_NOTIFICATION,
     APPLY_CHANGESETS,
     CLEAR_CHANGESETS,
-    REQUEST_ANCILLARY_TRUST,
-    NotificationType,
     DEPLOY_ANCILLARY_TRUST,
+    REQUEST_ANCILLARY_TRUST,
     SET_SYSTEM_CHECKPOINT,
+    NotificationType,
 )
 from ui.ancillary_trust_database_admin import AncillaryTrustDatabaseAdmin
 from ui.store import init_store
 from ui.strings import (
     ANCILLARY_TRUST_LOAD_ERROR,
+    ANCILLARY_TRUSTED_FILE_MESSAGE,
+    ANCILLARY_UNKNOWN_FILE_MESSAGE,
     DEPLOY_ANCILLARY_ERROR_MSG,
     DEPLOY_ANCILLARY_SUCCESSFUL_MSG,
-    TRUSTED_FILE_MESSAGE,
-    UNKNOWN_FILE_MESSAGE,
 )
+
+from mocks import mock_System, mock_trust
 
 
 @pytest.fixture()
@@ -98,7 +101,9 @@ def test_updates_trust_details(widget, mocker):
     widget.trustFileDetails.set_on_file_system_view.assert_called_with(
         "stat for foo file\nSHA256: abc"
     )
-    widget.trustFileDetails.set_trust_status.assert_called_with(TRUSTED_FILE_MESSAGE)
+    widget.trustFileDetails.set_trust_status.assert_called_with(
+        ANCILLARY_TRUSTED_FILE_MESSAGE
+    )
 
 
 def test_updates_trust_details_for_deleted_files(widget, mocker):
@@ -114,7 +119,9 @@ def test_updates_trust_details_for_deleted_files(widget, mocker):
     widget.trustFileDetails.set_on_file_system_view.assert_called_with(
         "stat for foo file\nSHA256: abc"
     )
-    widget.trustFileDetails.set_trust_status.assert_called_with(UNKNOWN_FILE_MESSAGE)
+    widget.trustFileDetails.set_trust_status.assert_called_with(
+        ANCILLARY_UNKNOWN_FILE_MESSAGE
+    )
 
 
 def test_clears_trust_details(widget, mocker):

--- a/fapolicy_analyzer/tests/test_ancillary_trust_file_list.py
+++ b/fapolicy_analyzer/tests/test_ancillary_trust_file_list.py
@@ -1,10 +1,12 @@
-import context  # noqa: F401
-import pytest
 import gi
+import pytest
+
+import context  # noqa: F401
 
 gi.require_version("Gtk", "3.0")
-from gi.repository import Gtk
 from unittest.mock import MagicMock
+
+from gi.repository import Gtk
 from ui.ancillary_trust_file_list import AncillaryTrustFileList
 from ui.configs import Colors
 from ui.strings import (
@@ -14,9 +16,9 @@ from ui.strings import (
 )
 
 _trust = [
-    MagicMock(status="d", path="/tmp/foo", actual=MagicMock(last_modified=123456789)),
-    MagicMock(status="t", path="/tmp/baz", actual=MagicMock(last_modified=123456789)),
-    MagicMock(status="u", path="/tmp/bar", actual=MagicMock(last_modified=123456789)),
+    MagicMock(status="d", path="/tmp/1", actual=MagicMock(last_modified=123456789)),
+    MagicMock(status="t", path="/tmp/2", actual=MagicMock(last_modified=123456789)),
+    MagicMock(status="u", path="/tmp/3", actual=MagicMock(last_modified=123456789)),
 ]
 
 
@@ -85,12 +87,12 @@ def test_shows_changes_column(widget):
 
 def test_trust_add_actions_in_view(widget):
     mockChangeset = MagicMock(
-        get_path_action_map=MagicMock(return_value=({"/tmp/foo": "Add"}))
+        get_path_action_map=MagicMock(return_value=({"/tmp/1": "Add"}))
     )
     widget.set_changesets([mockChangeset])
     widget.load_trust(_trust)
     model = widget.get_object("treeView").get_model()
-    row = next(iter([x for x in model if x[2] == "/tmp/foo"]))
+    row = next(iter([x for x in model if x[2] == "/tmp/1"]))
     assert CHANGESET_ACTION_ADD == row[5]
 
 

--- a/fapolicy_analyzer/tests/test_object_list.py
+++ b/fapolicy_analyzer/tests/test_object_list.py
@@ -1,11 +1,14 @@
-import context  # noqa: F401
-import gi
-import pytest
 import re
 
+import gi
+import pytest
+
+import context  # noqa: F401
+
 gi.require_version("Gtk", "3.0")
-from gi.repository import Gtk
 from unittest.mock import MagicMock
+
+from gi.repository import Gtk
 from ui.configs import Colors
 from ui.object_list import ObjectList
 from ui.strings import FILE_LABEL, FILES_LABEL
@@ -41,13 +44,13 @@ def test_loads_store(widget):
     assert [t.trust for t in sortedObjects] == [
         strip_markup(x[0]) for x in view.get_model()
     ]
-    assert [t.mode for t in sortedObjects] == [
+    assert [t.access for t in sortedObjects] == [
         strip_markup(x[1]) for x in view.get_model()
     ]
-    assert [t.access for t in sortedObjects] == [
-        strip_markup(x[2]) for x in view.get_model()
+    assert [t.file for t in sortedObjects] == [x[2] for x in view.get_model()]
+    assert [t.mode for t in sortedObjects] == [
+        strip_markup(x[5]) for x in view.get_model()
     ]
-    assert [t.file for t in sortedObjects] == [x[3] for x in view.get_model()]
 
 
 def test_status_markup(widget):
@@ -78,34 +81,34 @@ def test_mode_markup(widget):
 
     # Read
     widget.load_store([_mock_object(mode="R")])
-    assert view.get_model()[0][1] == "<b><u>R</u></b>WX"
+    assert view.get_model()[0][5] == "<b><u>R</u></b>WX"
     # Write
     widget.load_store([_mock_object(mode="W")])
-    assert view.get_model()[0][1] == "R<b><u>W</u></b>X"
+    assert view.get_model()[0][5] == "R<b><u>W</u></b>X"
     # Execute
     widget.load_store([_mock_object(mode="X")])
-    assert view.get_model()[0][1] == "RW<b><u>X</u></b>"
+    assert view.get_model()[0][5] == "RW<b><u>X</u></b>"
     # Read/Write
     widget.load_store([_mock_object(mode="RW")])
-    assert view.get_model()[0][1] == "<b><u>R</u></b><b><u>W</u></b>X"
+    assert view.get_model()[0][5] == "<b><u>R</u></b><b><u>W</u></b>X"
     # Read/Execute
     widget.load_store([_mock_object(mode="RX")])
-    assert view.get_model()[0][1] == "<b><u>R</u></b>W<b><u>X</u></b>"
+    assert view.get_model()[0][5] == "<b><u>R</u></b>W<b><u>X</u></b>"
     # Write/Execute
     widget.load_store([_mock_object(mode="WX")])
-    assert view.get_model()[0][1] == "R<b><u>W</u></b><b><u>X</u></b>"
+    assert view.get_model()[0][5] == "R<b><u>W</u></b><b><u>X</u></b>"
     # Full Access
     widget.load_store([_mock_object(mode="RWX")])
-    assert view.get_model()[0][1] == "<b><u>R</u></b><b><u>W</u></b><b><u>X</u></b>"
+    assert view.get_model()[0][5] == "<b><u>R</u></b><b><u>W</u></b><b><u>X</u></b>"
     # Bad data
     widget.load_store([_mock_object(mode="foo")])
-    assert view.get_model()[0][1] == "RWX"
+    assert view.get_model()[0][5] == "RWX"
     # Empty data
     widget.load_store([_mock_object()])
-    assert view.get_model()[0][1] == "RWX"
+    assert view.get_model()[0][5] == "RWX"
     # Lowercase
     widget.load_store([_mock_object(mode="r")])
-    assert view.get_model()[0][1] == "<b><u>R</u></b>WX"
+    assert view.get_model()[0][5] == "<b><u>R</u></b>WX"
 
 
 def test_access_markup(widget):
@@ -113,19 +116,19 @@ def test_access_markup(widget):
 
     # Allowed
     widget.load_store([_mock_object(access="A")])
-    assert view.get_model()[0][2] == "<b><u>A</u></b>/D"
+    assert view.get_model()[0][1] == "<b><u>A</u></b>/D"
     # Denied
     widget.load_store([_mock_object(access="D")])
-    assert view.get_model()[0][2] == "A/<b><u>D</u></b>"
+    assert view.get_model()[0][1] == "A/<b><u>D</u></b>"
     # Bad data
     widget.load_store([_mock_object(access="foo")])
-    assert view.get_model()[0][2] == "A/D"
+    assert view.get_model()[0][1] == "A/D"
     # Empty data
     widget.load_store([_mock_object()])
-    assert view.get_model()[0][2] == "A/D"
+    assert view.get_model()[0][1] == "A/D"
     # Lowercase
     widget.load_store([_mock_object(access="a")])
-    assert view.get_model()[0][2] == "<b><u>A</u></b>/D"
+    assert view.get_model()[0][1] == "<b><u>A</u></b>/D"
 
 
 def test_path_color(widget):
@@ -133,22 +136,22 @@ def test_path_color(widget):
 
     # Denied
     widget.load_store([_mock_object(access="D", mode="RWX")])
-    assert view.get_model()[0][5] == Colors.LIGHT_RED
+    assert view.get_model()[0][4] == Colors.LIGHT_RED
     # Full Access
     widget.load_store([_mock_object(access="A", mode="RWX")])
-    assert view.get_model()[0][5] == Colors.LIGHT_GREEN
+    assert view.get_model()[0][4] == Colors.LIGHT_GREEN
     # Partical Access
     widget.load_store([_mock_object(access="A", mode="R")])
-    assert view.get_model()[0][5] == Colors.ORANGE
+    assert view.get_model()[0][4] == Colors.ORANGE
     # Bad data
     widget.load_store([_mock_object(access="foo")])
-    assert view.get_model()[0][5] == Colors.LIGHT_RED
+    assert view.get_model()[0][4] == Colors.LIGHT_RED
     # Empty data
     widget.load_store([_mock_object()])
-    assert view.get_model()[0][5] == Colors.LIGHT_RED
+    assert view.get_model()[0][4] == Colors.LIGHT_RED
     # Lowercase
     widget.load_store([_mock_object(access="a", mode="rwx")])
-    assert view.get_model()[0][5] == Colors.LIGHT_GREEN
+    assert view.get_model()[0][4] == Colors.LIGHT_GREEN
 
 
 def test_update_tree_count(widget):
@@ -161,9 +164,9 @@ def test_update_tree_count(widget):
     assert label.get_text() == f"2 {FILES_LABEL}"
 
 
-def test_fires_object_selection_changed_event(widget):
+def test_fires_file_selection_changed_event(widget):
     mockHandler = MagicMock()
-    widget.object_selection_changed += mockHandler
+    widget.file_selection_changed += mockHandler
     mockData = _mock_object(file="foo")
     widget.load_store([mockData])
     view = widget.get_object("treeView")

--- a/fapolicy_analyzer/tests/test_policy_rules_admin_page.py
+++ b/fapolicy_analyzer/tests/test_policy_rules_admin_page.py
@@ -1,12 +1,13 @@
-import context  # noqa: F401
 import gi
 import pytest
 
+import context  # noqa: F401
+
 gi.require_version("Gtk", "3.0")
-from gi.repository import Gtk
-from callee import Attrs, InstanceOf
 from unittest.mock import MagicMock
-from mocks import mock_System, mock_events, mock_groups, mock_log, mock_users
+
+from callee import Attrs, InstanceOf
+from gi.repository import Gtk
 from redux import Action
 from rx.subject import Subject
 from ui.actions import (
@@ -17,12 +18,14 @@ from ui.actions import (
     NotificationType,
 )
 from ui.policy_rules_admin_page import PolicyRulesAdminPage
+from ui.store import init_store
 from ui.strings import (
     GET_GROUPS_LOG_ERROR_MSG,
     GET_USERS_ERROR_MSG,
     PARSE_EVENT_LOG_ERROR_MSG,
 )
-from ui.store import init_store
+
+from mocks import mock_events, mock_groups, mock_log, mock_System, mock_users
 
 _mock_file = "foo"
 
@@ -32,6 +35,8 @@ def _build_state(**kwargs):
         "events": {"loading": False, "error": None, "events": []},
         "groups": {"loading": False, "error": None, "groups": []},
         "users": {"loading": False, "error": None, "users": []},
+        "system_trust": {"loading": False, "error": None, "trust": []},
+        "ancillary_trust": {"loading": False, "error": None, "trust": []},
     }
 
     combined = {
@@ -253,9 +258,9 @@ def test_loads_objects_from_subject(view, subjectListView, objectListView):
     model = objectListView.get_model()
     expectedObject = mock_events()[0].object
     assert expectedObject.trust in next(iter([x[0] for x in model]))
-    assert expectedObject.mode in next(iter([x[1] for x in model]))
-    assert expectedObject.access in next(iter([x[2] for x in model]))
-    assert expectedObject.file == next(iter([x[3] for x in model]))
+    assert expectedObject.access in next(iter([x[1] for x in model]))
+    assert expectedObject.file == next(iter([x[2] for x in model]))
+    assert expectedObject.mode in next(iter([x[5] for x in model]))
 
 
 @pytest.mark.parametrize(
@@ -270,9 +275,9 @@ def test_loads_objects_from_acl(
     model = objectListView.get_model()
     expectedObject = mock_events()[0].object
     assert expectedObject.trust in next(iter([x[0] for x in model]))
-    assert expectedObject.mode in next(iter([x[1] for x in model]))
-    assert expectedObject.access in next(iter([x[2] for x in model]))
-    assert expectedObject.file == next(iter([x[3] for x in model]))
+    assert expectedObject.access in next(iter([x[1] for x in model]))
+    assert expectedObject.file == next(iter([x[2] for x in model]))
+    assert expectedObject.mode in next(iter([x[5] for x in model]))
 
 
 @pytest.mark.parametrize(

--- a/fapolicy_analyzer/tests/test_system_trust_database_admin.py
+++ b/fapolicy_analyzer/tests/test_system_trust_database_admin.py
@@ -1,20 +1,23 @@
-import context  # noqa: F401
-import pytest
 import gi
+import pytest
+
+import context  # noqa: F401
 
 gi.require_version("Gtk", "3.0")
-from callee import InstanceOf, Attrs
+from unittest.mock import MagicMock
+
+from callee import Attrs, InstanceOf
 from callee.strings import Regex
 from gi.repository import Gtk
-from mocks import mock_System, mock_trust
 from redux import Action
 from rx.subject import Subject
-from unittest.mock import MagicMock
 from ui.actions import ADD_NOTIFICATION, NotificationType
 from ui.configs import Colors
-from ui.strings import SYSTEM_TRUST_LOAD_ERROR
 from ui.store import init_store
+from ui.strings import SYSTEM_TRUST_LOAD_ERROR, SYSTEM_TRUSTED_FILE_MESSAGE
 from ui.system_trust_database_admin import SystemTrustDatabaseAdmin
+
+from mocks import mock_System, mock_trust
 
 
 @pytest.fixture()
@@ -67,7 +70,9 @@ def test_updates_trust_details(widget, mocker):
     widget.trustFileDetails.set_on_file_system_view.assert_called_with(
         Regex(r"stat: cannot statx? '/tmp/foo': No such file or directory\nSHA256: abc")
     )
-    widget.trustFileDetails.set_trust_status.assert_called_with("This file is trusted.")
+    widget.trustFileDetails.set_trust_status.assert_called_with(
+        SYSTEM_TRUSTED_FILE_MESSAGE
+    )
 
 
 def test_disables_add_button(widget):

--- a/fapolicy_analyzer/tests/test_trust_reconciliation_dialog.py
+++ b/fapolicy_analyzer/tests/test_trust_reconciliation_dialog.py
@@ -1,0 +1,152 @@
+import gi
+import pytest
+
+import context  # noqa: F401
+
+gi.require_version("Gtk", "3.0")
+from unittest.mock import MagicMock
+
+from gi.repository import Gtk
+from ui.strings import (
+    ANCILLARY_DISCREPANCY_FILE_MESSAGE,
+    ANCILLARY_TRUSTED_FILE_MESSAGE,
+    ANCILLARY_UNKNOWN_FILE_MESSAGE,
+    SYSTEM_DISCREPANCY_FILE_MESSAGE,
+    SYSTEM_TRUSTED_FILE_MESSAGE,
+    SYSTEM_UNKNOWN_FILE_MESSAGE,
+    UNKNOWN_FILE_MESSAGE,
+)
+from ui.trust_reconciliation_dialog import TrustReconciliationDialog
+
+
+@pytest.fixture
+def patch(mocker):
+    mocker.patch("ui.trust_reconciliation_dialog.fs.sha", return_value="abc")
+
+
+@pytest.fixture
+def mockTrustDetailsWidget(mocker):
+    mock = MagicMock(
+        set_in_database_view=MagicMock(),
+        set_on_file_system_view=MagicMock(),
+        set_trust_status=MagicMock(),
+        get_ref=MagicMock(return_value=Gtk.Box()),
+    )
+    mocker.patch(
+        "ui.trust_reconciliation_dialog.TrustFileDetails",
+        return_value=mock,
+    )
+    return mock
+
+
+@pytest.mark.usefixtures("patch")
+def test_creates_widget():
+    widget = TrustReconciliationDialog(MagicMock())
+    assert type(widget.get_ref()) is Gtk.Dialog
+
+
+@pytest.mark.usefixtures("patch")
+def test_adds_dialog_to_parent():
+    parent = Gtk.Window()
+    widget = TrustReconciliationDialog(MagicMock(), parent=parent)
+    assert widget.get_ref().get_transient_for() == parent
+
+
+@pytest.mark.usefixtures("patch")
+def test_shows_in_database_data(mockTrustDetailsWidget):
+    mockTrustObj = MagicMock(file="foo")
+    mockDatabaseTrust = MagicMock(size=1, hash="abc", status="T")
+    TrustReconciliationDialog(mockTrustObj, databaseTrust=mockDatabaseTrust)
+    mockTrustDetailsWidget.set_in_database_view.assert_called_once_with(
+        """FILE: foo
+SIZE: 1
+SHA256: abc"""
+    )
+
+
+@pytest.mark.usefixtures("patch")
+def test_handles_empty_database_data(mockTrustDetailsWidget):
+    mockTrustObj = MagicMock(file="foo")
+    TrustReconciliationDialog(mockTrustObj)
+    mockTrustDetailsWidget.set_in_database_view.assert_called_once_with(
+        """FILE: foo
+SIZE: Unknown
+SHA256: Unknown"""
+    )
+
+
+@pytest.mark.usefixtures("patch")
+def test_shows_on_system_data(mockTrustDetailsWidget, mocker):
+    mockTrustObj = MagicMock(file="foo")
+    mockDatabaseTrust = MagicMock(size=1, hash="abc", status="T")
+    mocker.patch(
+        "ui.trust_reconciliation_dialog.fs.stat", return_value="foo file stats"
+    )
+    TrustReconciliationDialog(mockTrustObj, databaseTrust=mockDatabaseTrust)
+    mockTrustDetailsWidget.set_on_file_system_view.assert_called_once_with(
+        """foo file stats
+SHA256: abc"""
+    )
+
+
+@pytest.mark.usefixtures("patch")
+@pytest.mark.parametrize(
+    "trust, status, message",
+    [
+        ("st", "t", SYSTEM_TRUSTED_FILE_MESSAGE),
+        ("st", "d", SYSTEM_DISCREPANCY_FILE_MESSAGE),
+        ("st", "foo", SYSTEM_UNKNOWN_FILE_MESSAGE),
+        ("at", "t", ANCILLARY_TRUSTED_FILE_MESSAGE),
+        ("at", "d", ANCILLARY_DISCREPANCY_FILE_MESSAGE),
+        ("at", "foo", ANCILLARY_UNKNOWN_FILE_MESSAGE),
+        ("u", "foo", UNKNOWN_FILE_MESSAGE),
+        ("baz", "foo", UNKNOWN_FILE_MESSAGE),
+    ],
+)
+def test_shows_trust_message(mockTrustDetailsWidget, trust, status, message):
+    mockTrustObj = MagicMock(trust=trust)
+    mockDatabaseTrust = MagicMock(status=status)
+    TrustReconciliationDialog(mockTrustObj, databaseTrust=mockDatabaseTrust)
+    mockTrustDetailsWidget.set_trust_status.assert_called_once_with(message)
+
+
+@pytest.mark.usefixtures("patch")
+@pytest.mark.parametrize(
+    "trust, status, visible",
+    [
+        ("st", "t", False),
+        ("st", "d", True),
+        ("st", "foo", True),
+        ("at", "t", False),
+        ("at", "d", True),
+        ("at", "foo", True),
+        ("u", "foo", True),
+        ("baz", "foo", True),
+    ],
+)
+def test_sets_trust_button_visiblity(trust, status, visible):
+    mockTrustObj = MagicMock(trust=trust)
+    mockDatabaseTrust = MagicMock(status=status)
+    widget = TrustReconciliationDialog(mockTrustObj, databaseTrust=mockDatabaseTrust)
+    assert widget.get_object("trustBtn").get_visible() == visible
+
+
+@pytest.mark.usefixtures("patch")
+@pytest.mark.parametrize(
+    "trust, status, visible",
+    [
+        ("st", "t", False),
+        ("st", "d", False),
+        ("st", "foo", False),
+        ("at", "t", True),
+        ("at", "d", False),
+        ("at", "foo", False),
+        ("u", "foo", False),
+        ("baz", "foo", False),
+    ],
+)
+def test_sets_untrust_button_visiblity(trust, status, visible):
+    mockTrustObj = MagicMock(trust=trust)
+    mockDatabaseTrust = MagicMock(status=status)
+    widget = TrustReconciliationDialog(mockTrustObj, databaseTrust=mockDatabaseTrust)
+    assert widget.get_object("untrustBtn").get_visible() == visible

--- a/fapolicy_analyzer/ui/acl_list.py
+++ b/fapolicy_analyzer/ui/acl_list.py
@@ -2,6 +2,7 @@ import gi
 
 gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk
+
 from .searchable_list import SearchableList
 
 
@@ -21,7 +22,7 @@ class ACLList(SearchableList):
         lbl = self.label if count == 1 else self.label_plural
         self.treeCount.set_text(" ".join([str(count), lbl or ""]).strip())
 
-    def load_store(self, acls):
+    def load_store(self, acls, **kwargs):
         store = Gtk.ListStore(str, int)
 
         for acl in acls:

--- a/fapolicy_analyzer/ui/ancillary_trust_database_admin.py
+++ b/fapolicy_analyzer/ui/ancillary_trust_database_admin.py
@@ -1,21 +1,24 @@
-import gi
 import logging
+
 import fapolicy_analyzer.ui.strings as strings
+import gi
 
 gi.require_version("Gtk", "3.0")
-from gi.repository import Gtk
-from fapolicy_analyzer import Changeset, Trust
 from locale import gettext as _
+
+from fapolicy_analyzer import Changeset, Trust
 from fapolicy_analyzer.util import fs  # noqa: F401
-from fapolicy_analyzer.util.format import f
 from fapolicy_analyzer.util.fapd_dbase import fapd_dbase_snapshot
+from fapolicy_analyzer.util.format import f
+from gi.repository import Gtk
+
 from .actions import (
-    apply_changesets,
-    add_notification,
-    clear_changesets,
     NotificationType,
-    request_ancillary_trust,
+    add_notification,
+    apply_changesets,
+    clear_changesets,
     deploy_ancillary_trust,
+    request_ancillary_trust,
     set_system_checkpoint,
 )
 from .ancillary_trust_file_list import AncillaryTrustFileList
@@ -112,11 +115,11 @@ SHA256: {fs.sha(trust.path)}"""
             )
 
             self.trustFileDetails.set_trust_status(
-                strings.TRUSTED_FILE_MESSAGE
+                strings.ANCILLARY_TRUSTED_FILE_MESSAGE
                 if trusted
-                else strings.DISCREPANCY_FILE_MESSAGE
+                else strings.ANCILLARY_DISCREPANCY_FILE_MESSAGE
                 if status == "d"
-                else strings.UNKNOWN_FILE_MESSAGE
+                else strings.ANCILLARY_UNKNOWN_FILE_MESSAGE
             )
         else:
             trustBtn.set_sensitive(False)

--- a/fapolicy_analyzer/ui/object_list.py
+++ b/fapolicy_analyzer/ui/object_list.py
@@ -1,62 +1,24 @@
-import gi
 import fapolicy_analyzer.ui.strings as strings
+import gi
 
 gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk
-from .add_file_button import AddFileButton
+
 from .configs import Colors
-from .searchable_list import SearchableList
-from .strings import FILE_LABEL, FILES_LABEL
+from .subject_list import SubjectList
 
 
-class ObjectList(SearchableList):
-    def __init__(self):
-        self.__events__ = [
-            *super().__events__,
-            "object_selection_changed",
-        ]
-
-        add_button = AddFileButton()
-        add_button.files_added += lambda files: print(files)
-        add_button.get_ref().set_sensitive(False)  # disable for now in readonly-view
-
-        super().__init__(
-            self.__columns(),
-            add_button.get_ref(),
-            searchColumnIndex=3,
-            defaultSortIndex=3,
-        )
-
-        self.load_store([])
-        self.selection_changed += self.__handle_selection_changed
-
-    def __columns(self):
-        trustCell = Gtk.CellRendererText()
-        trustCell.set_property("background", "light gray")
-        trustColumn = Gtk.TreeViewColumn(
-            strings.FILE_LIST_TRUST_HEADER, trustCell, markup=0
-        )
-        trustColumn.set_sort_column_id(0)
+class ObjectList(SubjectList):
+    def _columns(self):
+        columns = super()._columns()
         modeCell = Gtk.CellRendererText()
         modeCell.set_property("background", "light gray")
         modeColumn = Gtk.TreeViewColumn(
-            strings.FILE_LIST_MODE_HEADER, modeCell, markup=1
+            strings.FILE_LIST_MODE_HEADER, modeCell, markup=5
         )
-        modeColumn.set_sort_column_id(1)
-        accessCell = Gtk.CellRendererText()
-        accessCell.set_property("background", "light gray")
-        accessColumn = Gtk.TreeViewColumn(
-            strings.FILE_LIST_ACCESS_HEADER, accessCell, markup=2
-        )
-        accessColumn.set_sort_column_id(2)
-        fileColumn = Gtk.TreeViewColumn(
-            strings.FILE_LIST_FILE_HEADER,
-            Gtk.CellRendererText(),
-            text=3,
-            cell_background=5,
-        )
-        fileColumn.set_sort_column_id(3)
-        return [trustColumn, modeColumn, accessColumn, fileColumn]
+        modeColumn.set_sort_column_id(5)
+        columns.insert(1, modeColumn)
+        return columns
 
     def __markup(self, value, options, seperator="/", multiValue=False):
         def wrap(x):
@@ -79,16 +41,10 @@ class ObjectList(SearchableList):
             else Colors.LIGHT_RED
         )
 
-    def __handle_selection_changed(self, data):
-        object = data[4] if data else None
-        self.object_selection_changed(object)
-
-    def _update_tree_count(self, count):
-        label = FILE_LABEL if count == 1 else FILES_LABEL
-        self.treeCount.set_text(" ".join([str(count), label]))
-
-    def load_store(self, objects):
-        store = Gtk.ListStore(str, str, str, str, object, str)
+    def load_store(self, objects, **kwargs):
+        self._systemTrust = kwargs.get("systemTrust", [])
+        self._ancillaryTrust = kwargs.get("ancillaryTrust", [])
+        store = Gtk.ListStore(str, str, str, object, str, str)
         for o in objects:
             status = self.__markup(o.trust.upper(), ["ST", "AT", "U"])
             mode = self.__markup(
@@ -99,6 +55,7 @@ class ObjectList(SearchableList):
             )
             access = self.__markup(o.access.upper(), ["A", "D"])
             bgColor = self.__color(o.access, o.mode)
-            store.append([status, mode, access, o.file, o, bgColor])
+            store.append([status, access, o.file, o, bgColor, mode])
 
-        super().load_store(store)
+        # call grandfather SearchableList's load_store method
+        super(SubjectList, self).load_store(store)

--- a/fapolicy_analyzer/ui/searchable_list.py
+++ b/fapolicy_analyzer/ui/searchable_list.py
@@ -3,6 +3,7 @@ import gi
 gi.require_version("Gtk", "3.0")
 from events import Events
 from gi.repository import Gtk
+
 from .loader import Loader
 from .ui_widget import UIBuilderWidget
 
@@ -49,7 +50,7 @@ class SearchableList(UIBuilderWidget, Events):
     def _update_tree_count(self, count):
         self.treeCount.set_text(str(count))
 
-    def load_store(self, store):
+    def load_store(self, store, **kwargs):
         def apply_prev_sort(model):
             if currentModel := self.treeView.get_model():
                 currentSort = currentModel.get_sort_column_id()

--- a/fapolicy_analyzer/ui/strings.py
+++ b/fapolicy_analyzer/ui/strings.py
@@ -1,5 +1,8 @@
 from locale import gettext as _
 
+FILE = _("FILE")
+SIZE = _("SIZE")
+
 SYSTEM_INITIALIZATION_ERROR = _("Error initializing System")
 ANCILLARY_TRUST_LOAD_ERROR = _("Error loading Ancillary Trust")
 SYSTEM_TRUST_LOAD_ERROR = _("Error loading System Trust")
@@ -16,9 +19,25 @@ DEPLOY_ANCILLARY_ERROR_MSG = _(
     "An error occurred trying to deploy the changes. Please try again."
 )
 
-TRUSTED_FILE_MESSAGE = _("This file is trusted.")
-DISCREPANCY_FILE_MESSAGE = _("There is a discrepancy with this file.")
-UNKNOWN_FILE_MESSAGE = _("The trust status of this file is unknown.")
+SYSTEM_TRUSTED_FILE_MESSAGE = _("This file is trusted in the System Trust Database.")
+SYSTEM_DISCREPANCY_FILE_MESSAGE = _(
+    "There is a discrepancy between this file and the System Trust Database."
+)
+SYSTEM_UNKNOWN_FILE_MESSAGE = _(
+    "The trust status of this file is unknown in the System Trust Database."
+)
+
+ANCILLARY_TRUSTED_FILE_MESSAGE = _(
+    "This file is trusted in the Ancillary Trust Database."
+)
+ANCILLARY_DISCREPANCY_FILE_MESSAGE = _(
+    "There is a discrepancy between this file and the Ancillary Trust Database."
+)
+ANCILLARY_UNKNOWN_FILE_MESSAGE = _(
+    "The trust status of this file is unknown in the Ancillary Trust Database."
+)
+
+UNKNOWN_FILE_MESSAGE = _("The trust status of this file is unknown")
 
 SYSTEM_TRUST_TAB_LABEL = _("System Trust Database")
 ANCILLARY_TRUST_TAB_LABEL = _("Ancillary Trust Database")

--- a/fapolicy_analyzer/ui/subject_list.py
+++ b/fapolicy_analyzer/ui/subject_list.py
@@ -1,19 +1,28 @@
-import gi
 import fapolicy_analyzer.ui.strings as strings
+import gi
 
 gi.require_version("Gtk", "3.0")
-from gi.repository import Gtk
+from fapolicy_analyzer import Changeset
+from gi.repository import Gdk, Gtk
+from more_itertools import first_true
+
+from .actions import apply_changesets
 from .add_file_button import AddFileButton
 from .configs import Colors
 from .searchable_list import SearchableList
+from .store import dispatch
 from .strings import FILE_LABEL, FILES_LABEL
+from .trust_reconciliation_dialog import TrustReconciliationDialog
+
+_UNTRUST_RESP = 0
+_TRUST_RESP = 1
 
 
 class SubjectList(SearchableList):
     def __init__(self):
         self.__events__ = [
             *super().__events__,
-            "subject_selection_changed",
+            "file_selection_changed",
         ]
 
         add_button = AddFileButton()
@@ -21,16 +30,31 @@ class SubjectList(SearchableList):
         add_button.get_ref().set_sensitive(False)  # disable for now in readonly-view
 
         super().__init__(
-            self.__columns(),
+            self._columns(),
             add_button.get_ref(),
             searchColumnIndex=2,
             defaultSortIndex=2,
         )
 
+        self._systemTrust = []
+        self._ancillaryTrust = []
+        self.contextMenu = self.__build_context_menu()
         self.load_store([])
         self.selection_changed += self.__handle_selection_changed
+        self.get_object("treeView").connect("row-activated", self.on_view_row_activated)
+        self.get_object("treeView").connect(
+            "button-press-event", self.on_view_button_press_event
+        )
 
-    def __columns(self):
+    def __build_context_menu(self):
+        menu = Gtk.Menu()
+        reconcileItem = Gtk.MenuItem.new_with_label("Reconcile File")
+        reconcileItem.connect("activate", self.on_reconcile_file_activate)
+        menu.append(reconcileItem)
+        menu.show_all()
+        return menu
+
+    def _columns(self):
         trustCell = Gtk.CellRendererText()
         trustCell.set_property("background", "light gray")
         trustColumn = Gtk.TreeViewColumn(
@@ -69,14 +93,46 @@ class SubjectList(SearchableList):
         )
 
     def __handle_selection_changed(self, data):
-        subject = data[3] if data else None
-        self.subject_selection_changed(subject)
+        fileObj = data[3] if data else None
+        self.file_selection_changed(fileObj)
+
+    def __show_reconciliation_dialog(self, subject):
+        def find_db_trust(subject):
+            trust = subject.trust.lower()
+            file = subject.file
+            trustList = (
+                self._systemTrust
+                if trust == "st"
+                else self._ancillaryTrust
+                if trust == "at"
+                else []
+            )
+            return first_true(trustList, pred=lambda x: x.path == file)
+
+        changeset = None
+        parent = self.get_ref().get_toplevel()
+        reconciliationDialog = TrustReconciliationDialog(
+            subject, databaseTrust=find_db_trust(subject), parent=parent
+        ).get_ref()
+        resp = reconciliationDialog.run()
+        reconciliationDialog.destroy()
+        if resp == _UNTRUST_RESP:
+            changeset = Changeset()
+            changeset.del_trust(subject.file)
+        elif resp == _TRUST_RESP:
+            changeset = Changeset()
+            changeset.add_trust(subject.file)
+
+        if changeset:
+            dispatch(apply_changesets(changeset))
 
     def _update_tree_count(self, count):
         label = FILE_LABEL if count == 1 else FILES_LABEL
         self.treeCount.set_text(" ".join([str(count), label]))
 
-    def load_store(self, subjects):
+    def load_store(self, subjects, **kwargs):
+        self._systemTrust = kwargs.get("systemTrust", [])
+        self._ancillaryTrust = kwargs.get("ancillaryTrust", [])
         store = Gtk.ListStore(str, str, str, object, str)
         for s in subjects:
             status = self.__markup(s.trust.upper(), ["ST", "AT", "U"])
@@ -85,3 +141,20 @@ class SubjectList(SearchableList):
             store.append([status, access, s.file, s, bgColor])
 
         super().load_store(store)
+
+    def on_view_row_activated(self, treeView, row, *args):
+        model = treeView.get_model()
+        iter_ = model.get_iter(row)
+        subject = model.get_value(iter_, 3)
+        self.__show_reconciliation_dialog(subject)
+
+    def on_view_button_press_event(self, widget, event):
+        if event.type == Gdk.EventType.BUTTON_PRESS and event.button == 3:
+            self.contextMenu.popup_at_pointer()
+
+    def on_reconcile_file_activate(self, *args):
+        treeView = self.get_object("treeView")
+        model, pathlist = treeView.get_selection().get_selected_rows()
+        iter_ = model.get_iter(next(iter(pathlist)))  # single select use first path
+        subject = model.get_value(iter_, 3)
+        self.__show_reconciliation_dialog(subject)

--- a/fapolicy_analyzer/ui/system_trust_database_admin.py
+++ b/fapolicy_analyzer/ui/system_trust_database_admin.py
@@ -1,18 +1,16 @@
 import logging
+from locale import gettext as _
+
 import fapolicy_analyzer.ui.strings as strings
 from events import Events
-from locale import gettext as _
-from fapolicy_analyzer.util.format import f
 from fapolicy_analyzer.util import fs  # noqa: F401
-from .actions import (
-    NotificationType,
-    add_notification,
-    request_system_trust,
-)
+from fapolicy_analyzer.util.format import f
+
+from .actions import NotificationType, add_notification, request_system_trust
 from .configs import Colors
 from .store import dispatch, get_system_feature
-from .trust_file_list import TrustFileList
 from .trust_file_details import TrustFileDetails
+from .trust_file_list import TrustFileList
 from .ui_widget import UIConnectedWidget
 
 
@@ -99,11 +97,11 @@ SHA256: {fs.sha(trust.path)}"""
                 )
             )
             self.trustFileDetails.set_trust_status(
-                strings.TRUSTED_FILE_MESSAGE
+                strings.SYSTEM_TRUSTED_FILE_MESSAGE
                 if trusted
-                else strings.DISCREPANCY_FILE_MESSAGE
+                else strings.SYSTEM_DISCREPANCY_FILE_MESSAGE
                 if status == "d"
-                else strings.UNKNOWN_FILE_MESSAGE
+                else strings.SYSTEM_UNKNOWN_FILE_MESSAGE
             )
         else:
             addBtn.set_sensitive(False)

--- a/fapolicy_analyzer/ui/trust_file_list.py
+++ b/fapolicy_analyzer/ui/trust_file_list.py
@@ -42,7 +42,7 @@ class TrustFileList(SearchableList):
         ]
 
         super().__init__(
-            self._columns(), *args, searchColumnIndex=1, defaultSortIndex=1
+            self._columns(), *args, searchColumnIndex=2, defaultSortIndex=2
         )
         self.trust_func = trust_func
         self.markup_func = markup_func

--- a/fapolicy_analyzer/ui/trust_reconciliation_dialog.py
+++ b/fapolicy_analyzer/ui/trust_reconciliation_dialog.py
@@ -1,0 +1,87 @@
+from collections import namedtuple
+
+from fapolicy_analyzer.ui.strings import (
+    ANCILLARY_DISCREPANCY_FILE_MESSAGE,
+    ANCILLARY_TRUSTED_FILE_MESSAGE,
+    ANCILLARY_UNKNOWN_FILE_MESSAGE,
+    FILE,
+    SIZE,
+    SYSTEM_DISCREPANCY_FILE_MESSAGE,
+    SYSTEM_TRUSTED_FILE_MESSAGE,
+    SYSTEM_UNKNOWN_FILE_MESSAGE,
+    UNKNOWN_FILE_MESSAGE,
+)
+from fapolicy_analyzer.ui.trust_file_details import TrustFileDetails
+from fapolicy_analyzer.ui.ui_widget import UIBuilderWidget
+from fapolicy_analyzer.util import fs  # noqa: F401
+
+_MESSAGES = {
+    "st": {
+        "t": SYSTEM_TRUSTED_FILE_MESSAGE,
+        "d": SYSTEM_DISCREPANCY_FILE_MESSAGE,
+        "unknown": SYSTEM_UNKNOWN_FILE_MESSAGE,
+    },
+    "at": {
+        "t": ANCILLARY_TRUSTED_FILE_MESSAGE,
+        "d": ANCILLARY_DISCREPANCY_FILE_MESSAGE,
+        "unknown": ANCILLARY_UNKNOWN_FILE_MESSAGE,
+    },
+    "u": {"unknown": UNKNOWN_FILE_MESSAGE},
+}
+
+
+class TrustReconciliationDialog(UIBuilderWidget):
+    def __init__(self, trustObj, databaseTrust=None, parent=None):
+        super().__init__()
+        if parent:
+            self.get_ref().set_transient_for(parent)
+
+        trustFileDetails = self.__load_details(trustObj, databaseTrust)
+        self.get_object("content").add(trustFileDetails.get_ref())
+
+    def __load_details(self, trustObj, databaseTrust):
+        def set_btn_visibility(trust=False, untrust=False):
+            self.get_object("trustBtn").set_visible(trust)
+            self.get_object("untrustBtn").set_visible(untrust)
+
+        def get_db_details_or_defaults():
+            DBDetails = namedtuple("details", "size, hash, status")
+            return (
+                DBDetails(
+                    databaseTrust.size, databaseTrust.hash, databaseTrust.status.lower()
+                )
+                if databaseTrust
+                else DBDetails(None, None, "unknown")
+            )
+
+        trustFileDetails = TrustFileDetails()
+        dbDetails = get_db_details_or_defaults()
+
+        trustFileDetails.set_in_database_view(
+            f"""{FILE}: {trustObj.file}
+{SIZE}: {dbDetails.size or 'Unknown'}
+SHA256: {dbDetails.hash or 'Unknown'}"""
+        )
+
+        trustFileDetails.set_on_file_system_view(
+            f"""{fs.stat(trustObj.file)}
+SHA256: {fs.sha(trustObj.file)}"""
+        )
+
+        # set status message of file
+        trust = trustObj.trust.lower()
+        trustMsgs = _MESSAGES.get(trust, _MESSAGES["u"])
+        statusMsg = trustMsgs.get(dbDetails.status) or trustMsgs["unknown"]
+        trustFileDetails.set_trust_status(statusMsg)
+
+        # set available buttons
+        if trust == "st":
+            set_btn_visibility(trust=dbDetails.status != "t")
+        elif trust == "at":
+            set_btn_visibility(
+                trust=dbDetails.status != "t", untrust=dbDetails.status == "t"
+            )
+        else:
+            set_btn_visibility(trust=True)
+
+        return trustFileDetails

--- a/scripts/rpm/fapolicy-analyzer.spec.j2
+++ b/scripts/rpm/fapolicy-analyzer.spec.j2
@@ -12,7 +12,7 @@ Source0: %{url}/archive/%{git_commit}/%{name}-%{git_commit}.tar.gz
 BuildArch:      x86_64
 Requires:       {{ pyrpm }} >= 3.9
 BuildRequires:  {{ pyrpm }} >= 3.9, {{ pyrpm }}-rpm-macros, {{ pyrpm }}-devel, {{ pyrpm }}-pip, {{ pyrpm }}-wheel
-Recommends:     {{ pyrpm }}-gobject, {{ pyrpm }}-events, {{ pyrpm }}-configargparse
+Recommends:     {{ pyrpm }}-gobject, {{ pyrpm }}-events, {{ pyrpm }}-configargparse, {{ pyrpm }}-more-itertools
 Requires:       gtk3, dbus-libs
 BuildRequires:  dbus-devel, cargo
 AutoReqProv:    no


### PR DESCRIPTION
Adds a trust reconciliation dialog to the Policy Event Analysis tool.  It can be opened by either double clicking a subject or object, or right clicking it and selecting `Reconcile` from the context menu.  The dialog uses the following rules:

* If the file is trusted in the system DB it is view only
* if the file is untrusted in the system DB or the ancillary DB you can Trust it
* if the file is trusted in the ancillary DB you can Untrust it
* if the file is unknown you can Trust it

These will generate changesets that can then be applied by going to the ADTA tool and deploying. Eventually the deploy will be available from the toolbar we talked about.

closes #316 