### PR TITLE
Rule validation wiring

### DIFF
--- a/crates/pyo3/src/system.rs
+++ b/crates/pyo3/src/system.rs
@@ -22,6 +22,7 @@ use crate::change::PyChangeset;
 use super::trust::PyTrust;
 use crate::rules::PyRule;
 use fapolicy_daemon::fapolicyd;
+use fapolicy_rules::db::RuleDef;
 
 #[pyclass(module = "app", name = "System")]
 #[derive(Clone)]
@@ -150,12 +151,17 @@ impl PySystem {
             .rules_db
             .iter()
             .map(|(id, r)| {
+                let (valid, text) = match r {
+                    RuleDef::Invalid(t) => (false, t.clone()),
+                    RuleDef::Valid(r) => (true, r.to_string()),
+                };
+
                 PyRule::new(
                     *id,
-                    r.to_string(),
+                    text,
                     fapolicyd::RULES_FILE_PATH.to_string(),
                     vec![],
-                    true,
+                    valid,
                 )
             })
             .collect())


### PR DESCRIPTION
This completes a required step in improving rule parse feedback by connecting the parse results through to the bindings for both success and failure cases.  The improvement here is that on parse failure the parsed text is conveyed through the bindings as a rule that is flagged as invalid, where previously the rule was simply evicted from the DB without any indication there was a failure.

Entries in the rule database are now a choice between a valid and invalid rule state.  Eventually checks will be added to identify the DB itself as valid or invalid, and that will then in turn inform the system as to whether it is valid or invalid.

for #269