### PR TITLE
Added read-only guided rules editor to Rules Admin tool

### DIFF
--- a/fapolicy_analyzer/glade/rules_admin_page.glade
+++ b/fapolicy_analyzer/glade/rules_admin_page.glade
@@ -22,44 +22,46 @@
     <property name="visible">True</property>
     <property name="can-focus">True</property>
     <child>
-      <object class="GtkBox" id="legacyContent">
+      <object class="GtkBox" id="guidedEditorContent">
         <property name="visible">True</property>
         <property name="can-focus">False</property>
         <property name="orientation">vertical</property>
         <child>
-          <object class="GtkScrolledWindow">
-            <property name="visible">True</property>
-            <property name="can-focus">True</property>
-            <property name="shadow-type">in</property>
-            <child>
-              <object class="GtkViewport">
-                <property name="visible">True</property>
-                <property name="can-focus">False</property>
-                <child>
-                  <object class="GtkSourceView" id="legacyTextView">
-                    <property name="visible">True</property>
-                    <property name="can-focus">True</property>
-                    <property name="editable">False</property>
-                  </object>
-                </child>
-              </object>
-            </child>
-          </object>
-          <packing>
-            <property name="expand">True</property>
-            <property name="fill">True</property>
-            <property name="position">0</property>
-          </packing>
+          <placeholder/>
         </child>
       </object>
     </child>
     <child type="tab">
-      <object class="GtkLabel" id="legacyView">
+      <object class="GtkLabel" id="tableView">
         <property name="visible">True</property>
         <property name="can-focus">False</property>
-        <property name="label" translatable="yes">Legacy View</property>
+        <property name="label" translatable="yes">Guided Editor</property>
       </object>
       <packing>
+        <property name="tab-fill">False</property>
+      </packing>
+    </child>
+    <child>
+      <object class="GtkBox" id="textEditorContent">
+        <property name="visible">True</property>
+        <property name="can-focus">False</property>
+        <property name="orientation">vertical</property>
+        <child>
+          <placeholder/>
+        </child>
+      </object>
+      <packing>
+        <property name="position">1</property>
+      </packing>
+    </child>
+    <child type="tab">
+      <object class="GtkLabel" id="textView">
+        <property name="visible">True</property>
+        <property name="can-focus">False</property>
+        <property name="label" translatable="yes">Text Editor</property>
+      </object>
+      <packing>
+        <property name="position">1</property>
         <property name="tab-fill">False</property>
       </packing>
     </child>

--- a/fapolicy_analyzer/glade/rules_text_view.glade
+++ b/fapolicy_analyzer/glade/rules_text_view.glade
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated with glade 3.38.2 -->
+<!--
+  Copyright Concurrent Technologies Corporation 2022
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+-->
+<interface>
+  <requires lib="gtk+" version="3.22"/>
+  <object class="GtkScrolledWindow" id="rulesTextView">
+    <property name="visible">True</property>
+    <property name="can-focus">True</property>
+    <property name="shadow-type">in</property>
+    <child>
+      <object class="GtkViewport" id="viewport">
+        <property name="visible">True</property>
+        <property name="can-focus">False</property>
+        <child>
+          <object class="GtkSourceView" id="textView">
+            <property name="visible">True</property>
+            <property name="can-focus">True</property>
+            <property name="editable">False</property>
+          </object>
+        </child>
+      </object>
+    </child>
+  </object>
+</interface>

--- a/fapolicy_analyzer/locale/fapolicy_analyzer.pot
+++ b/fapolicy_analyzer/locale/fapolicy_analyzer.pot
@@ -7,9 +7,9 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: fapolicy-analyzer 0.3.1+37.g4094dad.dirty\n"
+"Project-Id-Version: fapolicy-analyzer 0.3.1+38.g7066a13.dirty\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2022-02-02 07:11-0500\n"
+"POT-Creation-Date: 2022-02-16 14:50-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -419,8 +419,12 @@ msgstr ""
 msgid "x"
 msgstr ""
 
-#: fapolicy_analyzer/glade/rules_admin_page.glade:43
-msgid "Legacy View"
+#: fapolicy_analyzer/glade/rules_admin_page.glade:38
+msgid "Guided Editor"
+msgstr ""
+
+#: fapolicy_analyzer/glade/rules_admin_page.glade:61
+msgid "Text Editor"
 msgstr ""
 
 #: fapolicy_analyzer/glade/searchable_list.glade:125

--- a/fapolicy_analyzer/tests/rules/test_rules_admin_page.py
+++ b/fapolicy_analyzer/tests/rules/test_rules_admin_page.py
@@ -19,14 +19,13 @@ from unittest.mock import MagicMock
 import gi
 import pytest
 from callee import Attrs, InstanceOf
+from mocks import mock_rule, mock_System
 from redux import Action
 from rx.subject import Subject
 from ui.actions import ADD_NOTIFICATION
 from ui.rules import RulesAdminPage
 from ui.store import init_store
 from ui.strings import RULES_LOAD_ERROR
-
-from mocks import mock_rule, mock_System
 
 gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk  # isort: skip
@@ -77,14 +76,6 @@ def test_populates_rules(widget, mock_system_feature, mocker):
     )
     mock_list_renderer.assert_called_once_with(mock_rules)
     mock_text_renderer.assert_called_once_with(mock_rules)
-    # textView = widget.get_object("legacyTextView")
-    # textBuffer = textView.get_buffer()
-    # assert (
-    #     textBuffer.get_text(
-    #         textBuffer.get_start_iter(), textBuffer.get_end_iter(), True
-    #     )
-    #     == mock_rule().text
-    # )
 
 
 @pytest.mark.usefixtures("widget")

--- a/fapolicy_analyzer/tests/rules/test_rules_list_view.py
+++ b/fapolicy_analyzer/tests/rules/test_rules_list_view.py
@@ -1,0 +1,45 @@
+# Copyright Concurrent Technologies Corporation 2022
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import context  # noqa: F401 # isort: skip
+from unittest.mock import MagicMock
+
+import gi
+import pytest
+from ui.rules.rules_list_view import RulesListView
+
+gi.require_version("Gtk", "3.0")
+from gi.repository import Gtk  # isort: skip
+
+
+@pytest.fixture
+def widget():
+    return RulesListView()
+
+
+def test_creates_widget(widget):
+    assert type(widget.get_ref()) is Gtk.Box
+
+
+def test_renders_rules(widget):
+    rules = [
+        MagicMock(id=1, text="Mock Rule Number 1"),
+        MagicMock(id=2, text="Mock Rule Number 2"),
+    ]
+    widget.render_rules(rules)
+    model = widget.get_object("treeView").get_model()
+    assert [r.text for r in rules] == [x[0] for x in model]
+    assert [r.id for r in rules] == [x[1] for x in model]
+    assert ["gainsboro", "white"] == [x[2] for x in model]

--- a/fapolicy_analyzer/tests/rules/test_rules_text_view.py
+++ b/fapolicy_analyzer/tests/rules/test_rules_text_view.py
@@ -1,0 +1,50 @@
+# Copyright Concurrent Technologies Corporation 2022
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import context  # noqa: F401 # isort: skip
+from unittest.mock import MagicMock
+
+import gi
+import pytest
+from ui.rules.rules_text_view import RulesTextView
+
+gi.require_version("Gtk", "3.0")
+from gi.repository import Gtk  # isort: skip
+
+
+@pytest.fixture
+def widget():
+    return RulesTextView()
+
+
+def test_creates_widget(widget):
+    assert type(widget.get_ref()) is Gtk.ScrolledWindow
+
+
+def test_renders_rules(widget):
+    rules = [
+        MagicMock(id=1, text="Mock Rule Number 1"),
+        MagicMock(id=2, text="Mock Rule Number 2"),
+    ]
+    expected = "Mock Rule Number 1\nMock Rule Number 2"
+    widget.render_rules(rules)
+    textView = widget.get_object("textView")
+    textBuffer = textView.get_buffer()
+    assert (
+        textBuffer.get_text(
+            textBuffer.get_start_iter(), textBuffer.get_end_iter(), True
+        )
+        == expected
+    )

--- a/fapolicy_analyzer/tests/test_main_window.py
+++ b/fapolicy_analyzer/tests/test_main_window.py
@@ -67,7 +67,7 @@ def mock_dispatches(mocker):
     mocker.patch("ui.ancillary_trust_database_admin.dispatch")
     mocker.patch("ui.system_trust_database_admin.dispatch")
     mocker.patch("ui.policy_rules_admin_page.dispatch")
-    mocker.patch("ui.rules_admin_page.dispatch")
+    mocker.patch("ui.rules.rules_admin_page.dispatch")
 
 
 @pytest.fixture
@@ -177,7 +177,7 @@ def test_opens_analyze_with_syslog_page(mainWindow):
 
 
 def test_opens_rules_admin_page(mainWindow, mocker):
-    mocker.patch("ui.rules_admin_page.get_system_feature")
+    mocker.patch("ui.rules.rules_admin_page.get_system_feature")
     menuItem = mainWindow.get_object("rulesAdminMenu")
     menuItem.activate()
     refresh_gui()

--- a/fapolicy_analyzer/tests/test_rules_admin_page.py
+++ b/fapolicy_analyzer/tests/test_rules_admin_page.py
@@ -19,10 +19,10 @@ from unittest.mock import MagicMock
 import gi
 import pytest
 from callee import Attrs, InstanceOf
+from fapolicy_analyzer.ui.rules import RulesAdminPage
 from redux import Action
 from rx.subject import Subject
 from ui.actions import ADD_NOTIFICATION
-from ui.rules_admin_page import RulesAdminPage
 from ui.store import init_store
 from ui.strings import RULES_LOAD_ERROR
 

--- a/fapolicy_analyzer/tests/test_rules_admin_page.py
+++ b/fapolicy_analyzer/tests/test_rules_admin_page.py
@@ -19,10 +19,10 @@ from unittest.mock import MagicMock
 import gi
 import pytest
 from callee import Attrs, InstanceOf
-from fapolicy_analyzer.ui.rules import RulesAdminPage
 from redux import Action
 from rx.subject import Subject
 from ui.actions import ADD_NOTIFICATION
+from ui.rules import RulesAdminPage
 from ui.store import init_store
 from ui.strings import RULES_LOAD_ERROR
 
@@ -34,14 +34,14 @@ from gi.repository import Gtk  # isort: skip
 
 @pytest.fixture()
 def mock_dispatch(mocker):
-    return mocker.patch("ui.rules_admin_page.dispatch")
+    return mocker.patch("ui.rules.rules_admin_page.dispatch")
 
 
 @pytest.fixture()
 def mock_system_feature(mocker):
     mockSystemFeature = Subject()
     mocker.patch(
-        "ui.rules_admin_page.get_system_feature",
+        "ui.rules.rules_admin_page.get_system_feature",
         return_value=mockSystemFeature,
     )
     yield mockSystemFeature
@@ -58,20 +58,33 @@ def test_creates_widget(widget):
     assert type(widget.get_ref()) is Gtk.Notebook
 
 
-def test_populates_rules(widget, mock_system_feature):
+def test_populates_rules(widget, mock_system_feature, mocker):
+    mock_rules = [mock_rule()]
+    mock_list_renderer = MagicMock()
+    mock_text_renderer = MagicMock()
+    mocker.patch(
+        "fapolicy_analyzer.ui.rules.rules_list_view.RulesListView.render_rules",
+        mock_list_renderer,
+    )
+    mocker.patch(
+        "fapolicy_analyzer.ui.rules.rules_text_view.RulesTextView.render_rules",
+        mock_text_renderer,
+    )
     mock_system_feature.on_next(
         {
-            "rules": MagicMock(error=None, rules=[mock_rule()], loading=False),
+            "rules": MagicMock(error=None, rules=mock_rules, loading=False),
         }
     )
-    textView = widget.get_object("legacyTextView")
-    textBuffer = textView.get_buffer()
-    assert (
-        textBuffer.get_text(
-            textBuffer.get_start_iter(), textBuffer.get_end_iter(), True
-        )
-        == mock_rule().text
-    )
+    mock_list_renderer.assert_called_once_with(mock_rules)
+    mock_text_renderer.assert_called_once_with(mock_rules)
+    # textView = widget.get_object("legacyTextView")
+    # textBuffer = textView.get_buffer()
+    # assert (
+    #     textBuffer.get_text(
+    #         textBuffer.get_start_iter(), textBuffer.get_end_iter(), True
+    #     )
+    #     == mock_rule().text
+    # )
 
 
 @pytest.mark.usefixtures("widget")

--- a/fapolicy_analyzer/ui/__main__.py
+++ b/fapolicy_analyzer/ui/__main__.py
@@ -27,6 +27,7 @@ from .splash_screen import SplashScreen
 from .store import init_store
 
 gi.require_version("Gtk", "3.0")
+gi.require_version("GtkSource", "3.0")
 from gi.repository import Gtk, GtkSource, GObject  # isort: skip
 
 

--- a/fapolicy_analyzer/ui/acl_list.py
+++ b/fapolicy_analyzer/ui/acl_list.py
@@ -15,10 +15,10 @@
 
 import gi
 
-gi.require_version("Gtk", "3.0")
-from gi.repository import Gtk
-
 from .searchable_list import SearchableList
+
+gi.require_version("Gtk", "3.0")
+from gi.repository import Gtk  # isort: skip
 
 
 class ACLList(SearchableList):

--- a/fapolicy_analyzer/ui/main_window.py
+++ b/fapolicy_analyzer/ui/main_window.py
@@ -35,7 +35,7 @@ from .database_admin_page import DatabaseAdminPage
 from .notification import Notification
 from .operations import DeployChangesetsOp
 from .policy_rules_admin_page import PolicyRulesAdminPage
-from .rules_admin_page import RulesAdminPage
+from .rules import RulesAdminPage
 from .session_manager import sessionManager
 from .store import dispatch, get_system_feature
 from .ui_widget import UIConnectedWidget

--- a/fapolicy_analyzer/ui/rules/__init__.py
+++ b/fapolicy_analyzer/ui/rules/__init__.py
@@ -1,0 +1,20 @@
+# Copyright Concurrent Technologies Corporation 2022
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+from typing import Tuple
+
+from .rules_admin_page import RulesAdminPage
+
+__all__: Tuple[str, ...] = ("RulesAdminPage",)

--- a/fapolicy_analyzer/ui/rules/rules_list_view.py
+++ b/fapolicy_analyzer/ui/rules/rules_list_view.py
@@ -25,15 +25,18 @@ from gi.repository import Gtk  # isort: skip
 
 class RulesListView(SearchableList):
     def __init__(self):
-        super().__init__(self.__columns())
+        super().__init__(self.__columns(), view_headers_visible=False)
 
     def __columns(self):
-        return [Gtk.TreeViewColumn("", Gtk.CellRendererText(), text=0)]
+        return [
+            Gtk.TreeViewColumn("", Gtk.CellRendererText(), text=0, cell_background=2)
+        ]
 
     def render_rules(self, rules: Sequence[Rule]):
-        store = Gtk.ListStore(str, int)
+        store = Gtk.ListStore(str, int, str)
 
-        for rule in rules:
-            store.append([rule.text, rule.id])
+        for idx, rule in enumerate(rules):
+            row_color = "white" if idx % 2 else "gainsboro"
+            store.append([rule.text, rule.id, row_color])
 
         self.load_store(store)

--- a/fapolicy_analyzer/ui/rules/rules_list_view.py
+++ b/fapolicy_analyzer/ui/rules/rules_list_view.py
@@ -1,0 +1,39 @@
+# Copyright Concurrent Technologies Corporation 2022
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+from typing import Sequence
+
+import gi
+from fapolicy_analyzer import Rule
+from fapolicy_analyzer.ui.searchable_list import SearchableList
+
+gi.require_version("Gtk", "3.0")
+from gi.repository import Gtk  # isort: skip
+
+
+class RulesListView(SearchableList):
+    def __init__(self):
+        super().__init__(self.__columns())
+
+    def __columns(self):
+        return [Gtk.TreeViewColumn("", Gtk.CellRendererText(), text=0)]
+
+    def render_rules(self, rules: Sequence[Rule]):
+        store = Gtk.ListStore(str, int)
+
+        for rule in rules:
+            store.append([rule.text, rule.id])
+
+        self.load_store(store)

--- a/fapolicy_analyzer/ui/rules/rules_text_view.py
+++ b/fapolicy_analyzer/ui/rules/rules_text_view.py
@@ -1,0 +1,30 @@
+# Copyright Concurrent Technologies Corporation 2022
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+from typing import Sequence
+
+from fapolicy_analyzer import Rule
+from fapolicy_analyzer.ui.ui_widget import UIBuilderWidget
+
+
+class RulesTextView(UIBuilderWidget):
+    def __init__(self):
+        super().__init__()
+        self.__text_view = self.get_object("textView")
+        self.__text_view.set_show_line_numbers(True)
+
+    def render_rules(self, rules: Sequence[Rule]):
+        text = "\n".join([r.text for r in rules])
+        self.__text_view.get_buffer().set_text(text)

--- a/fapolicy_analyzer/ui/trust_file_list.py
+++ b/fapolicy_analyzer/ui/trust_file_list.py
@@ -13,17 +13,17 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import fapolicy_analyzer.ui.strings as strings
-import gi
-
-gi.require_version("Gtk", "3.0")
 from concurrent.futures import ThreadPoolExecutor
 from time import localtime, mktime, strftime, strptime
 
-from gi.repository import GLib, Gtk
+import fapolicy_analyzer.ui.strings as strings
+import gi
 
 from .searchable_list import SearchableList
 from .strings import FILE_LABEL, FILES_LABEL
+
+gi.require_version("Gtk", "3.0")
+from gi.repository import GLib, Gtk  # isort: skip
 
 # global variable used for stopping the running executor from call for UI
 # updates if the widget was destroyed
@@ -57,7 +57,11 @@ class TrustFileList(SearchableList):
         ]
 
         super().__init__(
-            self._columns(), *args, searchColumnIndex=2, defaultSortIndex=2, selection_type="multi",
+            self._columns(),
+            *args,
+            searchColumnIndex=2,
+            defaultSortIndex=2,
+            selection_type="multi",
         )
         self.trust_func = trust_func
         self.markup_func = markup_func


### PR DESCRIPTION
Adds the guided rules editor (aka list view) to the Rules Admin tool. There are now 2 tabs to toggle between the guided editor and the text editor.  Also adds filtering to the guided rules editor view.

closed #399 #400 