### PR TITLE
Fixup: Fix rpm build issue

### DIFF
--- a/.github/workflows/rpm.yml
+++ b/.github/workflows/rpm.yml
@@ -1,7 +1,7 @@
 on:
   push:
     branches:
-      - master
+      - fix-rpm-build-issue
     tags:
       - 'v*'
   pull_request:
@@ -24,7 +24,7 @@ jobs:
         run: |
           grep -e "^Red Hat Enterprise Linux" /etc/redhat-release \
           && RELEASE=$(grep -oE "[0-9]+\.[0-9]+" /etc/redhat-release) \
-          && printf "[rocky-$RELEASE-appstream]\nname=Rocky Linux $RELEASE - AppStream\nbaseurl=http://dl.rockylinux.org/pub/rocky/$RELEASE/AppStream/x86_64/os/\ngpgcheck=1\nenabled=1\ngpgkey=https://git.rockylinux.org/label/rocky-repos/-/raw/r8/SOURCES/RPM-GPG-KEY-rockyofficial\nincludepkgs=rpmdevtools,dbus-devel\n" > /etc/yum.repos.d/Rocky-"$RELEASE"-AppStream.repo \
+          && printf "[rocky-$RELEASE-appstream]\nname=Rocky Linux $RELEASE - AppStream\nbaseurl=http://dl.rockylinux.org/pub/rocky/$RELEASE/AppStream/x86_64/os/\ngpgcheck=1\nenabled=1\ngpgkey=https://dl.rockylinux.org/pub/rocky/8.5/AppStream/x86_64/os/RPM-GPG-KEY-rockyofficial\nincludepkgs=rpmdevtools,dbus-devel\n" > /etc/yum.repos.d/Rocky-"$RELEASE"-AppStream.repo \
           || true
 
       - name: Install basic rpmbuild toolchain

--- a/.github/workflows/rpm.yml
+++ b/.github/workflows/rpm.yml
@@ -1,7 +1,7 @@
 on:
   push:
     branches:
-      - fix-rpm-build-issue
+      - master
     tags:
       - 'v*'
   pull_request:

--- a/.github/workflows/rpm.yml
+++ b/.github/workflows/rpm.yml
@@ -24,7 +24,7 @@ jobs:
         run: |
           grep -e "^Red Hat Enterprise Linux" /etc/redhat-release \
           && RELEASE=$(grep -oE "[0-9]+\.[0-9]+" /etc/redhat-release) \
-          && printf "[rocky-$RELEASE-appstream]\nname=Rocky Linux $RELEASE - AppStream\nbaseurl=http://dl.rockylinux.org/pub/rocky/$RELEASE/AppStream/x86_64/os/\ngpgcheck=1\nenabled=1\ngpgkey=https://dl.rockylinux.org/pub/rocky/8.5/AppStream/x86_64/os/RPM-GPG-KEY-rockyofficial\nincludepkgs=rpmdevtools,dbus-devel\n" > /etc/yum.repos.d/Rocky-"$RELEASE"-AppStream.repo \
+          && printf "[rocky-$RELEASE-appstream]\nname=Rocky Linux $RELEASE - AppStream\nbaseurl=http://dl.rockylinux.org/pub/rocky/$RELEASE/AppStream/x86_64/os/\ngpgcheck=1\nenabled=1\ngpgkey=https://dl.rockylinux.org/pub/rocky/$RELEASE/AppStream/x86_64/os/RPM-GPG-KEY-rockyofficial\nincludepkgs=rpmdevtools,dbus-devel\n" > /etc/yum.repos.d/Rocky-"$RELEASE"-AppStream.repo \
           || true
 
       - name: Install basic rpmbuild toolchain


### PR DESCRIPTION
Updated the URL used for pulling the GPG key for the Appstream repo during RPM builds on RHEL 8.5. The old URL was breaking the builds with a bad key https://github.com/ctc-oss/fapolicy-analyzer/runs/5218341144?check_suite_focus=true.  The new URL is pulling the key from the same location we are pointing to for the Rocky 8.5 Appstream repo `baseurl`.