### PR TITLE
Reverse rules.d loading

### DIFF
--- a/crates/rules/src/load.rs
+++ b/crates/rules/src/load.rs
@@ -41,6 +41,7 @@ fn rules_dir(rules_source_path: PathBuf) -> Result<Vec<RuleSource>, io::Error> {
         .filter(|p| p.is_file() && p.display().to_string().ends_with(".rules"))
         .collect();
     d_files.sort_by_key(|p| p.display().to_string());
+    d_files.reverse();
 
     let d_files: Result<Vec<(PathBuf, File)>, io::Error> = d_files
         .into_iter()


### PR DESCRIPTION
Rules from .d were loading in reverse order, this switches that around.