### PR TITLE
Lang support for file markers

### DIFF
--- a/share/sourceview/language-specs/fapolicyd-rules.lang
+++ b/share/sourceview/language-specs/fapolicyd-rules.lang
@@ -32,6 +32,7 @@
         <style id="subject" name="Subject list"/>
         <style id="object" name="Object list"/>
         <style id="wildcard" name="Wildcard identifiers"/>
+        <style id="marker" name="File marker"/>
     </styles>
 
     <definitions>
@@ -85,6 +86,11 @@
             <keyword>trust</keyword>
         </context>
 
+        <context id="markers" style-ref="marker">
+            <start>\[</start>
+            <end>]</end>
+        </context>
+
         <context id="fapolicyd-rules">
             <include>
                 <context ref="seperator"/>
@@ -95,6 +101,7 @@
                 <context ref="objects"/>
                 <context ref="permission"/>
                 <context ref="wildcards"/>
+                <context ref="markers"/>
 
                 <context ref="def:shell-like-comment"/>
             </include>

--- a/share/sourceview/styles/fapolicyd.xml
+++ b/share/sourceview/styles/fapolicyd.xml
@@ -52,7 +52,7 @@
     <!-- fapolicyd settings -->
 
     <!-- Misc -->
-    <style name="fapolicyd-rules:sep" background="red" bold="true" italic="true"/>
+    <style name="fapolicyd-rules:sep" background="red" bold="true"/>
     <style name="fapolicyd-rules:set" background="gray" foreground="yellow"/>
     <style name="fapolicyd-rules:wildcard" foreground="magenta" bold="true"/>
 
@@ -67,5 +67,8 @@
     <!-- Permissions -->
     <style name="fapolicyd-rules:subject" foreground="bordeaux"/>
     <style name="fapolicyd-rules:object" foreground="bordeaux"/>
+
+    <!-- Discriminator -->
+    <style name="fapolicyd-rules:discriminator" foreground="gray" bold="true" italic="true"/>
 
 </style-scheme>


### PR DESCRIPTION
Enable the fapolicyd-rules lang to recognize and highlight the discriminator format.

I was planning on doing a separate fapolicy-analyzer lang that extends fapolicyd, but instead this will be part of the fapolicyd lang.  It can be separated later if needed, but for now it is less overhead.

![image](https://user-images.githubusercontent.com/1545372/160238417-e9daed27-26c6-4841-b000-336e0f7a267d.png)

Closes #437