### PR TITLE
Rules.d support

### DIFF
--- a/crates/pyo3/src/system.rs
+++ b/crates/pyo3/src/system.rs
@@ -14,7 +14,6 @@ use fapolicy_analyzer::events::db::DB as EventDB;
 use fapolicy_app::app::State;
 use fapolicy_app::cfg;
 use fapolicy_app::sys::deploy_app_state;
-use fapolicy_daemon::fapolicyd;
 use fapolicy_rules::db::RuleDef;
 
 use crate::acl::{PyGroup, PyUser};
@@ -159,7 +158,7 @@ impl PySystem {
                 PyRule::new(
                     *id,
                     text,
-                    fapolicyd::RULES_FILE_PATH.to_string(),
+                    self.rs.rules_db.source(*id).unwrap(),
                     info,
                     valid,
                 )

--- a/crates/rules/src/lib.rs
+++ b/crates/rules/src/lib.rs
@@ -25,6 +25,8 @@ pub mod parse;
 
 pub mod db;
 pub mod error;
+pub mod load;
+
 mod permission;
 pub mod read;
 mod rule;

--- a/crates/rules/src/load.rs
+++ b/crates/rules/src/load.rs
@@ -1,0 +1,77 @@
+/*
+ * Copyright Concurrent Technologies Corporation 2021
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+use std::fs::File;
+use std::io::{BufRead, BufReader};
+use std::path::PathBuf;
+use std::{fs, io};
+
+pub(crate) type RuleSource = (PathBuf, String);
+
+pub fn rules_from(path: PathBuf) -> Result<Vec<RuleSource>, io::Error> {
+    if path.is_dir() {
+        rules_dir(path)
+    } else {
+        rules_file(path)
+    }
+}
+
+fn rules_file(path: PathBuf) -> Result<Vec<RuleSource>, io::Error> {
+    let reader = File::open(&path).map(BufReader::new)?;
+    let lines = reader
+        .lines()
+        .flatten()
+        .map(|s| (path.clone(), s))
+        .collect();
+    Ok(lines)
+}
+
+fn rules_dir(rules_source_path: PathBuf) -> Result<Vec<RuleSource>, io::Error> {
+    let d_files: Result<Vec<PathBuf>, io::Error> = fs::read_dir(&rules_source_path)?
+        .map(|e| e.map(|e| e.path()))
+        .collect();
+
+    let mut d_files: Vec<PathBuf> = d_files?
+        .into_iter()
+        .filter(|p| p.is_file() && p.display().to_string().ends_with(".rules"))
+        .collect();
+    d_files.sort_by_key(|p| p.display().to_string());
+
+    let d_files: Result<Vec<(PathBuf, File)>, io::Error> = d_files
+        .into_iter()
+        .map(|p| (p.clone(), File::open(&p)))
+        .map(|(p, r)| r.map(|f| (p, f)))
+        .collect();
+
+    let d_files = d_files?.into_iter().map(|(p, f)| (p, BufReader::new(f)));
+
+    // todo;; externalize result flattening via expect here
+    let d_files = d_files.into_iter().map(|(path, rdr)| {
+        (
+            path.clone(),
+            rdr.lines()
+                .collect::<Result<Vec<String>, io::Error>>()
+                .unwrap_or_else(|_| {
+                    panic!("failed to read lines from rules file, {}", path.display())
+                }),
+        )
+    });
+
+    let d_files: Vec<RuleSource> = d_files
+        .into_iter()
+        .flat_map(|(src, lines)| {
+            lines
+                .iter()
+                .map(|l| (src.clone(), l.clone()))
+                .collect::<Vec<RuleSource>>()
+        })
+        .collect();
+
+    // todo;; revisit result flattening
+    Ok(d_files)
+}

--- a/crates/rules/src/parser/trace.rs
+++ b/crates/rules/src/parser/trace.rs
@@ -83,11 +83,11 @@ where
     type IterElem = I::IterElem;
 
     fn iter_indices(&self) -> Self::Iter {
-        todo!()
+        self.fragment.iter_indices()
     }
 
     fn iter_elements(&self) -> Self::IterElem {
-        todo!()
+        self.fragment.iter_elements()
     }
 
     fn position<P>(&self, predicate: P) -> Option<usize>

--- a/examples/show_rules.py
+++ b/examples/show_rules.py
@@ -19,6 +19,7 @@ green = '\033[91m'
 red = '\033[92m'
 yellow = '\033[93m'
 blue = '\033[96m'
+gray = '\033[33m'
 
 s1 = System()
 
@@ -26,7 +27,9 @@ origin = None
 for r in s1.rules():
     if r.origin != origin:
         origin = r.origin
-        print(f"[{origin}]")
+        print()
+        print(gray, end='')
+        print(f"🗎 [{origin}]\033[0m")
 
     print(red if r.is_valid else green, end='')
     print(f"{r.id} {r.text} \033[0m")

--- a/examples/show_trust.rs
+++ b/examples/show_trust.rs
@@ -1,0 +1,35 @@
+// Copyright Concurrent Technologies Corporation 2021
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+use fapolicy_app::app::State;
+use fapolicy_app::cfg::All;
+use fapolicy_trust::stat::Status::{Discrepancy, Trusted};
+use std::error::Error;
+
+fn main() -> Result<(), Box<dyn Error>> {
+    let cfg = All::load()?;
+    let state = State::load_checked(&cfg)?;
+
+    state.trust_db.iter().for_each(|(p, rec)| {
+        let flag = match rec.status {
+            Some(Trusted(_, _)) => "T",
+            Some(Discrepancy(_, _)) => "D",
+            _ => "U",
+        };
+        println!("[{}] - {}", flag, p);
+    });
+
+    Ok(())
+}


### PR DESCRIPTION
Add support for specifying a directory as the source of rules.

When specified the loader reads all *.rules files under this dir into the Rules DB.

Closes #428 