### PR TITLE
Initial rule linting

### DIFF
--- a/crates/pyo3/src/system.rs
+++ b/crates/pyo3/src/system.rs
@@ -149,19 +149,22 @@ impl PySystem {
             .iter()
             .map(|(id, r)| {
                 let (valid, text, info) = match r {
-                    RuleDef::Invalid(t, why) => {
-                        (false, t.clone(), vec![("e".to_string(), why.clone())])
+                    RuleDef::Invalid { text, error } => {
+                        (false, text.clone(), vec![("e".to_string(), error.clone())])
                     }
                     RuleDef::Valid(r) => (true, r.to_string(), vec![]),
+                    RuleDef::ValidWithWarning(r, w) => {
+                        (true, r.to_string(), vec![("w".to_string(), w.clone())])
+                    }
                 };
+                let origin = self
+                    .rs
+                    .rules_db
+                    .source(*id)
+                    // todo;; this should be converted to a python exception
+                    .unwrap_or_else(|| "<unknown>".to_string());
 
-                PyRule::new(
-                    *id,
-                    text,
-                    self.rs.rules_db.source(*id).unwrap(),
-                    info,
-                    valid,
-                )
+                PyRule::new(*id, text, origin, info, valid)
             })
             .collect())
     }

--- a/crates/rules/src/db.rs
+++ b/crates/rules/src/db.rs
@@ -17,9 +17,9 @@ use crate::Rule;
 /// When valid the text definition can be rendered from the ADTs
 #[derive(Clone, Debug)]
 pub enum RuleDef {
-    // Rule Text, Error Msg
-    Invalid(String, String),
     Valid(Rule),
+    ValidWithWarning(Rule, String),
+    Invalid { text: String, error: String },
 }
 
 /// Rules Database
@@ -121,7 +121,10 @@ mod tests {
         pub fn unwrap(&self) -> Rule {
             match self {
                 RuleDef::Valid(val) => val.clone(),
-                RuleDef::Invalid(_, _) => panic!("called `RuleDef::unwrap()` on an invalid rule"),
+                RuleDef::ValidWithWarning(val, _) => val.clone(),
+                RuleDef::Invalid { text: _, error: _ } => {
+                    panic!("called `RuleDef::unwrap()` on an invalid rule")
+                }
             }
         }
     }

--- a/crates/rules/src/lib.rs
+++ b/crates/rules/src/lib.rs
@@ -20,6 +20,7 @@ pub mod parser;
 
 mod decision;
 mod file_type;
+mod linter;
 mod object;
 pub mod parse;
 

--- a/crates/rules/src/linter/findings.rs
+++ b/crates/rules/src/linter/findings.rs
@@ -1,0 +1,47 @@
+/*
+ * Copyright Concurrent Technologies Corporation 2021
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+use crate::db::DB;
+use crate::Rule;
+use std::path::PathBuf;
+
+pub fn l001(id: usize, r: &Rule, db: &DB) -> Option<String> {
+    if id < db.len() // rules are indexed from 1
+        && r.perm.is_any()
+        && r.subj.is_all()
+        && r.obj.is_all()
+    {
+        Some("Using any+all+all here will short-circuit all other rules.".to_string())
+    } else {
+        None
+    }
+}
+
+pub fn l002(_id: usize, r: &Rule, _db: &DB) -> Option<String> {
+    if let Some(path) = r.subj.exe().map(PathBuf::from) {
+        if !path.exists() {
+            Some("The exe specified does not exist.".to_string())
+        } else {
+            None
+        }
+    } else {
+        None
+    }
+}
+
+pub fn l003(_id: usize, r: &Rule, _db: &DB) -> Option<String> {
+    if let Some(path) = r.obj.path().map(PathBuf::from) {
+        if !path.exists() {
+            Some("The path specified does not exist.".to_string())
+        } else {
+            None
+        }
+    } else {
+        None
+    }
+}

--- a/crates/rules/src/linter/lint.rs
+++ b/crates/rules/src/linter/lint.rs
@@ -1,0 +1,38 @@
+/*
+ * Copyright Concurrent Technologies Corporation 2021
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+use crate::db::{RuleDef, DB};
+use crate::linter::findings::*;
+use crate::Rule;
+
+type LintFn = fn(usize, &Rule, &DB) -> Option<String>;
+
+pub fn lint_db(db: DB) -> DB {
+    let lints: Vec<LintFn> = vec![l001, l002, l003];
+    DB::from_sources(
+        db.iter()
+            .map(|(&id, def)| {
+                let source = db.source(id).unwrap();
+                match def {
+                    RuleDef::Valid(r) => {
+                        let x: Vec<String> = lints.iter().filter_map(|f| f(id, r, &db)).collect();
+                        if x.is_empty() {
+                            (source, RuleDef::Valid(r.clone()))
+                        } else {
+                            (
+                                source,
+                                RuleDef::ValidWithWarning(r.clone(), x.first().unwrap().clone()),
+                            )
+                        }
+                    }
+                    d => (source, d.clone()),
+                }
+            })
+            .collect(),
+    )
+}

--- a/crates/rules/src/linter/mod.rs
+++ b/crates/rules/src/linter/mod.rs
@@ -1,0 +1,10 @@
+/*
+ * Copyright Concurrent Technologies Corporation 2021
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+mod findings;
+pub mod lint;

--- a/crates/rules/src/object.rs
+++ b/crates/rules/src/object.rs
@@ -26,6 +26,10 @@ impl Object {
         Object { parts }
     }
 
+    pub fn is_all(&self) -> bool {
+        self.parts.contains(&Part::All)
+    }
+
     pub fn all() -> Self {
         Self::new(vec![ObjPart::All])
     }

--- a/crates/rules/src/permission.rs
+++ b/crates/rules/src/permission.rs
@@ -22,6 +22,12 @@ pub enum Permission {
     Execute,
 }
 
+impl Permission {
+    pub fn is_any(&self) -> bool {
+        matches!(self, Permission::Any)
+    }
+}
+
 impl Display for Permission {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         f.write_str("perm=")?;

--- a/crates/rules/src/read.rs
+++ b/crates/rules/src/read.rs
@@ -16,6 +16,7 @@ use nom::sequence::tuple;
 
 use crate::db::{RuleDef, DB};
 use crate::error::Error;
+use crate::linter::lint::lint_db;
 use crate::parse::{StrTrace, TraceResult};
 use crate::read::Line::*;
 use crate::{load, parse, Rule, Set};
@@ -78,10 +79,10 @@ pub fn load_rules_db(path: &str) -> Result<DB, Error> {
         .map(|(source, line)| (source.display().to_string(), line))
         .filter_map(|(source, line)| match line {
             WellFormedRule(r) => Some((source, RuleDef::Valid(r))),
-            MalformedRule(txt, why) => Some((source, RuleDef::Invalid(txt, why))),
+            MalformedRule(text, error) => Some((source, RuleDef::Invalid { text, error })),
             _ => None,
         })
         .collect();
 
-    Ok(DB::from_sources(lookup))
+    Ok(lint_db(DB::from_sources(lookup)))
 }

--- a/crates/rules/src/subject.rs
+++ b/crates/rules/src/subject.rs
@@ -26,6 +26,10 @@ impl Subject {
         Subject { parts }
     }
 
+    pub fn is_all(&self) -> bool {
+        self.parts.contains(&Part::All)
+    }
+
     pub fn all() -> Self {
         Self::new(vec![SubjPart::All])
     }


### PR DESCRIPTION
Rule linting reference implementation intended to providing substance for  testing, discussion, and seeing the full round trip to the frontend.  A better solution will emerge.

### lints

![image](https://user-images.githubusercontent.com/1545372/159843505-6169ebe0-fd5a-431a-8f67-50888c92553b.png)

- warn: when an `any+all+all` rule is not the last rule
- warn: when a subject exe does not exist on disk
- warn: when an object path does not exist on disk 