### PR TITLE
Rule Info API

### DIFF
--- a/crates/pyo3/src/rules.rs
+++ b/crates/pyo3/src/rules.rs
@@ -13,11 +13,25 @@ use pyo3::prelude::*;
 pub struct PyRule {
     pub id: usize,
     pub text: String,
+    pub info: Vec<PyRuleInfo>,
+    pub valid: bool,
 }
 
 impl PyRule {
-    pub fn new(id: usize, text: String) -> Self {
-        Self { id, text }
+    pub fn new(id: usize, text: String, info: Vec<(String, String)>, valid: bool) -> Self {
+        let info = info
+            .iter()
+            .map(|(c, m)| PyRuleInfo {
+                category: c.clone(),
+                message: m.clone(),
+            })
+            .collect();
+        Self {
+            id,
+            text,
+            info,
+            valid,
+        }
     }
 }
 
@@ -32,9 +46,40 @@ impl PyRule {
     fn get_text(&self) -> String {
         self.text.clone()
     }
+
+    #[getter]
+    fn get_info(&self) -> Vec<PyRuleInfo> {
+        self.info.clone()
+    }
+
+    #[getter]
+    fn is_valid(&self) -> bool {
+        self.valid
+    }
+}
+
+#[pyclass(module = "rules", name = "Info")]
+#[derive(Clone)]
+pub struct PyRuleInfo {
+    pub category: String,
+    pub message: String,
+}
+
+#[pymethods]
+impl PyRuleInfo {
+    #[getter]
+    fn get_category(&self) -> String {
+        self.category.clone()
+    }
+
+    #[getter]
+    fn get_message(&self) -> String {
+        self.message.clone()
+    }
 }
 
 pub fn init_module(_py: Python, m: &PyModule) -> PyResult<()> {
     m.add_class::<PyRule>()?;
+    m.add_class::<PyRuleInfo>()?;
     Ok(())
 }

--- a/crates/pyo3/src/system.rs
+++ b/crates/pyo3/src/system.rs
@@ -148,7 +148,7 @@ impl PySystem {
             .rs
             .rules_db
             .iter()
-            .map(|(id, r)| PyRule::new(*id, r.to_string()))
+            .map(|(id, r)| PyRule::new(*id, r.to_string(), vec![], true))
             .collect())
     }
 }

--- a/examples/show_rules.py
+++ b/examples/show_rules.py
@@ -1,0 +1,29 @@
+# Copyright Concurrent Technologies Corporation 2021
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+from fapolicy_analyzer import *
+
+green = '\033[91m'
+red = '\033[92m'
+yellow = '\033[93m'
+blue = '\033[96m'
+
+s1 = System()
+for r in s1.rules():
+    print(red if r.is_valid else green, end='')
+    print(f"{r.id} {r.text} \033[0m")
+    for info in r.info:
+        print(yellow if info.category == 'w' else blue, end='')
+        print(f"\t- [{info.category}] {info.message} \033[0m")


### PR DESCRIPTION
A mechanism to provide metadata for a rule.

Metadata can be generated from various sources, for example during the parse that creates a rule from text there can be warnings or errors. Another producer could be a post parse linting process that could generate warnings or suggestions.  This change allows the Rule API to pass any of these types of info along.

This also provides a bool field which indicates whether the rule should be considered valid according to the current configuration of the application.

Closes #390