### PR TITLE
Specifying prior version of pypi jinja2 package

### DIFF
--- a/.github/workflows/rpm.yml
+++ b/.github/workflows/rpm.yml
@@ -30,6 +30,7 @@ jobs:
       - name: Install basic rpmbuild toolchain
         run: |
           dnf install -y git rpm-build rpmdevtools dnf-plugins-core python3-pip
+          pip3 install --no-input jinja2==3.0.3
           pip3 install --no-input jinja2-cli
 
       - uses: actions/checkout@v2

--- a/scripts/rpm/Dockerfile
+++ b/scripts/rpm/Dockerfile
@@ -24,6 +24,7 @@ RUN grep -e "^Red Hat Enterprise Linux" /etc/redhat-release \
 
 # Install base toolchain; for tools not packaged in el8, just use pip always.
 RUN dnf install -y rpm-build rpmdevtools dnf-plugins-core python3-pip \
+ && pip3 install --no-input jinja2==3.0.3 \
  && pip3 install --no-input jinja2-cli \
  && dnf clean all
 


### PR DESCRIPTION
Pypi updated their jinjja2 package this morning. Appears to affect the CI rpm generation step in the pipeline.