### PR TITLE
Updated Rules Administration Text Editor to read directly from the fapolicyd rules file

### DIFF
--- a/fapolicy_analyzer/locale/fapolicy_analyzer.pot
+++ b/fapolicy_analyzer/locale/fapolicy_analyzer.pot
@@ -7,9 +7,9 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: fapolicy-analyzer 0.3.1+38.g7066a13.dirty\n"
+"Project-Id-Version: fapolicy-analyzer 0.3.1+41.gd73d0d1\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2022-02-16 14:50-0500\n"
+"POT-Creation-Date: 2022-02-18 12:18-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -90,135 +90,143 @@ msgid "Error loading Rules"
 msgstr ""
 
 #: fapolicy_analyzer/ui/strings.py:25
-msgid "Error initializing communications with daemon"
+msgid "Error loading Rules configuration"
+msgstr ""
+
+#: fapolicy_analyzer/ui/strings.py:26
+msgid "Error reading the Rules file"
 msgstr ""
 
 #: fapolicy_analyzer/ui/strings.py:27
+msgid "Error initializing communications with daemon"
+msgstr ""
+
+#: fapolicy_analyzer/ui/strings.py:29
 msgid "Deploy Ancillary Trust Changes?"
 msgstr ""
 
-#: fapolicy_analyzer/ui/strings.py:28
+#: fapolicy_analyzer/ui/strings.py:30
 msgid ""
 "Are you sure you wish to deploy your changes to the ancillary trust "
 "database?\n"
 " This will update the fapolicy trust and restart the service."
 msgstr ""
 
-#: fapolicy_analyzer/ui/strings.py:32
+#: fapolicy_analyzer/ui/strings.py:34
 msgid "Action"
 msgstr ""
 
-#: fapolicy_analyzer/ui/strings.py:33
+#: fapolicy_analyzer/ui/strings.py:35
 msgid "File Path"
 msgstr ""
 
-#: fapolicy_analyzer/ui/strings.py:34
+#: fapolicy_analyzer/ui/strings.py:36
 msgid "Changes successfully deployed."
 msgstr ""
 
-#: fapolicy_analyzer/ui/strings.py:35
+#: fapolicy_analyzer/ui/strings.py:37
 msgid "An error occurred trying to deploy the changes. Please try again."
 msgstr ""
 
-#: fapolicy_analyzer/ui/strings.py:39
+#: fapolicy_analyzer/ui/strings.py:41
 msgid "This file is trusted in the System Trust Database."
 msgstr ""
 
-#: fapolicy_analyzer/ui/strings.py:40
+#: fapolicy_analyzer/ui/strings.py:42
 msgid "There is a discrepancy between this file and the System Trust Database."
 msgstr ""
 
-#: fapolicy_analyzer/ui/strings.py:43
+#: fapolicy_analyzer/ui/strings.py:45
 msgid "The trust status of this file is unknown in the System Trust Database."
 msgstr ""
 
-#: fapolicy_analyzer/ui/strings.py:47
+#: fapolicy_analyzer/ui/strings.py:49
 msgid "This file is trusted in the Ancillary Trust Database."
 msgstr ""
 
-#: fapolicy_analyzer/ui/strings.py:50
+#: fapolicy_analyzer/ui/strings.py:52
 msgid "There is a discrepancy between this file and the Ancillary Trust Database."
 msgstr ""
 
-#: fapolicy_analyzer/ui/strings.py:53
+#: fapolicy_analyzer/ui/strings.py:55
 msgid "The trust status of this file is unknown in the Ancillary Trust Database."
 msgstr ""
 
-#: fapolicy_analyzer/ui/strings.py:57
+#: fapolicy_analyzer/ui/strings.py:59
 msgid "The trust status of this file is unknown"
 msgstr ""
 
-#: fapolicy_analyzer/ui/strings.py:59
+#: fapolicy_analyzer/ui/strings.py:61
 msgid "System Trust Database"
 msgstr ""
 
-#: fapolicy_analyzer/ui/strings.py:60
+#: fapolicy_analyzer/ui/strings.py:62
 msgid "Ancillary Trust Database"
 msgstr ""
 
 #: fapolicy_analyzer/glade/ancillary_trust_database_admin.glade:60
 #: fapolicy_analyzer/glade/trust_reconciliation_dialog.glade:41
-#: fapolicy_analyzer/ui/strings.py:62
+#: fapolicy_analyzer/ui/strings.py:64
 msgid "Trust"
 msgstr ""
 
-#: fapolicy_analyzer/ui/strings.py:63
+#: fapolicy_analyzer/ui/strings.py:65
 msgid "File"
 msgstr ""
 
-#: fapolicy_analyzer/ui/strings.py:64
+#: fapolicy_analyzer/ui/strings.py:66
 msgid "MTime"
 msgstr ""
 
-#: fapolicy_analyzer/ui/strings.py:65
+#: fapolicy_analyzer/ui/strings.py:67
 msgid "Changes"
 msgstr ""
 
-#: fapolicy_analyzer/ui/strings.py:66
+#: fapolicy_analyzer/ui/strings.py:68
 msgid "Mode"
 msgstr ""
 
-#: fapolicy_analyzer/ui/strings.py:67
+#: fapolicy_analyzer/ui/strings.py:69
 msgid "Access"
 msgstr ""
 
-#: fapolicy_analyzer/ui/strings.py:69
+#: fapolicy_analyzer/ui/strings.py:71
 msgid "Add"
 msgstr ""
 
-#: fapolicy_analyzer/ui/strings.py:70
+#: fapolicy_analyzer/ui/strings.py:72
 msgid "Delete"
 msgstr ""
 
-#: fapolicy_analyzer/ui/strings.py:72
+#: fapolicy_analyzer/ui/strings.py:74
 msgid "Add File"
 msgstr ""
 
-#: fapolicy_analyzer/ui/strings.py:73
+#: fapolicy_analyzer/ui/strings.py:75
 msgid "Open File"
 msgstr ""
 
-#: fapolicy_analyzer/ui/strings.py:74
+#: fapolicy_analyzer/ui/strings.py:76
 msgid "Save As..."
 msgstr ""
 
-#: fapolicy_analyzer/ui/strings.py:75
+#: fapolicy_analyzer/ui/strings.py:77
 msgid "FA Session files"
 msgstr ""
 
-#: fapolicy_analyzer/ui/strings.py:76
+#: fapolicy_analyzer/ui/strings.py:78
 msgid "fapolicyd archive files"
 msgstr ""
 
-#: fapolicy_analyzer/ui/strings.py:77
+#: fapolicy_analyzer/ui/strings.py:79
 msgid "Any files"
 msgstr ""
 
-#: fapolicy_analyzer/ui/strings.py:79
+#: fapolicy_analyzer/ui/strings.py:81
 msgid "File path(s) contains embedded whitespace."
 msgstr ""
 
-#: fapolicy_analyzer/ui/strings.py:80
+#: fapolicy_analyzer/ui/strings.py:82
 msgid ""
 "fapolicyd currently does not support paths containing spaces. The "
 "following paths will not be added to the Trusted Files List.\n"
@@ -226,7 +234,7 @@ msgid ""
 "\n"
 msgstr ""
 
-#: fapolicy_analyzer/ui/strings.py:85
+#: fapolicy_analyzer/ui/strings.py:87
 msgid ""
 "\n"
 "        Restore your prior session now?\n"
@@ -243,57 +251,57 @@ msgid ""
 "        "
 msgstr ""
 
-#: fapolicy_analyzer/ui/strings.py:101
+#: fapolicy_analyzer/ui/strings.py:103
 msgid "An error occurred trying to restore a prior autosaved edit session"
 msgstr ""
 
-#: fapolicy_analyzer/glade/loader.glade:45 fapolicy_analyzer/ui/strings.py:105
+#: fapolicy_analyzer/glade/loader.glade:45 fapolicy_analyzer/ui/strings.py:107
 msgid "Loading..."
 msgstr ""
 
-#: fapolicy_analyzer/ui/strings.py:107
+#: fapolicy_analyzer/ui/strings.py:109
 msgid "file"
 msgstr ""
 
-#: fapolicy_analyzer/ui/strings.py:108
+#: fapolicy_analyzer/ui/strings.py:110
 msgid "files"
 msgstr ""
 
-#: fapolicy_analyzer/ui/strings.py:109
+#: fapolicy_analyzer/ui/strings.py:111
 msgid "user"
 msgstr ""
 
-#: fapolicy_analyzer/ui/strings.py:110
+#: fapolicy_analyzer/ui/strings.py:112
 msgid "users"
 msgstr ""
 
-#: fapolicy_analyzer/ui/strings.py:111
+#: fapolicy_analyzer/ui/strings.py:113
 msgid "group"
 msgstr ""
 
-#: fapolicy_analyzer/ui/strings.py:112
+#: fapolicy_analyzer/ui/strings.py:114
 msgid "groups"
 msgstr ""
 
-#: fapolicy_analyzer/ui/strings.py:113
+#: fapolicy_analyzer/ui/strings.py:115
 msgid ""
 "An error occurred trying to parse the event log file. Please try again or"
 " select a different file."
 msgstr ""
 
-#: fapolicy_analyzer/ui/strings.py:116
+#: fapolicy_analyzer/ui/strings.py:118
 msgid "An error occurred trying to retrieve the user list. Please try again."
 msgstr ""
 
-#: fapolicy_analyzer/ui/strings.py:119
+#: fapolicy_analyzer/ui/strings.py:121
 msgid "An error occurred trying to retrieve the group list. Please try again."
 msgstr ""
 
-#: fapolicy_analyzer/ui/strings.py:123
+#: fapolicy_analyzer/ui/strings.py:125
 msgid "Trust Database"
 msgstr ""
 
-#: fapolicy_analyzer/ui/strings.py:124
+#: fapolicy_analyzer/ui/strings.py:126
 msgid ""
 "\n"
 "The fapolicyd trusted resources database\n"

--- a/fapolicy_analyzer/tests/reducers/test_rules_config_reducer.py
+++ b/fapolicy_analyzer/tests/reducers/test_rules_config_reducer.py
@@ -1,0 +1,49 @@
+# Copyright Concurrent Technologies Corporation 2022
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+from unittest.mock import MagicMock
+
+import context  # noqa: F401
+import pytest
+from ui.reducers.rules_config_reducer import (
+    RuleConfigState,
+    handle_error_rules_config,
+    handle_received_rules_config,
+    handle_request_rules_config,
+)
+
+
+@pytest.fixture()
+def initial_state():
+    return RuleConfigState(error=None, rules_config={}, loading=False)
+
+
+def test_handle_request_rules_config(initial_state):
+    result = handle_request_rules_config(initial_state, MagicMock())
+    assert result == RuleConfigState(error=None, rules_config={}, loading=True)
+
+
+def test_handle_received_rules_config(initial_state):
+    result = handle_received_rules_config(
+        initial_state, MagicMock(payload={"rules_path": "foo"})
+    )
+    assert result == RuleConfigState(
+        error=None, rules_config={"rules_path": "foo"}, loading=False
+    )
+
+
+def test_handle_error_rules_config(initial_state):
+    result = handle_error_rules_config(initial_state, MagicMock(payload="foo"))
+    assert result == RuleConfigState(error="foo", rules_config={}, loading=False)

--- a/fapolicy_analyzer/tests/rules/test_rules_admin_page.py
+++ b/fapolicy_analyzer/tests/rules/test_rules_admin_page.py
@@ -25,7 +25,7 @@ from rx.subject import Subject
 from ui.actions import ADD_NOTIFICATION
 from ui.rules import RulesAdminPage
 from ui.store import init_store
-from ui.strings import RULES_LOAD_ERROR
+from ui.strings import RULES_CONFIG_LOAD_ERROR, RULES_LOAD_ERROR
 
 gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk  # isort: skip
@@ -57,35 +57,67 @@ def test_creates_widget(widget):
     assert type(widget.get_ref()) is Gtk.Notebook
 
 
-def test_populates_rules(widget, mock_system_feature, mocker):
+def test_populates_guided_editor(widget, mock_system_feature, mocker):
     mock_rules = [mock_rule()]
     mock_list_renderer = MagicMock()
-    mock_text_renderer = MagicMock()
     mocker.patch(
         "fapolicy_analyzer.ui.rules.rules_list_view.RulesListView.render_rules",
         mock_list_renderer,
     )
+    mock_system_feature.on_next(
+        {
+            "rules": MagicMock(error=None, rules=mock_rules, loading=False),
+            "rules_config": MagicMock(),
+        }
+    )
+    mock_list_renderer.assert_called_once_with(mock_rules)
+
+
+@pytest.mark.usefixtures("widget")
+def test_handles_rules_exception(mock_dispatch, mock_system_feature):
+    mock_dispatch.reset_mock()
+    mock_system_feature.on_next(
+        {"rules": MagicMock(error="foo", loading=False), "rules_config": MagicMock()}
+    )
+    mock_dispatch.assert_called_with(
+        InstanceOf(Action)
+        & Attrs(
+            type=ADD_NOTIFICATION,
+            payload=Attrs(text=RULES_LOAD_ERROR),
+        )
+    )
+
+
+def test_populates_text_editor(widget, mock_system_feature, mocker):
+    mock_rules_file_path = "/foo/path"
+    mock_text_renderer = MagicMock()
     mocker.patch(
         "fapolicy_analyzer.ui.rules.rules_text_view.RulesTextView.render_rules",
         mock_text_renderer,
     )
     mock_system_feature.on_next(
         {
-            "rules": MagicMock(error=None, rules=mock_rules, loading=False),
+            "rules": MagicMock(),
+            "rules_config": MagicMock(
+                error=None,
+                rules_config={"rules_path": mock_rules_file_path},
+                loading=False,
+            ),
         }
     )
-    mock_list_renderer.assert_called_once_with(mock_rules)
-    mock_text_renderer.assert_called_once_with(mock_rules)
+    mock_text_renderer.assert_called_once_with(mock_rules_file_path)
 
 
 @pytest.mark.usefixtures("widget")
-def test_rules_w_exception(mock_dispatch, mock_system_feature):
+def test_handles_rules_config_exception(mock_dispatch, mock_system_feature):
     mock_dispatch.reset_mock()
-    mock_system_feature.on_next({"rules": MagicMock(error="foo", loading=False)})
+    mock_system_feature.on_next(
+        {"rules": MagicMock(), "rules_config": MagicMock(error="foo", loading=False)}
+    )
     mock_dispatch.assert_called_with(
         InstanceOf(Action)
         & Attrs(
             type=ADD_NOTIFICATION,
-            payload=Attrs(text=RULES_LOAD_ERROR),
+            payload=Attrs(text=RULES_CONFIG_LOAD_ERROR),
         )
     )

--- a/fapolicy_analyzer/tests/test_actions.py
+++ b/fapolicy_analyzer/tests/test_actions.py
@@ -30,6 +30,7 @@ from ui.actions import (
     ERROR_EVENTS,
     ERROR_GROUPS,
     ERROR_RULES,
+    ERROR_RULES_CONFIG,
     ERROR_SYSTEM_INITIALIZATION,
     ERROR_SYSTEM_TRUST,
     ERROR_USERS,
@@ -38,6 +39,7 @@ from ui.actions import (
     RECEIVED_EVENTS,
     RECEIVED_GROUPS,
     RECEIVED_RULES,
+    RECEIVED_RULES_CONFIG,
     RECEIVED_SYSTEM_TRUST,
     RECEIVED_USERS,
     REMOVE_NOTIFICATION,
@@ -45,6 +47,7 @@ from ui.actions import (
     REQUEST_EVENTS,
     REQUEST_GROUPS,
     REQUEST_RULES,
+    REQUEST_RULES_CONFIG,
     REQUEST_SYSTEM_TRUST,
     REQUEST_USERS,
     RESTORE_SYSTEM_CHECKPOINT,
@@ -63,6 +66,7 @@ from ui.actions import (
     error_events,
     error_groups,
     error_rules,
+    error_rules_config,
     error_system_trust,
     error_users,
     init_system,
@@ -70,6 +74,7 @@ from ui.actions import (
     received_events,
     received_groups,
     received_rules,
+    received_rules_config,
     received_system_trust,
     received_users,
     remove_notification,
@@ -77,6 +82,7 @@ from ui.actions import (
     request_events,
     request_groups,
     request_rules,
+    request_rules_config,
     request_system_trust,
     request_users,
     restore_system_checkpoint,
@@ -299,6 +305,28 @@ def test_error_rules():
     action = error_rules("foo")
     assert type(action) is Action
     assert action.type == ERROR_RULES
+    assert action.payload == "foo"
+
+
+def test_request_rules_config():
+    action = request_rules_config()
+    assert type(action) is Action
+    assert action.type == REQUEST_RULES_CONFIG
+    assert not action.payload
+
+
+def test_received_rules_config():
+    config = {"rules_path": "/foo/path"}
+    action = received_rules_config(config)
+    assert type(action) is Action
+    assert action.type == RECEIVED_RULES_CONFIG
+    assert action.payload == config
+
+
+def test_error_rules_config():
+    action = error_rules_config("foo")
+    assert type(action) is Action
+    assert action.type == ERROR_RULES_CONFIG
     assert action.payload == "foo"
 
 

--- a/fapolicy_analyzer/ui/actions.py
+++ b/fapolicy_analyzer/ui/actions.py
@@ -15,7 +15,7 @@
 
 from enum import Enum
 from itertools import count
-from typing import Any, Iterator, NamedTuple, Sequence
+from typing import Any, Iterator, Mapping, NamedTuple, Sequence
 
 from fapolicy_analyzer import Changeset, Event, Group, Rule, Trust, User
 from redux import Action, create_action
@@ -61,6 +61,10 @@ ERROR_GROUPS = "ERROR_GROUPS"
 REQUEST_RULES = "REQUEST_RULES"
 RECEIVED_RULES = "RECEIVED_RULES"
 ERROR_RULES = "ERROR_RULES"
+
+REQUEST_RULES_CONFIG = "REQUEST_RULES_CONFIG"
+RECEIVED_RULES_CONFIG = "RECEIVED_RULES_CONFIG"
+ERROR_RULES_CONFIG = "ERROR_RULES_CONFIG"
 
 
 def _create_action(type: str, payload: Any = None) -> Action:
@@ -193,6 +197,18 @@ def received_rules(rules: Sequence[Rule]) -> Action:
 
 def error_rules(error: str) -> Action:
     return _create_action(ERROR_RULES, error)
+
+
+def request_rules_config() -> Action:
+    return _create_action(REQUEST_RULES_CONFIG)
+
+
+def received_rules_config(rules_config: Mapping[str, str]) -> Action:
+    return _create_action(RECEIVED_RULES_CONFIG, rules_config)
+
+
+def error_rules_config(error: str) -> Action:
+    return _create_action(ERROR_RULES_CONFIG, error)
 
 
 def init_system() -> Action:

--- a/fapolicy_analyzer/ui/features/system_feature.py
+++ b/fapolicy_analyzer/ui/features/system_feature.py
@@ -14,14 +14,10 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import logging
-
-import gi
-
-gi.require_version("Gtk", "3.0")
-
 from concurrent.futures import ThreadPoolExecutor
 from typing import Callable, Sequence
 
+import gi
 from fapolicy_analyzer import Changeset, System, rollback_fapolicyd
 from fapolicy_analyzer.ui.actions import (
     APPLY_CHANGESETS,
@@ -30,6 +26,7 @@ from fapolicy_analyzer.ui.actions import (
     REQUEST_EVENTS,
     REQUEST_GROUPS,
     REQUEST_RULES,
+    REQUEST_RULES_CONFIG,
     REQUEST_SYSTEM_TRUST,
     REQUEST_USERS,
     RESTORE_SYSTEM_CHECKPOINT,
@@ -42,6 +39,7 @@ from fapolicy_analyzer.ui.actions import (
     error_events,
     error_groups,
     error_rules,
+    error_rules_config,
     error_system_trust,
     error_users,
     init_system,
@@ -49,6 +47,7 @@ from fapolicy_analyzer.ui.actions import (
     received_events,
     received_groups,
     received_rules,
+    received_rules_config,
     received_system_trust,
     received_users,
     system_initialization_error,
@@ -57,7 +56,6 @@ from fapolicy_analyzer.ui.actions import (
 from fapolicy_analyzer.ui.reducers import system_reducer
 from fapolicy_analyzer.ui.strings import SYSTEM_INITIALIZATION_ERROR
 from fapolicy_analyzer.util.fapd_dbase import fapd_dbase_snapshot
-from gi.repository import GLib
 from redux import (
     Action,
     ReduxFeatureModule,
@@ -68,6 +66,9 @@ from redux import (
 )
 from rx import of, pipe
 from rx.operators import catch, ignore_elements, map
+
+gi.require_version("Gtk", "3.0")
+from gi.repository import GLib  # isort: skip
 
 SYSTEM_FEATURE = "system"
 _system: System
@@ -172,6 +173,11 @@ def create_system_feature(
         rules = _system.rules()
         return received_rules(rules)
 
+    def _get_rules_config(_: Action) -> Action:
+        # TODO: This will eventually come from the backend
+        rules_config = {"rules_path": "/etc/fapolicyd/fapolicyd.rules"}
+        return received_rules_config(rules_config)
+
     init_epic = pipe(
         of_init_feature(SYSTEM_FEATURE),
         map(lambda _: _init_system()),
@@ -234,6 +240,12 @@ def create_system_feature(
         catch(lambda ex, source: of(error_rules(str(ex)))),
     )
 
+    request_rules_config_epic = pipe(
+        of_type(REQUEST_RULES_CONFIG),
+        map(_get_rules_config),
+        catch(lambda ex, source: of(error_rules_config(str(ex)))),
+    )
+
     system_epic = combine_epics(
         init_epic,
         apply_changesets_epic,
@@ -242,6 +254,7 @@ def create_system_feature(
         request_events_epic,
         request_groups_epic,
         request_rules_epic,
+        request_rules_config_epic,
         request_system_trust_epic,
         request_users_epic,
         restore_system_checkpoint_epic,

--- a/fapolicy_analyzer/ui/reducers/rules_config_reducer.py
+++ b/fapolicy_analyzer/ui/reducers/rules_config_reducer.py
@@ -1,0 +1,61 @@
+# Copyright Concurrent Technologies Corporation 2022
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+from typing import Any, Mapping, NamedTuple, Optional, cast
+
+from fapolicy_analyzer.ui.actions import (
+    ERROR_RULES_CONFIG,
+    RECEIVED_RULES_CONFIG,
+    REQUEST_RULES_CONFIG,
+)
+from redux import Action, Reducer, handle_actions
+
+
+class RuleConfigState(NamedTuple):
+    error: Optional[str]
+    loading: bool
+    rules_config: Mapping[str, str]
+
+
+def _create_state(state: RuleConfigState, **kwargs: Optional[Any]) -> RuleConfigState:
+    return RuleConfigState(**{**state._asdict(), **kwargs})
+
+
+def handle_request_rules_config(state: RuleConfigState, _: Action) -> RuleConfigState:
+    return _create_state(state, loading=True, error=None)
+
+
+def handle_received_rules_config(
+    state: RuleConfigState, action: Action
+) -> RuleConfigState:
+    payload = cast(Mapping[str, str], action.payload)
+    return _create_state(state, rules_config=payload, error=None, loading=False)
+
+
+def handle_error_rules_config(
+    state: RuleConfigState, action: Action
+) -> RuleConfigState:
+    payload = cast(str, action.payload)
+    return _create_state(state, error=payload, loading=False)
+
+
+rules_config_reducer: Reducer = handle_actions(
+    {
+        REQUEST_RULES_CONFIG: handle_request_rules_config,
+        RECEIVED_RULES_CONFIG: handle_received_rules_config,
+        ERROR_RULES_CONFIG: handle_error_rules_config,
+    },
+    RuleConfigState(error=None, rules_config={}, loading=False),
+)

--- a/fapolicy_analyzer/ui/reducers/system_reducer.py
+++ b/fapolicy_analyzer/ui/reducers/system_reducer.py
@@ -21,6 +21,7 @@ from .changeset_reducer import changeset_reducer
 from .event_reducer import event_reducer
 from .group_reducer import group_reducer
 from .rule_reducer import rule_reducer
+from .rules_config_reducer import rules_config_reducer
 from .system_trust_reducer import system_trust_reducer
 from .user_reducer import user_reducer
 
@@ -41,6 +42,7 @@ system_reducer: Reducer = combine_reducers(
         "events": event_reducer,
         "groups": group_reducer,
         "rules": rule_reducer,
+        "rules_config": rules_config_reducer,
         "system_trust": system_trust_reducer,
         "users": user_reducer,
     }

--- a/fapolicy_analyzer/ui/rules/rules_admin_page.py
+++ b/fapolicy_analyzer/ui/rules/rules_admin_page.py
@@ -17,16 +17,13 @@ import logging
 from typing import Any, Mapping, Optional, Sequence
 
 from fapolicy_analyzer import Rule
-from fapolicy_analyzer.ui.actions import (
-    NotificationType,
-    add_notification,
-    request_rules,
-    request_rules_config,
-)
+from fapolicy_analyzer.ui.actions import (NotificationType, add_notification,
+                                          request_rules, request_rules_config)
 from fapolicy_analyzer.ui.rules.rules_list_view import RulesListView
 from fapolicy_analyzer.ui.rules.rules_text_view import RulesTextView
 from fapolicy_analyzer.ui.store import dispatch, get_system_feature
-from fapolicy_analyzer.ui.strings import RULES_CONFIG_LOAD_ERROR, RULES_LOAD_ERROR
+from fapolicy_analyzer.ui.strings import (RULES_CONFIG_LOAD_ERROR,
+                                          RULES_LOAD_ERROR)
 from fapolicy_analyzer.ui.ui_page import UIPage
 from fapolicy_analyzer.ui.ui_widget import UIConnectedWidget
 
@@ -70,7 +67,7 @@ class RulesAdminPage(UIConnectedWidget, UIPage):
         if not rules_state.loading and self.__error_rules != rules_state.error:
             self.__error_rules = rules_state.error
             self.__loading_rules = False
-            logging.error("%s: %s", RULES_LOAD_ERROR, self.__error)
+            logging.error("%s: %s", RULES_LOAD_ERROR, self.__error_rules)
             dispatch(add_notification(RULES_LOAD_ERROR, NotificationType.ERROR))
         elif (
             self.__loading_rules
@@ -85,7 +82,7 @@ class RulesAdminPage(UIConnectedWidget, UIPage):
         if not config_state.loading and self.__error_config != config_state.error:
             self.__error_config = config_state.error
             self.__loading_config = False
-            logging.error("%s: %s", RULES_CONFIG_LOAD_ERROR, self.__error)
+            logging.error("%s: %s", RULES_CONFIG_LOAD_ERROR, self.__error_config)
             dispatch(add_notification(RULES_CONFIG_LOAD_ERROR, NotificationType.ERROR))
         elif (
             self.__loading_config

--- a/fapolicy_analyzer/ui/rules/rules_text_view.py
+++ b/fapolicy_analyzer/ui/rules/rules_text_view.py
@@ -13,9 +13,11 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-from typing import Sequence
+import logging
 
-from fapolicy_analyzer import Rule
+from fapolicy_analyzer.ui.actions import NotificationType, add_notification
+from fapolicy_analyzer.ui.store import dispatch
+from fapolicy_analyzer.ui.strings import RULES_FILE_READ_ERROR
 from fapolicy_analyzer.ui.ui_widget import UIBuilderWidget
 
 
@@ -25,6 +27,12 @@ class RulesTextView(UIBuilderWidget):
         self.__text_view = self.get_object("textView")
         self.__text_view.set_show_line_numbers(True)
 
-    def render_rules(self, rules: Sequence[Rule]):
-        text = "\n".join([r.text for r in rules])
+    def render_rules(self, rules_path: str):
+        try:
+            with open(rules_path, "r") as f:
+                text = f.read()
+        except (IOError, FileNotFoundError) as e:
+            logging.error("%s: %s", RULES_FILE_READ_ERROR, e)
+            dispatch(add_notification(RULES_FILE_READ_ERROR, NotificationType.ERROR))
+
         self.__text_view.get_buffer().set_text(text)

--- a/fapolicy_analyzer/ui/rules/rules_text_view.py
+++ b/fapolicy_analyzer/ui/rules/rules_text_view.py
@@ -29,7 +29,6 @@ class RulesTextView(UIBuilderWidget):
 
     def render_rules(self, rules_path: str):
         text = ""
-        print(open)
         try:
             with open(rules_path, "r") as f:
                 text = f.read()

--- a/fapolicy_analyzer/ui/rules/rules_text_view.py
+++ b/fapolicy_analyzer/ui/rules/rules_text_view.py
@@ -28,6 +28,8 @@ class RulesTextView(UIBuilderWidget):
         self.__text_view.set_show_line_numbers(True)
 
     def render_rules(self, rules_path: str):
+        text = ""
+        print(open)
         try:
             with open(rules_path, "r") as f:
                 text = f.read()

--- a/fapolicy_analyzer/ui/strings.py
+++ b/fapolicy_analyzer/ui/strings.py
@@ -22,6 +22,8 @@ SYSTEM_INITIALIZATION_ERROR = _("Error initializing System")
 ANCILLARY_TRUST_LOAD_ERROR = _("Error loading Ancillary Trust")
 SYSTEM_TRUST_LOAD_ERROR = _("Error loading System Trust")
 RULES_LOAD_ERROR = _("Error loading Rules")
+RULES_CONFIG_LOAD_ERROR = _("Error loading Rules configuration")
+RULES_FILE_READ_ERROR = _("Error reading the Rules file")
 DAEMON_INITIALIZATION_ERROR = _("Error initializing communications with daemon")
 
 DEPLOY_ANCILLARY_CONFIRM_DIALOG_TITLE = _("Deploy Ancillary Trust Changes?")


### PR DESCRIPTION
This PR reworks the Rules Admin tool's Text Editor view so it reads in and displays the fapolicyd rules file directly instead of using the parsed rules list from the backend. Right now it's hard coded to the monolithic rules file location. The backend will need updates to handle both the rules.d directory structure and a call to return the current rules file(s) location as config data at some point.