### PR TITLE
Added an application toolbar with deploy button

### DIFF
--- a/fapolicy_analyzer/glade/main_window.glade
+++ b/fapolicy_analyzer/glade/main_window.glade
@@ -54,7 +54,7 @@
             <property name="can-focus">False</property>
             <property name="orientation">vertical</property>
             <child>
-              <object class="GtkMenuBar">
+              <object class="GtkMenuBar" id="mainMenu">
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
                 <child>
@@ -183,6 +183,32 @@
               </packing>
             </child>
             <child>
+              <object class="GtkToolbar" id="toolbar">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <child>
+                  <object class="GtkToolButton" id="deployChanges">
+                    <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                    <property name="tooltip-text" translatable="yes">Deploy Changes</property>
+                    <property name="label" translatable="yes">Deploy</property>
+                    <property name="use-underline">True</property>
+                    <property name="icon-name">system-software-update</property>
+                    <signal name="clicked" handler="on_deployChanges_clicked" swapped="no"/>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="homogeneous">True</property>
+                  </packing>
+                </child>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+            <child>
               <object class="GtkBox" id="mainContent">
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
@@ -194,7 +220,7 @@
               <packing>
                 <property name="expand">True</property>
                 <property name="fill">True</property>
-                <property name="position">1</property>
+                <property name="position">2</property>
               </packing>
             </child>
           </object>

--- a/fapolicy_analyzer/glade/main_window.glade
+++ b/fapolicy_analyzer/glade/main_window.glade
@@ -189,6 +189,7 @@
                 <child>
                   <object class="GtkToolButton" id="deployChanges">
                     <property name="visible">True</property>
+                    <property name="sensitive">False</property>
                     <property name="can-focus">False</property>
                     <property name="tooltip-text" translatable="yes">Deploy Changes</property>
                     <property name="label" translatable="yes">Deploy</property>

--- a/fapolicy_analyzer/tests/operations/test_deploy_changesets_op.py
+++ b/fapolicy_analyzer/tests/operations/test_deploy_changesets_op.py
@@ -1,0 +1,250 @@
+import fapolicy_analyzer.tests.context  # noqa: F401 # isort: skip
+from unittest.mock import MagicMock, patch
+
+import gi
+import pytest
+from callee import InstanceOf
+from callee.attributes import Attrs
+from fapolicy_analyzer.ui.actions import (
+    ADD_NOTIFICATION,
+    CLEAR_CHANGESETS,
+    DEPLOY_ANCILLARY_TRUST,
+    RESTORE_SYSTEM_CHECKPOINT,
+    SET_SYSTEM_CHECKPOINT,
+    NotificationType,
+)
+from fapolicy_analyzer.ui.operations.deploy_changesets_op import DeployChangesetsOp
+from fapolicy_analyzer.ui.store import init_store
+from fapolicy_analyzer.ui.strings import (
+    DEPLOY_ANCILLARY_ERROR_MSG,
+    DEPLOY_ANCILLARY_SUCCESSFUL_MSG,
+)
+from mocks import mock_System, mock_trust
+from redux import Action
+from rx.subject import Subject
+
+gi.require_version("Gtk", "3.0")
+from gi.repository import Gtk  # isort: skip
+
+
+@pytest.fixture()
+def mock_dispatch(mocker):
+    return mocker.patch("fapolicy_analyzer.ui.operations.deploy_changesets_op.dispatch")
+
+
+@pytest.fixture
+def operation(mock_dispatch):
+    init_store(mock_System())
+    yield (op := DeployChangesetsOp(Gtk.Window()))
+    op.dispose()
+
+
+@pytest.fixture
+def confirm_dialog(confirm_resp, mocker):
+    mock_confirm_dialog = MagicMock(
+        run=MagicMock(return_value=confirm_resp),
+        hide=MagicMock(),
+        get_save_state=MagicMock(return_value=False),
+    )
+    mocker.patch(
+        "fapolicy_analyzer.ui.operations.deploy_changesets_op.ConfirmInfoDialog",
+        return_value=mock_confirm_dialog,
+    )
+
+    return mock_confirm_dialog
+
+
+@pytest.fixture
+def revert_dialog(revert_resp, mocker):
+    mock_revert_dialog = MagicMock(
+        run=MagicMock(return_value=revert_resp), hide=MagicMock()
+    )
+    mocker.patch(
+        "fapolicy_analyzer.ui.operations.deploy_changesets_op.DeployConfirmDialog.get_ref",
+        return_value=mock_revert_dialog,
+    )
+    return mock_revert_dialog
+
+
+@pytest.mark.parametrize("confirm_resp", [Gtk.ResponseType.YES])
+@pytest.mark.parametrize("revert_resp", [Gtk.ResponseType.NO])
+@pytest.mark.usefixtures("revert_dialog")
+def test_on_confirm_deployment(operation, confirm_dialog, mock_dispatch):
+    operation.deploy([])
+    mock_dispatch.assert_called_with(
+        InstanceOf(Action) & Attrs(type=DEPLOY_ANCILLARY_TRUST)
+    )
+    confirm_dialog.run.assert_called()
+    confirm_dialog.hide.assert_called()
+
+
+@pytest.mark.usefixtures("confirm_dialog")
+@pytest.mark.parametrize("confirm_resp", [Gtk.ResponseType.YES])
+def test_deploy_w_exception(mock_dispatch, mocker):
+    system_features_mock = Subject()
+    mocker.patch(
+        "fapolicy_analyzer.ui.operations.deploy_changesets_op.get_system_feature",
+        return_value=system_features_mock,
+    )
+    init_store(mock_System())
+    with DeployChangesetsOp(Gtk.Window()) as operation:
+        system_features_mock.on_next(
+            {
+                "changesets": [],
+                "ancillary_trust": MagicMock(
+                    trust=[mock_trust()], error=None, loading=False
+                ),
+            }
+        )
+        operation.deploy([])
+        system_features_mock.on_next(
+            {"changesets": [], "ancillary_trust": MagicMock(error="foo")}
+        )
+    mock_dispatch.assert_any_call(
+        InstanceOf(Action)
+        & Attrs(
+            type=ADD_NOTIFICATION,
+            payload=Attrs(type=NotificationType.ERROR, text=DEPLOY_ANCILLARY_ERROR_MSG),
+        )
+    )
+
+
+@pytest.mark.parametrize("confirm_resp", [Gtk.ResponseType.NO])
+def test_on_neg_confirm_deployment(confirm_dialog, mock_dispatch, mocker):
+    system_features_mock = Subject()
+    mocker.patch(
+        "fapolicy_analyzer.ui.operations.deploy_changesets_op.get_system_feature",
+        return_value=system_features_mock,
+    )
+    init_store(mock_System())
+    with DeployChangesetsOp(Gtk.Window()) as operation:
+        system_features_mock.on_next(
+            {
+                "changesets": [],
+                "ancillary_trust": MagicMock(trust=[mock_trust()], error=None),
+            }
+        )
+        operation.deploy([])
+    confirm_dialog.run.assert_called()
+    confirm_dialog.hide.assert_called()
+    mock_dispatch.assert_not_any_call(
+        InstanceOf(Action) & Attrs(type=DEPLOY_ANCILLARY_TRUST)
+    )
+
+
+@pytest.mark.parametrize("confirm_resp", [Gtk.ResponseType.YES])
+@pytest.mark.parametrize("revert_resp", [Gtk.ResponseType.NO])
+@pytest.mark.usefixtures("confirm_dialog", "revert_dialog")
+def test_on_revert_deployment(mock_dispatch, mocker):
+    system_features_mock = Subject()
+    mocker.patch(
+        "fapolicy_analyzer.ui.operations.deploy_changesets_op.get_system_feature",
+        return_value=system_features_mock,
+    )
+    init_store(mock_System())
+    with DeployChangesetsOp(Gtk.Window()) as operation:
+        system_features_mock.on_next(
+            {
+                "changesets": [],
+                "ancillary_trust": MagicMock(trust=[mock_trust()], error=None),
+            }
+        )
+        operation.deploy([])
+        system_features_mock.on_next(
+            {
+                "changesets": [],
+                "ancillary_trust": MagicMock(trust=[mock_trust()], error=None),
+            }
+        )
+    mock_dispatch.assert_any_call(
+        InstanceOf(Action)
+        & Attrs(
+            type=ADD_NOTIFICATION,
+            payload=Attrs(
+                type=NotificationType.SUCCESS, text=DEPLOY_ANCILLARY_SUCCESSFUL_MSG
+            ),
+        )
+    )
+    mock_dispatch.assert_any_call(
+        InstanceOf(Action) & Attrs(type=RESTORE_SYSTEM_CHECKPOINT)
+    )
+    # mock_dispatch.assert_not_any_call(
+    #     InstanceOf(Action) & Attrs(type=SET_SYSTEM_CHECKPOINT)
+    # )
+    # mock_dispatch.assert_not_any_call(InstanceOf(Action) & Attrs(type=CLEAR_CHANGESETS))
+
+
+@pytest.mark.parametrize("confirm_resp", [Gtk.ResponseType.YES])
+@pytest.mark.parametrize("revert_resp", [Gtk.ResponseType.YES])
+@pytest.mark.usefixtures("confirm_dialog", "revert_dialog")
+def test_on_neg_revert_deployment(mock_dispatch, mocker):
+    system_features_mock = Subject()
+    mocker.patch(
+        "fapolicy_analyzer.ui.operations.deploy_changesets_op.get_system_feature",
+        return_value=system_features_mock,
+    )
+    init_store(mock_System())
+    with DeployChangesetsOp(Gtk.Window()) as operation:
+        system_features_mock.on_next(
+            {
+                "changesets": [],
+                "ancillary_trust": MagicMock(trust=[mock_trust()], error=None),
+            }
+        )
+        operation.deploy([])
+        system_features_mock.on_next(
+            {
+                "changesets": [],
+                "ancillary_trust": MagicMock(trust=[mock_trust()], error=None),
+            }
+        )
+    mock_dispatch.assert_any_call(
+        InstanceOf(Action)
+        & Attrs(
+            type=ADD_NOTIFICATION,
+            payload=Attrs(
+                type=NotificationType.SUCCESS, text=DEPLOY_ANCILLARY_SUCCESSFUL_MSG
+            ),
+        )
+    )
+    mock_dispatch.assert_any_call(
+        InstanceOf(Action) & Attrs(type=SET_SYSTEM_CHECKPOINT)
+    )
+    mock_dispatch.assert_any_call(InstanceOf(Action) & Attrs(type=CLEAR_CHANGESETS))
+
+
+@pytest.mark.usefixtures("confirm_dialog")
+@pytest.mark.parametrize("confirm_resp", [Gtk.ResponseType.YES])
+def test_handle_deploy_exception(operation):
+    with patch("fapolicy_analyzer.System") as mock:
+        mock.deploy = MagicMock(
+            return_value=None, side_effect=Exception("mocked error")
+        )
+        operation.system = mock
+        with pytest.raises(Exception) as excinfo:
+            operation.deploy([])
+            assert excinfo.value.message == "mocked error"
+
+
+@pytest.mark.usefixtures("mock_dispatch")
+def test_saves_state(operation, mocker):
+    mocker.patch(
+        "fapolicy_analyzer.ui.operations.deploy_changesets_op.ConfirmInfoDialog",
+        return_value=MagicMock(
+            run=MagicMock(return_value=Gtk.ResponseType.YES),
+            get_save_state=MagicMock(return_value=True),
+        ),
+    )
+    mocker.patch(
+        "fapolicy_analyzer.ui.operations.deploy_changesets_op._FapdArchiveFileChooserDialog.run",
+        return_value=Gtk.ResponseType.OK,
+    )
+    mocker.patch(
+        "fapolicy_analyzer.ui.operations.deploy_changesets_op._FapdArchiveFileChooserDialog.get_filename",
+        return_value="fooFile",
+    )
+    mockSnapshot = mocker.patch(
+        "fapolicy_analyzer.ui.operations.deploy_changesets_op.fapd_dbase_snapshot"
+    )
+    operation.deploy([])
+    mockSnapshot.assert_called_once_with("fooFile")

--- a/fapolicy_analyzer/tests/operations/test_deploy_changesets_op.py
+++ b/fapolicy_analyzer/tests/operations/test_deploy_changesets_op.py
@@ -1,4 +1,4 @@
-import fapolicy_analyzer.tests.context  # noqa: F401 # isort: skip
+import context  # noqa: F401 # isort: skip
 from unittest.mock import MagicMock, patch
 
 import gi

--- a/fapolicy_analyzer/tests/test_ancillary_trust_database_admin.py
+++ b/fapolicy_analyzer/tests/test_ancillary_trust_database_admin.py
@@ -1,24 +1,18 @@
+import context  # noqa: F401 # isort: skip
+from unittest.mock import MagicMock
+
 import gi
 import pytest
-
-import context  # noqa: F401
-
-gi.require_version("Gtk", "3.0")
-from unittest.mock import MagicMock, patch
-
-from callee import Attrs, InstanceOf, Sequence
+from callee import InstanceOf
+from callee.attributes import Attrs
+from callee.collections import Sequence
 from fapolicy_analyzer import Changeset, Trust
-from gi.repository import Gtk
 from redux import Action
 from rx.subject import Subject
 from ui.actions import (
     ADD_NOTIFICATION,
     APPLY_CHANGESETS,
-    CLEAR_CHANGESETS,
-    DEPLOY_ANCILLARY_TRUST,
     REQUEST_ANCILLARY_TRUST,
-    RESTORE_SYSTEM_CHECKPOINT,
-    SET_SYSTEM_CHECKPOINT,
     NotificationType,
 )
 from ui.ancillary_trust_database_admin import AncillaryTrustDatabaseAdmin
@@ -27,11 +21,12 @@ from ui.strings import (
     ANCILLARY_TRUST_LOAD_ERROR,
     ANCILLARY_TRUSTED_FILE_MESSAGE,
     ANCILLARY_UNKNOWN_FILE_MESSAGE,
-    DEPLOY_ANCILLARY_ERROR_MSG,
-    DEPLOY_ANCILLARY_SUCCESSFUL_MSG,
 )
 
-from mocks import mock_System, mock_trust
+from mocks import mock_System
+
+gi.require_version("Gtk", "3.0")
+from gi.repository import Gtk  # isort: skip
 
 
 @pytest.fixture()
@@ -44,43 +39,6 @@ def widget(mock_dispatch, mocker):
     mocker.patch("ui.ancillary_trust_database_admin.fs.sha", return_value="abc")
     init_store(mock_System())
     return AncillaryTrustDatabaseAdmin()
-
-
-@pytest.fixture
-def confirm_dialog(confirm_resp, mocker):
-    mock_confirm_dialog = MagicMock(
-        run=MagicMock(return_value=confirm_resp),
-        hide=MagicMock(),
-        get_save_state=MagicMock(return_value=False),
-    )
-    mocker.patch(
-        "ui.ancillary_trust_database_admin.ConfirmInfoDialog",
-        return_value=mock_confirm_dialog,
-    )
-
-    mocker.patch(
-        "ui.trust_file_list.epoch_to_string",
-        return_value="10-01-2020",
-    )
-
-    mocker.patch(
-        "ui.ancillary_trust_file_list.epoch_to_string",
-        return_value="10-01-2020",
-    )
-
-    return mock_confirm_dialog
-
-
-@pytest.fixture
-def revert_dialog(revert_resp, mocker):
-    mock_revert_dialog = MagicMock(
-        run=MagicMock(return_value=revert_resp), hide=MagicMock()
-    )
-    mocker.patch(
-        "ui.ancillary_trust_database_admin.DeployConfirmDialog.get_ref",
-        return_value=mock_revert_dialog,
-    )
-    return mock_revert_dialog
 
 
 def test_creates_widget(widget):
@@ -135,149 +93,6 @@ def test_clears_trust_details(widget, mocker):
     assert not trustBtn.get_sensitive()
     assert not untrustBtn.get_sensitive()
     widget.trustFileDetails.clear.assert_called()
-
-
-@pytest.mark.parametrize("confirm_resp", [Gtk.ResponseType.YES])
-@pytest.mark.parametrize("revert_resp", [Gtk.ResponseType.NO])
-@pytest.mark.usefixtures("revert_dialog")
-def test_on_confirm_deployment(widget, confirm_dialog, mock_dispatch):
-    widget.get_object("deployBtn").clicked()
-    mock_dispatch.assert_called_with(
-        InstanceOf(Action) & Attrs(type=DEPLOY_ANCILLARY_TRUST)
-    )
-    confirm_dialog.run.assert_called()
-    confirm_dialog.hide.assert_called()
-
-
-@pytest.mark.usefixtures("confirm_dialog")
-@pytest.mark.parametrize("confirm_resp", [Gtk.ResponseType.YES])
-def test_on_deployment_w_exception(mock_dispatch, mocker):
-    system_features_mock = Subject()
-    mocker.patch(
-        "ui.ancillary_trust_database_admin.get_system_feature",
-        return_value=system_features_mock,
-    )
-    init_store(mock_System())
-    widget = AncillaryTrustDatabaseAdmin()
-    system_features_mock.on_next(
-        {
-            "changesets": [],
-            "ancillary_trust": MagicMock(
-                trust=[mock_trust()], error=None, loading=False
-            ),
-        }
-    )
-    widget.get_object("deployBtn").clicked()
-    system_features_mock.on_next(
-        {"changesets": [], "ancillary_trust": MagicMock(error="foo")}
-    )
-    mock_dispatch.assert_any_call(
-        InstanceOf(Action)
-        & Attrs(
-            type=ADD_NOTIFICATION,
-            payload=Attrs(type=NotificationType.ERROR, text=DEPLOY_ANCILLARY_ERROR_MSG),
-        )
-    )
-
-
-@pytest.mark.parametrize("confirm_resp", [Gtk.ResponseType.NO])
-def test_on_neg_confirm_deployment(confirm_dialog, mock_dispatch, mocker):
-    system_features_mock = Subject()
-    mocker.patch(
-        "ui.ancillary_trust_database_admin.get_system_feature",
-        return_value=system_features_mock,
-    )
-    init_store(mock_System())
-    widget = AncillaryTrustDatabaseAdmin()
-    system_features_mock.on_next(
-        {
-            "changesets": [],
-            "ancillary_trust": MagicMock(trust=[mock_trust()], error=None),
-        }
-    )
-    widget.get_object("deployBtn").clicked()
-    confirm_dialog.run.assert_called()
-    confirm_dialog.hide.assert_called()
-    mock_dispatch.assert_not_any_call(
-        InstanceOf(Action) & Attrs(type=DEPLOY_ANCILLARY_TRUST)
-    )
-
-
-@pytest.mark.parametrize("confirm_resp", [Gtk.ResponseType.YES])
-@pytest.mark.parametrize("revert_resp", [Gtk.ResponseType.NO])
-@pytest.mark.usefixtures("confirm_dialog", "revert_dialog")
-def test_on_revert_deployment(mock_dispatch, mocker):
-    system_features_mock = Subject()
-    mocker.patch(
-        "ui.ancillary_trust_database_admin.get_system_feature",
-        return_value=system_features_mock,
-    )
-    init_store(mock_System())
-    widget = AncillaryTrustDatabaseAdmin()
-    system_features_mock.on_next(
-        {
-            "changesets": [],
-            "ancillary_trust": MagicMock(trust=[mock_trust()], error=None),
-        }
-    )
-    widget.get_object("deployBtn").clicked()
-    system_features_mock.on_next(
-        {
-            "changesets": [],
-            "ancillary_trust": MagicMock(trust=[mock_trust()], error=None),
-        }
-    )
-    mock_dispatch.assert_any_call(
-        InstanceOf(Action)
-        & Attrs(
-            type=ADD_NOTIFICATION,
-            payload=Attrs(
-                type=NotificationType.SUCCESS, text=DEPLOY_ANCILLARY_SUCCESSFUL_MSG
-            ),
-        )
-    )
-    mock_dispatch.assert_any_call(
-        InstanceOf(Action) & Attrs(type=RESTORE_SYSTEM_CHECKPOINT)
-    )
-
-
-@pytest.mark.parametrize("confirm_resp", [Gtk.ResponseType.YES])
-@pytest.mark.parametrize("revert_resp", [Gtk.ResponseType.YES])
-@pytest.mark.usefixtures("confirm_dialog", "revert_dialog")
-def test_on_neg_revert_deployment(mock_dispatch, mocker):
-    system_features_mock = Subject()
-    mocker.patch(
-        "ui.ancillary_trust_database_admin.get_system_feature",
-        return_value=system_features_mock,
-    )
-    init_store(mock_System())
-    widget = AncillaryTrustDatabaseAdmin()
-    system_features_mock.on_next(
-        {
-            "changesets": [],
-            "ancillary_trust": MagicMock(trust=[mock_trust()], error=None),
-        }
-    )
-    widget.get_object("deployBtn").clicked()
-    system_features_mock.on_next(
-        {
-            "changesets": [],
-            "ancillary_trust": MagicMock(trust=[mock_trust()], error=None),
-        }
-    )
-    mock_dispatch.assert_any_call(
-        InstanceOf(Action)
-        & Attrs(
-            type=ADD_NOTIFICATION,
-            payload=Attrs(
-                type=NotificationType.SUCCESS, text=DEPLOY_ANCILLARY_SUCCESSFUL_MSG
-            ),
-        )
-    )
-    mock_dispatch.assert_any_call(
-        InstanceOf(Action) & Attrs(type=SET_SYSTEM_CHECKPOINT)
-    )
-    mock_dispatch.assert_any_call(InstanceOf(Action) & Attrs(type=CLEAR_CHANGESETS))
 
 
 def test_add_trusted_files(widget, mock_dispatch):
@@ -391,18 +206,6 @@ def test_on_file_deleted_empty(widget, mock_dispatch):
     )
 
 
-@pytest.mark.parametrize("confirm_resp", [Gtk.ResponseType.YES])
-def test_handle_deploy_exception(widget, confirm_dialog):
-    with patch("fapolicy_analyzer.System") as mock:
-        mock.deploy = MagicMock(
-            return_value=None, side_effect=Exception("mocked error")
-        )
-        widget.system = mock
-        with pytest.raises(Exception) as excinfo:
-            widget.on_deployBtn_clicked()
-            assert excinfo.value.message == "mocked error"
-
-
 def test_reloads_trust_w_changeset_change(mock_dispatch, mocker):
     mockSystemFeature = Subject()
     mocker.patch(
@@ -424,6 +227,32 @@ def test_reloads_trust_w_changeset_change(mock_dispatch, mocker):
     mock_dispatch.assert_called_with(
         InstanceOf(Action) & Attrs(type=REQUEST_ANCILLARY_TRUST)
     )
+
+
+def test_load_trust(mocker):
+    mockChangeset = MagicMock(spec=Changeset)
+    mockSystemFeature = Subject()
+    mocker.patch(
+        "ui.ancillary_trust_database_admin.get_system_feature",
+        return_value=mockSystemFeature,
+    )
+    init_store(mock_System())
+    widget = AncillaryTrustDatabaseAdmin()
+    mockLoadList = mocker.patch.object(widget.trustFileList, "load_trust")
+    mockSystemFeature.on_next(
+        {
+            "changesets": [mockChangeset],
+            "ancillary_trust": MagicMock(error=False),
+        }
+    )
+
+    mockSystemFeature.on_next(
+        {
+            "changesets": [mockChangeset],
+            "ancillary_trust": MagicMock(error=False, loading=False, trust="foo"),
+        }
+    )
+    mockLoadList.assert_called_once_with("foo")
 
 
 def test_load_trust_w_exception(mock_dispatch, mocker):
@@ -448,14 +277,12 @@ def test_load_trust_w_exception(mock_dispatch, mocker):
     )
 
 
-def test_display_save_fapd_archive_dlg(widget, mocker):
-    # Mock the FileChooser dlg
-    mockFileChooserDlg = MagicMock()
-    mockFileChooserDlg.run.return_value = Gtk.ResponseType.OK
-    mockFileChooserDlg.get_filename.return_value = "/tmp/save_as_tmp.tgz"
+def test_deploy_operation(widget, mocker):
     mocker.patch(
-        "ui.ancillary_trust_database_admin.Gtk.FileChooserDialog",
-        return_value=mockFileChooserDlg,
+        "fapolicy_analyzer.ui.operations.deploy_changesets_op.get_system_feature"
     )
-    widget.display_save_fapd_archive_dlg(MagicMock())
-    mockFileChooserDlg.run.assert_called()
+    mockDeploy = mocker.patch(
+        "ui.ancillary_trust_database_admin.DeployChangesetsOp.deploy"
+    )
+    widget.get_object("deployBtn").clicked()
+    mockDeploy.assert_called_once()

--- a/fapolicy_analyzer/tests/test_main_window.py
+++ b/fapolicy_analyzer/tests/test_main_window.py
@@ -13,6 +13,7 @@ from fapolicy_analyzer import Changeset
 from gi.repository import Gtk
 from redux import Action
 from rx import create
+from rx.subject import Subject
 from ui.actions import ADD_NOTIFICATION
 from ui.main_window import MainWindow, router
 from ui.session_manager import NotificationType, sessionManager
@@ -401,3 +402,33 @@ def test_toolbar_deploy_operation(mainWindow, mocker):
     mockDeploy = mocker.patch("ui.main_window.DeployChangesetsOp.deploy")
     mainWindow.get_object("deployChanges").get_child().clicked()
     mockDeploy.assert_called_once()
+
+
+def test_toggles_deploy_changes_toolbar_btn(mocker):
+    system_features_mock = Subject()
+    mocker.patch(
+        "ui.main_window.get_system_feature",
+        return_value=system_features_mock,
+    )
+    init_store(mock_System())
+    deployBtn = MainWindow().get_object("deployChanges")
+    assert not deployBtn.get_sensitive()
+    system_features_mock.on_next({"changesets": ["foo"]})
+    assert deployBtn.get_sensitive()
+    system_features_mock.on_next({"changesets": []})
+    assert not deployBtn.get_sensitive()
+
+
+def test_toggles_dirty_title(mocker):
+    system_features_mock = Subject()
+    mocker.patch(
+        "ui.main_window.get_system_feature",
+        return_value=system_features_mock,
+    )
+    init_store(mock_System())
+    windowRef = MainWindow().get_ref()
+    assert not windowRef.get_title().startswith("*")
+    system_features_mock.on_next({"changesets": ["foo"]})
+    assert windowRef.get_title().startswith("*")
+    system_features_mock.on_next({"changesets": []})
+    assert not windowRef.get_title().startswith("*")

--- a/fapolicy_analyzer/tests/test_main_window.py
+++ b/fapolicy_analyzer/tests/test_main_window.py
@@ -1,22 +1,26 @@
-import context  # noqa: F401
-import pytest
 import locale
+
 import gi
+import pytest
+
+import context  # noqa: F401
 
 gi.require_version("Gtk", "3.0")
-from gi.repository import Gtk
+from unittest.mock import MagicMock
+
 from callee import Attrs, InstanceOf
 from fapolicy_analyzer import Changeset
-from helpers import refresh_gui
-from mocks import mock_System
+from gi.repository import Gtk
 from redux import Action
 from rx import create
-from unittest.mock import MagicMock
 from ui.actions import ADD_NOTIFICATION
 from ui.main_window import MainWindow, router
-from ui.session_manager import sessionManager, NotificationType
+from ui.session_manager import NotificationType, sessionManager
 from ui.store import init_store
 from ui.strings import AUTOSAVE_RESTORE_ERROR_MSG
+
+from helpers import refresh_gui
+from mocks import mock_System
 
 test_changeset = Changeset()
 test_changeset.add_trust("/tmp/DeadBeef.txt")
@@ -390,3 +394,10 @@ def test_on_start_w_failed_restore(mock_dispatch, mocker):
             ),
         )
     )
+
+
+def test_toolbar_deploy_operation(mainWindow, mocker):
+    mocker.patch("ui.operations.deploy_changesets_op.get_system_feature")
+    mockDeploy = mocker.patch("ui.main_window.DeployChangesetsOp.deploy")
+    mainWindow.get_object("deployChanges").get_child().clicked()
+    mockDeploy.assert_called_once()

--- a/fapolicy_analyzer/ui/ancillary_trust_database_admin.py
+++ b/fapolicy_analyzer/ui/ancillary_trust_database_admin.py
@@ -1,30 +1,19 @@
 import logging
-
-import fapolicy_analyzer.ui.strings as strings
-import gi
-
-gi.require_version("Gtk", "3.0")
 from locale import gettext as _
 
+import fapolicy_analyzer.ui.strings as strings
 from fapolicy_analyzer import Changeset, Trust
+from fapolicy_analyzer.ui.operations.deploy_changesets_op import DeployChangesetsOp
 from fapolicy_analyzer.util import fs  # noqa: F401
-from fapolicy_analyzer.util.fapd_dbase import fapd_dbase_snapshot
 from fapolicy_analyzer.util.format import f
-from gi.repository import Gtk
 
 from .actions import (
     NotificationType,
     add_notification,
     apply_changesets,
-    clear_changesets,
-    deploy_ancillary_trust,
     request_ancillary_trust,
-    restore_system_checkpoint,
-    set_system_checkpoint,
 )
 from .ancillary_trust_file_list import AncillaryTrustFileList
-from .confirm_info_dialog import ConfirmInfoDialog
-from .deploy_confirm_dialog import DeployConfirmDialog
 from .store import dispatch, get_system_feature
 from .trust_file_details import TrustFileDetails
 from .ui_widget import UIConnectedWidget
@@ -35,7 +24,6 @@ class AncillaryTrustDatabaseAdmin(UIConnectedWidget):
         super().__init__(get_system_feature(), on_next=self.on_next_system)
         self._changesets = []
         self._trust = []
-        self._deploying = False
         self._loading = False
         self.selectedFile = None
 
@@ -60,17 +48,6 @@ class AncillaryTrustDatabaseAdmin(UIConnectedWidget):
 
     def __apply_changeset(self, changeset):
         dispatch(apply_changesets(changeset))
-
-    def __display_deploy_confirmation_dialog(self):
-        parent = self.get_ref().get_toplevel()
-        deployConfirmDialog = DeployConfirmDialog(parent).get_ref()
-        revert_resp = deployConfirmDialog.run()
-        deployConfirmDialog.hide()
-        if revert_resp == Gtk.ResponseType.YES:
-            dispatch(set_system_checkpoint())
-            dispatch(clear_changesets())
-        else:
-            dispatch(restore_system_checkpoint())
 
     def add_trusted_files(self, *files):
         changeset = Changeset()
@@ -143,28 +120,8 @@ SHA256: {fs.sha(trust.path)}"""
             self.delete_trusted_files(self.selectedFile)
 
     def on_deployBtn_clicked(self, *args):
-        def changesets_to_path_action_pairs(changesets):
-            """Converts to list of human-readable undeployed path/operation pairs"""
-            return [t for e in changesets for t in e.get_path_action_map().items()]
-
-        listPathActionTuples = changesets_to_path_action_pairs(self._changesets)
-        logging.debug(listPathActionTuples)
-        parent = self.get_ref().get_toplevel()
-        dlgDeployList = ConfirmInfoDialog(parent, listPathActionTuples)
-        confirm_resp = dlgDeployList.run()
-        dlgDeployList.hide()
-
-        if confirm_resp == Gtk.ResponseType.YES:
-            bSaveFapolicydState = dlgDeployList.get_save_state()
-            logging.debug("Save fapolicyd data = {}".format(bSaveFapolicydState))
-            if bSaveFapolicydState:
-                # Invoke a file chooser dlg and generate the fapd state tarball
-                if strArchiveName := self.display_save_fapd_archive_dlg(parent):
-                    fapd_dbase_snapshot(strArchiveName)
-
-            logging.debug("Deploying...")
-            self._deploying = True
-            dispatch(deploy_ancillary_trust())
+        with DeployChangesetsOp(parentWindow=self.get_ref().get_toplevel()) as op:
+            op.deploy(self._changesets)
 
     def on_next_system(self, system):
         changesets = system.get("changesets")
@@ -177,86 +134,20 @@ SHA256: {fs.sha(trust.path)}"""
             self.trustFileList.set_changesets(changesets)
             self.__load_trust()
 
-        # if there was an error check if we were loading or deploying and show appropriate notification
-        if trustState.error:
-            if self._loading:
-                self._loading = False
-                logging.error(
-                    "%s: %s", strings.ANCILLARY_TRUST_LOAD_ERROR, trustState.error
+        # if there was an error loading show appropriate notification
+        if trustState.error and self._loading:
+            self._loading = False
+            logging.error(
+                "%s: %s", strings.ANCILLARY_TRUST_LOAD_ERROR, trustState.error
+            )
+            dispatch(
+                add_notification(
+                    strings.ANCILLARY_TRUST_LOAD_ERROR, NotificationType.ERROR
                 )
-                dispatch(
-                    add_notification(
-                        strings.ANCILLARY_TRUST_LOAD_ERROR, NotificationType.ERROR
-                    )
-                )
-            elif self._deploying:
-                self._deploying = False
-                logging.error(
-                    "%s: %s", strings.DEPLOY_ANCILLARY_ERROR_MSG, trustState.error
-                )
-                dispatch(
-                    add_notification(
-                        strings.DEPLOY_ANCILLARY_ERROR_MSG, NotificationType.ERROR
-                    )
-                )
+            )
 
         # if not loading and the trust changes reload the view
         if self._loading and not trustState.loading and self._trust != trustState.trust:
             self._loading = False
             self._trust = trustState.trust
             self.trustFileList.load_trust(self._trust)
-
-        # if not deploying and we were deploying then confirm
-        if self._deploying and trustState.deployed:
-            self._deploying = False
-            dispatch(
-                add_notification(
-                    strings.DEPLOY_ANCILLARY_SUCCESSFUL_MSG,
-                    NotificationType.SUCCESS,
-                )
-            )
-            self.__display_deploy_confirmation_dialog()
-
-    # ########## Fapd backup ########
-    def display_save_fapd_archive_dlg(self, parent):
-        """Display a file chooser dialog to specify the output archive file."""
-        logging.debug("atda::display_save_fapd_archive_dlg()")
-
-        # Display file chooser dialog
-        fcd = Gtk.FileChooserDialog(
-            strings.SAVE_AS_FILE_LABEL,
-            parent,
-            Gtk.FileChooserAction.SAVE,
-            (
-                Gtk.STOCK_CANCEL,
-                Gtk.ResponseType.CANCEL,
-                Gtk.STOCK_SAVE,
-                Gtk.ResponseType.OK,
-            ),
-        )
-
-        self.__apply_tgz_file_filters(fcd)
-        fcd.set_do_overwrite_confirmation(True)
-        response = fcd.run()
-        fcd.hide()
-
-        strFilename = None
-        if response == Gtk.ResponseType.OK:
-            strFilename = fcd.get_filename()
-            logging.debug(
-                f"fadp_dbase::display_save_fapd_archive_dlg::strFilename = {strFilename}"
-            )
-
-        fcd.destroy()
-        return strFilename
-
-    def __apply_tgz_file_filters(self, dialog):
-        fileFilterTgz = Gtk.FileFilter()
-        fileFilterTgz.set_name(strings.FA_ARCHIVE_FILES_FILTER_LABEL)
-        fileFilterTgz.add_pattern("*.tgz")
-        dialog.add_filter(fileFilterTgz)
-
-        fileFilterAny = Gtk.FileFilter()
-        fileFilterAny.set_name(strings.ANY_FILES_FILTER_LABEL)
-        fileFilterAny.add_pattern("*")
-        dialog.add_filter(fileFilterAny)

--- a/fapolicy_analyzer/ui/main_window.py
+++ b/fapolicy_analyzer/ui/main_window.py
@@ -1,21 +1,24 @@
-from os import path
 import logging
-import gi
-import fapolicy_analyzer.ui.strings as strings
-
-gi.require_version("Gtk", "3.0")
-from gi.repository import Gtk
 from locale import gettext as _
+from os import path
+
+import fapolicy_analyzer.ui.strings as strings
+import gi
 from fapolicy_analyzer.util.format import f
-from .actions import add_notification, NotificationType
+
+from .actions import NotificationType, add_notification
 from .analyzer_selection_dialog import ANALYZER_SELECTION
 from .database_admin_page import DatabaseAdminPage
 from .notification import Notification
+from .operations import DeployChangesetsOp
 from .policy_rules_admin_page import PolicyRulesAdminPage
 from .session_manager import sessionManager
 from .store import dispatch, get_system_feature
-from .unapplied_changes_dialog import UnappliedChangesDialog
 from .ui_widget import UIConnectedWidget
+from .unapplied_changes_dialog import UnappliedChangesDialog
+
+gi.require_version("Gtk", "3.0")
+from gi.repository import Gtk  # isort: skip
 
 
 def router(selection, data=None):
@@ -275,3 +278,7 @@ class MainWindow(UIConnectedWidget):
     def on_trustDbMenu_activate(self, menuitem, *args):
         self.__pack_main_content(router(ANALYZER_SELECTION.TRUST_DATABASE_ADMIN))
         self.__set_trustDbMenu_sensitive(False)
+
+    def on_deployChanges_clicked(self, *args):
+        with DeployChangesetsOp(self.window) as op:
+            op.deploy(self._changesets)

--- a/fapolicy_analyzer/ui/main_window.py
+++ b/fapolicy_analyzer/ui/main_window.py
@@ -153,6 +153,7 @@ class MainWindow(UIConnectedWidget):
         dirty = len(self._changesets) > 0
         title = f"*{self.strTopLevelTitle}" if dirty else self.strTopLevelTitle
         self.windowTopLevel.set_title(title)
+        self.get_object("deployChanges").set_sensitive(dirty)
 
     def on_openMenu_activate(self, menuitem, data=None):
         logging.debug("Callback entered: MainWindow::on_openMenu_activate()")

--- a/fapolicy_analyzer/ui/operations/__init__.py
+++ b/fapolicy_analyzer/ui/operations/__init__.py
@@ -1,0 +1,5 @@
+from typing import Tuple
+
+from .deploy_changesets_op import DeployChangesetsOp
+
+__all__: Tuple[str, ...] = ("DeployChangesetsOp",)

--- a/fapolicy_analyzer/ui/operations/deploy_changesets_op.py
+++ b/fapolicy_analyzer/ui/operations/deploy_changesets_op.py
@@ -1,0 +1,173 @@
+import logging
+from typing import Mapping, Sequence, Tuple
+
+import gi
+from fapolicy_analyzer import Changeset
+from fapolicy_analyzer.ui.actions import (
+    NotificationType,
+    add_notification,
+    clear_changesets,
+    deploy_ancillary_trust,
+    restore_system_checkpoint,
+    set_system_checkpoint,
+)
+from fapolicy_analyzer.ui.confirm_info_dialog import ConfirmInfoDialog
+from fapolicy_analyzer.ui.deploy_confirm_dialog import DeployConfirmDialog
+from fapolicy_analyzer.ui.store import dispatch, get_system_feature
+from fapolicy_analyzer.ui.strings import (
+    ANY_FILES_FILTER_LABEL,
+    DEPLOY_ANCILLARY_ERROR_MSG,
+    DEPLOY_ANCILLARY_SUCCESSFUL_MSG,
+    FA_ARCHIVE_FILES_FILTER_LABEL,
+    SAVE_AS_FILE_LABEL,
+)
+from fapolicy_analyzer.util.fapd_dbase import fapd_dbase_snapshot
+
+gi.require_version("Gtk", "3.0")
+from gi.repository import Gtk  # isort: skip
+
+
+class _FapdArchiveFileChooserDialog(Gtk.FileChooserDialog):
+    def __init__(self, parent):
+        super().__init__(
+            title=SAVE_AS_FILE_LABEL,
+            transient_for=parent,
+            action=Gtk.FileChooserAction.SAVE,
+        )
+        self.add_buttons(
+            Gtk.STOCK_CANCEL,
+            Gtk.ResponseType.CANCEL,
+            Gtk.STOCK_SAVE,
+            Gtk.ResponseType.OK,
+        )
+        self.set_do_overwrite_confirmation(True)
+
+        fileFilterTgz = Gtk.FileFilter()
+        fileFilterTgz.set_name(FA_ARCHIVE_FILES_FILTER_LABEL)
+        fileFilterTgz.add_pattern("*.tgz")
+        self.add_filter(fileFilterTgz)
+
+        fileFilterAny = Gtk.FileFilter()
+        fileFilterAny.set_name(ANY_FILES_FILTER_LABEL)
+        fileFilterAny.add_pattern("*")
+        self.add_filter(fileFilterAny)
+        self.show_all()
+
+
+class DeployChangesetsOp:
+    """Encapsulates the operation of deploying changesets.
+
+    Attributes
+    ----------
+    parentWindow : Gtk.Window, optional
+        top level window to attach dialog windows to
+
+    Methods
+    -------
+    deploy(changesets=None):
+        deploys the given changesets
+
+    To ensure proper cleanup it should be used within a with statement block.
+
+    Example:
+    with DeployChangesetsOp(parentWindow) as op:
+        op.deploy(changesets)
+    """
+
+    def __init__(self, parentWindow: Gtk.Window = None) -> None:
+        self.__window = parentWindow
+        self.__deploying = False
+        self.__subscription = get_system_feature().subscribe(on_next=self.__on_next)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        self.dispose()
+
+    def __changesets_to_path_action_pairs(
+        self,
+        changesets: Changeset,
+    ) -> Sequence[Tuple[str, str]]:
+        """Converts to list of human-readable undeployed path/operation pairs"""
+        return [t for e in changesets for t in e.get_path_action_map().items()]
+
+    def __get_fapd_archive_file_name(self) -> str:
+        """Display a file chooser dialog to specify the output archive file."""
+        fcd = _FapdArchiveFileChooserDialog(self.__window)
+        response = fcd.run()
+        fcd.hide()
+        strFilename = fcd.get_filename() if response == Gtk.ResponseType.OK else None
+        fcd.destroy()
+        return strFilename
+
+    def __display_deploy_confirmation_dialog(self):
+        deployConfirmDialog = DeployConfirmDialog(self.__window).get_ref()
+        revert_resp = deployConfirmDialog.run()
+        deployConfirmDialog.hide()
+        if revert_resp == Gtk.ResponseType.YES:
+            dispatch(set_system_checkpoint())
+            dispatch(clear_changesets())
+        else:
+            dispatch(restore_system_checkpoint())
+
+    def __on_next(self, system: Mapping[str, any]):
+        trustState = system.get("ancillary_trust")
+
+        if trustState.error and self.__deploying:
+            self.__deploying = False
+            logging.error("%s: %s", DEPLOY_ANCILLARY_ERROR_MSG, trustState.error)
+            dispatch(
+                add_notification(DEPLOY_ANCILLARY_ERROR_MSG, NotificationType.ERROR)
+            )
+        elif self.__deploying and trustState.deployed:
+            self.__deploying = False
+            dispatch(
+                add_notification(
+                    DEPLOY_ANCILLARY_SUCCESSFUL_MSG,
+                    NotificationType.SUCCESS,
+                )
+            )
+            self.__display_deploy_confirmation_dialog()
+
+    def deploy(self, changesets: Changeset):
+        """
+        Deploys the given changesets.
+
+        Parameters
+        ----------
+        changesets : : fapolicy_analyze.Changeset
+            Changesets to deploy
+
+        Returns
+        -------
+        None
+        """
+        listPathActionTuples = self.__changesets_to_path_action_pairs(changesets)
+        logging.debug(listPathActionTuples)
+        dlgDeployList = ConfirmInfoDialog(self.__window, listPathActionTuples)
+        confirm_resp = dlgDeployList.run()
+        dlgDeployList.hide()
+
+        if confirm_resp == Gtk.ResponseType.YES:
+            # Invoke a file chooser dlg and generate the fapd state tarball
+            if dlgDeployList.get_save_state() and (
+                strArchiveName := self.__get_fapd_archive_file_name()
+            ):
+                fapd_dbase_snapshot(strArchiveName)
+
+            logging.debug("Deploying...")
+            self.__deploying = True
+            dispatch((deploy_ancillary_trust()))
+
+        dlgDeployList.destroy()
+
+    def dispose(self):
+        """
+        Closes the feature subscriptions
+        """
+        if self.__subscription:
+            logging.debug(
+                "disposing of subscription for class {}".format(self.__class__.__name__)
+            )
+            self.__subscription.dispose()


### PR DESCRIPTION
This is an initial cut of adding a toolbar to the application.  I picture this being built out a bit more with more buttons, and buttons that are specific to each tool.  However for now my goal was to get a Deploy button out there for us from the Policy Event Analysis tool.  I've created the concept of a "operation" to house code that needs to be used for triggering something from multiple places.  In this case I needed to reuse the deployment workflow from both the button on the ADTA tool and the toolbar button.  This should allow use to also create a menu item if we want to to trigger a deployment.

closes #341 