### PR TITLE
Fix rust clippy lint warning

### DIFF
--- a/crates/app/src/sys.rs
+++ b/crates/app/src/sys.rs
@@ -32,13 +32,7 @@ pub fn deploy_app_state(state: &State) -> Result<(), Error> {
     for (path, meta) in state.trust_db.iter() {
         if meta.is_ancillary() {
             tf.write_all(
-                format!(
-                    "{} {} {}\n",
-                    path,
-                    meta.trusted.size,
-                    meta.trusted.hash
-                )
-                .as_bytes(),
+                format!("{} {} {}\n", path, meta.trusted.size, meta.trusted.hash).as_bytes(),
             )
             .map_err(|_| WriteAncillaryFail("unable to write ancillary trust entry".to_string()))?;
         }

--- a/crates/app/src/sys.rs
+++ b/crates/app/src/sys.rs
@@ -35,7 +35,7 @@ pub fn deploy_app_state(state: &State) -> Result<(), Error> {
                 format!(
                     "{} {} {}\n",
                     path,
-                    meta.trusted.size.to_string(),
+                    meta.trusted.size,
                     meta.trusted.hash
                 )
                 .as_bytes(),


### PR DESCRIPTION
1/13/2022 rust tool update generates a CI test suite failure (clippy lint warning).
