### PR TITLE
Rule origin

### DIFF
--- a/crates/pyo3/src/rules.rs
+++ b/crates/pyo3/src/rules.rs
@@ -13,12 +13,19 @@ use pyo3::prelude::*;
 pub struct PyRule {
     pub id: usize,
     pub text: String,
+    pub origin: String,
     pub info: Vec<PyRuleInfo>,
     pub valid: bool,
 }
 
 impl PyRule {
-    pub fn new(id: usize, text: String, info: Vec<(String, String)>, valid: bool) -> Self {
+    pub fn new(
+        id: usize,
+        text: String,
+        origin: String,
+        info: Vec<(String, String)>,
+        valid: bool,
+    ) -> Self {
         let info = info
             .iter()
             .map(|(c, m)| PyRuleInfo {
@@ -26,9 +33,11 @@ impl PyRule {
                 message: m.clone(),
             })
             .collect();
+
         Self {
             id,
             text,
+            origin,
             info,
             valid,
         }
@@ -45,6 +54,11 @@ impl PyRule {
     #[getter]
     fn get_text(&self) -> String {
         self.text.clone()
+    }
+
+    #[getter]
+    fn get_origin(&self) -> String {
+        self.origin.clone()
     }
 
     #[getter]

--- a/crates/pyo3/src/system.rs
+++ b/crates/pyo3/src/system.rs
@@ -21,6 +21,7 @@ use crate::change::PyChangeset;
 
 use super::trust::PyTrust;
 use crate::rules::PyRule;
+use fapolicy_daemon::fapolicyd;
 
 #[pyclass(module = "app", name = "System")]
 #[derive(Clone)]
@@ -148,7 +149,15 @@ impl PySystem {
             .rs
             .rules_db
             .iter()
-            .map(|(id, r)| PyRule::new(*id, r.to_string(), vec![], true))
+            .map(|(id, r)| {
+                PyRule::new(
+                    *id,
+                    r.to_string(),
+                    fapolicyd::RULES_FILE_PATH.to_string(),
+                    vec![],
+                    true,
+                )
+            })
             .collect())
     }
 }

--- a/examples/show_rules.py
+++ b/examples/show_rules.py
@@ -21,7 +21,13 @@ yellow = '\033[93m'
 blue = '\033[96m'
 
 s1 = System()
+
+origin = None
 for r in s1.rules():
+    if r.origin != origin:
+        origin = r.origin
+        print(f"[{origin}]")
+
     print(red if r.is_valid else green, end='')
     print(f"{r.id} {r.text} \033[0m")
     for info in r.info:


### PR DESCRIPTION
Track the file a rule originates in.

This is aimed at supporting the rules.d structure parsing.  It allows the GUI to display the various source files that contribute to the full rule set, while also providing the indication on edit of where the rule should be written out to.

#398
