### PR TITLE
Added whitespaces around Trust and Access data columns

### DIFF
--- a/fapolicy_analyzer/tests/test_ancillary_trust_file_list.py
+++ b/fapolicy_analyzer/tests/test_ancillary_trust_file_list.py
@@ -69,7 +69,7 @@ def test_uses_custom_markup_func():
     widget = AncillaryTrustFileList(trust_func=MagicMock())
     widget.load_trust(_trust)
     view = widget.get_object("treeView")
-    assert ["T/<b><u>D</u></b>", "<b><u>T</u></b>/D", "T/D"] == [
+    assert ["T / <b><u>D</u></b>", "<b><u>T</u></b> / D", "T / D"] == [
         x[0] for x in view.get_model()
     ]
     assert [Colors.LIGHT_RED, Colors.LIGHT_GREEN, Colors.ORANGE] == [

--- a/fapolicy_analyzer/tests/test_object_list.py
+++ b/fapolicy_analyzer/tests/test_object_list.py
@@ -30,7 +30,9 @@ from ui.strings import FILE_LABEL, FILES_LABEL
 
 
 def _mock_object(trust="", mode="", access="", file="", trust_status=""):
-    return MagicMock(trust=trust, mode=mode, access=access, file=file, trust_status=trust_status)
+    return MagicMock(
+        trust=trust, mode=mode, access=access, file=file, trust_status=trust_status
+    )
 
 
 _objects = [
@@ -69,6 +71,9 @@ def test_loads_store(widget):
 
 
 def test_status_markup(widget):
+    def eq_status(*parts):
+        return view.get_model()[0][0] == str.join(" / ", parts)
+
     view = widget.get_object("treeView")
     st_red = f'<span color="{Colors.RED}"><b>ST</b></span>'
     at_red = f'<span color="{Colors.RED}"><b>AT</b></span>'
@@ -78,37 +83,37 @@ def test_status_markup(widget):
 
     # System trust
     widget.load_store([_mock_object(trust="ST", trust_status="U")])
-    assert view.get_model()[0][0] == st_red + "/AT/U"
+    assert eq_status(st_red, "AT", "U")
     # System trust
     widget.load_store([_mock_object(trust="ST", trust_status="T")])
-    assert view.get_model()[0][0] == st_green + "/AT/U"
+    assert eq_status(st_green, "AT", "U")
     # Ancillary trust, untrusted
     widget.load_store([_mock_object(trust="AT", trust_status="U")])
-    assert view.get_model()[0][0] == "ST/" + at_red + "/U"
+    assert eq_status("ST", at_red, "U")
     # Ancillary trust, trusted
     widget.load_store([_mock_object(trust="AT", trust_status="T")])
-    assert view.get_model()[0][0] == "ST/" + at_green + "/U"
+    assert eq_status("ST", at_green, "U")
     # Untrusted
     widget.load_store([_mock_object(trust="U", trust_status="U")])
-    assert view.get_model()[0][0] == "ST/AT/" + u_green
+    assert eq_status("ST", "AT", u_green)
     # Bad data
     widget.load_store([_mock_object(trust="foo")])
-    assert view.get_model()[0][0] == "ST/AT/U"
+    assert eq_status("ST", "AT", "U")
     # Empty data
     widget.load_store([_mock_object()])
-    assert view.get_model()[0][0] == "ST/AT/U"
+    assert eq_status("ST", "AT", "U")
     # Lowercase
     widget.load_store([_mock_object(trust="st", trust_status="u")])
-    assert view.get_model()[0][0] == st_red + "/AT/U"
+    assert eq_status(st_red, "AT", "U")
     # Lowercase
     widget.load_store([_mock_object(trust="st", trust_status="t")])
-    assert view.get_model()[0][0] == st_green + "/AT/U"
+    assert eq_status(st_green, "AT", "U")
     # Lowercase
     widget.load_store([_mock_object(trust="at", trust_status="u")])
-    assert view.get_model()[0][0] == "ST/" + at_red + "/U"
+    assert eq_status("ST", at_red, "U")
     # Lowercase
     widget.load_store([_mock_object(trust="at", trust_status="t")])
-    assert view.get_model()[0][0] == "ST/" + at_green + "/U"
+    assert eq_status("ST", at_green, "U")
 
 
 def test_mode_markup(widget):
@@ -146,23 +151,28 @@ def test_mode_markup(widget):
 
 
 def test_access_markup(widget):
+    def eq_access(*parts):
+        return view.get_model()[0][1] == str.join(" / ", parts)
+
+    a_access = "<u><b>A</b></u>"
+    d_access = "<u><b>D</b></u>"
     view = widget.get_object("treeView")
 
     # Allowed
     widget.load_store([_mock_object(access="A")])
-    assert view.get_model()[0][1] == "<u><b>A</b></u>/D"
+    assert eq_access(a_access, "D")
     # Denied
     widget.load_store([_mock_object(access="D")])
-    assert view.get_model()[0][1] == "A/<u><b>D</b></u>"
+    assert eq_access("A", d_access)
     # Bad data
     widget.load_store([_mock_object(access="foo")])
-    assert view.get_model()[0][1] == "A/D"
+    assert eq_access("A", "D")
     # Empty data
     widget.load_store([_mock_object()])
-    assert view.get_model()[0][1] == "A/D"
+    assert eq_access("A", "D")
     # Lowercase
     widget.load_store([_mock_object(access="a")])
-    assert view.get_model()[0][1] == "<u><b>A</b></u>/D"
+    assert eq_access(a_access, "D")
 
 
 def test_path_color(widget):

--- a/fapolicy_analyzer/tests/test_subject_list.py
+++ b/fapolicy_analyzer/tests/test_subject_list.py
@@ -74,6 +74,9 @@ def test_loads_store(widget):
 
 
 def test_status_markup(widget):
+    def eq_status(*parts):
+        return view.get_model()[0][0] == str.join(" / ", parts)
+
     view = widget.get_object("treeView")
     st_red = f'<span color="{Colors.RED}"><b>ST</b></span>'
     at_red = f'<span color="{Colors.RED}"><b>AT</b></span>'
@@ -83,60 +86,66 @@ def test_status_markup(widget):
 
     # System trust
     widget.load_store([_mock_subject(trust="ST", trust_status="U")])
-    assert view.get_model()[0][0] == st_red + "/AT/U"
+    assert eq_status(st_red, "AT", "U")
     # System trust
     widget.load_store([_mock_subject(trust="ST", trust_status="T")])
-    assert view.get_model()[0][0] == st_green + "/AT/U"
+    assert eq_status(st_green, "AT", "U")
     # Ancillary trust, untrusted
     widget.load_store([_mock_subject(trust="AT", trust_status="U")])
-    assert view.get_model()[0][0] == "ST/" + at_red + "/U"
+    assert eq_status("ST", at_red, "U")
     # Ancillary trust, trusted
     widget.load_store([_mock_subject(trust="AT", trust_status="T")])
-    assert view.get_model()[0][0] == "ST/" + at_green + "/U"
+    assert eq_status("ST", at_green, "U")
     # Untrusted
     widget.load_store([_mock_subject(trust="U", trust_status="U")])
-    assert view.get_model()[0][0] == "ST/AT/" + u_green
+    assert eq_status("ST", "AT", u_green)
     # Bad data
     widget.load_store([_mock_subject(trust="foo")])
-    assert view.get_model()[0][0] == "ST/AT/U"
+    assert eq_status("ST", "AT", "U")
     # Empty data
     widget.load_store([_mock_subject()])
-    assert view.get_model()[0][0] == "ST/AT/U"
+    assert eq_status("ST", "AT", "U")
     # Lowercase
     widget.load_store([_mock_subject(trust="st", trust_status="u")])
-    assert view.get_model()[0][0] == st_red + "/AT/U"
+    assert eq_status(st_red, "AT", "U")
     # Lowercase
     widget.load_store([_mock_subject(trust="st", trust_status="t")])
-    assert view.get_model()[0][0] == st_green + "/AT/U"
+    assert eq_status(st_green, "AT", "U")
     # Lowercase
     widget.load_store([_mock_subject(trust="at", trust_status="u")])
-    assert view.get_model()[0][0] == "ST/" + at_red + "/U"
+    assert eq_status("ST", at_red, "U")
     # Lowercase
     widget.load_store([_mock_subject(trust="at", trust_status="t")])
-    assert view.get_model()[0][0] == "ST/" + at_green + "/U"
+    assert eq_status("ST", at_green, "U")
 
 
 def test_access_markup(widget):
+    def eq_access(*parts):
+        return view.get_model()[0][1] == str.join(" / ", parts)
+
+    a_access = "<u><b>A</b></u>"
+    p_access = "<u><b>P</b></u>"
+    d_access = "<u><b>D</b></u>"
     view = widget.get_object("treeView")
 
     # Allowed
     widget.load_store([_mock_subject(access="A")])
-    assert view.get_model()[0][1] == "<u><b>A</b></u>/P/D"
+    assert eq_access(a_access, "P", "D")
     # Partial
     widget.load_store([_mock_subject(access="P")])
-    assert view.get_model()[0][1] == "A/<u><b>P</b></u>/D"
+    assert eq_access("A", p_access, "D")
     # Denied
     widget.load_store([_mock_subject(access="D")])
-    assert view.get_model()[0][1] == "A/P/<u><b>D</b></u>"
+    assert eq_access("A", "P", d_access)
     # Bad data
     widget.load_store([_mock_subject(access="foo")])
-    assert view.get_model()[0][1] == "A/P/D"
+    assert eq_access("A", "P", "D")
     # Empty data
     widget.load_store([_mock_subject()])
-    assert view.get_model()[0][1] == "A/P/D"
+    assert eq_access("A", "P", "D")
     # Lowercase
     widget.load_store([_mock_subject(access="a")])
-    assert view.get_model()[0][1] == "<u><b>A</b></u>/P/D"
+    assert eq_access(a_access, "P", "D")
 
 
 def test_path_color(widget):

--- a/fapolicy_analyzer/tests/test_system_trust_database_admin.py
+++ b/fapolicy_analyzer/tests/test_system_trust_database_admin.py
@@ -63,11 +63,11 @@ def test_creates_widget(widget):
 
 def test_status_markup(widget):
     assert widget._SystemTrustDatabaseAdmin__status_markup("T") == (
-        "<b><u>T</u></b>/D",
+        "<b><u>T</u></b> / D",
         Colors.LIGHT_GREEN,
     )
     assert widget._SystemTrustDatabaseAdmin__status_markup("foo") == (
-        "T/<b><u>D</u></b>",
+        "T / <b><u>D</u></b>",
         Colors.LIGHT_RED,
     )
 

--- a/fapolicy_analyzer/ui/ancillary_trust_file_list.py
+++ b/fapolicy_analyzer/ui/ancillary_trust_file_list.py
@@ -13,17 +13,19 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import gi
-import fapolicy_analyzer.ui.strings as strings
-
-gi.require_version("Gtk", "3.0")
 import os.path
 from functools import reduce
-from gi.repository import Gtk
 from types import SimpleNamespace
-from .configs import Colors
+
+import fapolicy_analyzer.ui.strings as strings
+import gi
+
 from .add_file_button import AddFileButton
+from .configs import Colors
 from .trust_file_list import TrustFileList, epoch_to_string
+
+gi.require_version("Gtk", "3.0")
+from gi.repository import Gtk  # isort: skip
 
 
 class AncillaryTrustFileList(TrustFileList):
@@ -38,11 +40,11 @@ class AncillaryTrustFileList(TrustFileList):
     def __status_markup(self, status):
         s = status.lower()
         return (
-            ("<b><u>T</u></b>/D", Colors.LIGHT_GREEN)
+            ("<b><u>T</u></b> / D", Colors.LIGHT_GREEN)
             if s == "t"
-            else ("T/<b><u>D</u></b>", Colors.LIGHT_RED)
+            else ("T / <b><u>D</u></b>", Colors.LIGHT_RED)
             if s == "d"
-            else ("T/D", Colors.ORANGE)
+            else ("T / D", Colors.ORANGE)
         )
 
     def _changesets_to_map(self, changesets):
@@ -63,7 +65,7 @@ class AncillaryTrustFileList(TrustFileList):
     def _columns(self):
         self._changesColumn = Gtk.TreeViewColumn(
             strings.FILE_LIST_CHANGES_HEADER,
-            Gtk.CellRendererText(background="light gray"),
+            Gtk.CellRendererText(background=Colors.LIGHT_GRAY),
             text=5,
         )
         self._changesColumn.set_sort_column_id(5)

--- a/fapolicy_analyzer/ui/configs.py
+++ b/fapolicy_analyzer/ui/configs.py
@@ -18,6 +18,7 @@ class Colors:
     BLACK = "black"
     GREEN = "#008000"
     LIGHT_RED = "#FF3333"
+    LIGHT_GRAY = "light gray"
     LIGHT_GREEN = "light green"
     ORANGE = "#E69F00"
     RED = "#FF0000"

--- a/fapolicy_analyzer/ui/confirm_info_dialog.py
+++ b/fapolicy_analyzer/ui/confirm_info_dialog.py
@@ -17,6 +17,8 @@ import gi
 
 gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk
+
+from .configs import Colors
 from .strings import (
     CHANGESET_ACTION_ADD,
     CHANGESET_ACTION_DEL,
@@ -52,7 +54,7 @@ class ConfirmInfoDialog(Gtk.Dialog):
 
         columnAction = Gtk.TreeViewColumn(
             DEPLOY_ANCILLARY_CONFIRM_DLG_ACTION_COL_HDR,
-            Gtk.CellRendererText(background="light gray"),
+            Gtk.CellRendererText(background=Colors.LIGHT_GRAY),
             text=0,
         )
         columnAction.set_sort_column_id(0)

--- a/fapolicy_analyzer/ui/object_list.py
+++ b/fapolicy_analyzer/ui/object_list.py
@@ -24,11 +24,9 @@ from .subject_list import SubjectList
 
 
 class ObjectList(SubjectList):
-
     def _columns(self):
         columns = super()._columns()
-        modeCell = Gtk.CellRendererText()
-        modeCell.set_property("background", "light gray")
+        modeCell = Gtk.CellRendererText(background=Colors.LIGHT_GRAY, xalign=0.5)
         modeColumn = Gtk.TreeViewColumn(
             strings.FILE_LIST_MODE_HEADER, modeCell, markup=5
         )
@@ -36,7 +34,7 @@ class ObjectList(SubjectList):
         columns.insert(1, modeColumn)
         return columns
 
-    def __markup(self, value, options, seperator="/", multiValue=False):
+    def __markup(self, value, options, seperator=" / ", multiValue=False):
         def wrap(x):
             return f"<u><b>{x}</b></u>"
 

--- a/fapolicy_analyzer/ui/subject_list.py
+++ b/fapolicy_analyzer/ui/subject_list.py
@@ -26,6 +26,7 @@ from .searchable_list import SearchableList
 from .store import dispatch
 from .strings import FILE_LABEL, FILES_LABEL
 from .trust_reconciliation_dialog import TrustReconciliationDialog
+
 gi.require_version("Gtk", "3.0")
 from gi.repository import Gdk, Gtk  # isort: skip
 
@@ -84,14 +85,12 @@ class SubjectList(SearchableList):
         return menu
 
     def _columns(self):
-        trustCell = Gtk.CellRendererText()
-        trustCell.set_property("background", "light gray")
+        trustCell = Gtk.CellRendererText(background=Colors.LIGHT_GRAY, xalign=0.5)
         trustColumn = Gtk.TreeViewColumn(
             strings.FILE_LIST_TRUST_HEADER, trustCell, markup=0
         )
         trustColumn.set_sort_column_id(0)
-        accessCell = Gtk.CellRendererText()
-        accessCell.set_property("background", "light gray")
+        accessCell = Gtk.CellRendererText(background=Colors.LIGHT_GRAY, xalign=0.5)
         accessColumn = Gtk.TreeViewColumn(
             strings.FILE_LIST_ACCESS_HEADER, accessCell, markup=1
         )
@@ -110,20 +109,40 @@ class SubjectList(SearchableList):
         status = subject.trust_status.lower()
         trust = subject.trust.lower()
         if not status == "t":
-            at_str = f'<span color="{Colors.RED}"><b>AT</b></span>' if trust == "at" else "AT"
-            st_str = f'<span color="{Colors.RED}"><b>ST</b></span>' if trust == "st" else "ST"
-            u_str = f'<span color="{Colors.GREEN}"><u><b>U</b></u></span>' if trust == "u" else "U"
+            at_str = (
+                f'<span color="{Colors.RED}"><b>AT</b></span>'
+                if trust == "at"
+                else "AT"
+            )
+            st_str = (
+                f'<span color="{Colors.RED}"><b>ST</b></span>'
+                if trust == "st"
+                else "ST"
+            )
+            u_str = (
+                f'<span color="{Colors.GREEN}"><u><b>U</b></u></span>'
+                if trust == "u"
+                else "U"
+            )
         else:
-            at_str = f'<span color="{Colors.GREEN}"><u><b>AT</b></u></span>' if trust == "at" else "AT"
-            st_str = f'<span color="{Colors.GREEN}"><u><b>ST</b></u></span>' if trust == "st" else "ST"
+            at_str = (
+                f'<span color="{Colors.GREEN}"><u><b>AT</b></u></span>'
+                if trust == "at"
+                else "AT"
+            )
+            st_str = (
+                f'<span color="{Colors.GREEN}"><u><b>ST</b></u></span>'
+                if trust == "st"
+                else "ST"
+            )
             u_str = "U"
 
-        return "/".join([st_str, at_str, u_str])
+        return " / ".join([st_str, at_str, u_str])
 
     def __markup(self, value, options):
 
         idx = options.index(value) if value in options else -1
-        return "/".join(
+        return " / ".join(
             [f"<u><b>{o}</b></u>" if i == idx else o for i, o in enumerate(options)]
         )
 

--- a/fapolicy_analyzer/ui/system_trust_database_admin.py
+++ b/fapolicy_analyzer/ui/system_trust_database_admin.py
@@ -57,9 +57,9 @@ class SystemTrustDatabaseAdmin(UIConnectedWidget, Events):
 
     def __status_markup(self, status):
         return (
-            ("<b><u>T</u></b>/D", Colors.LIGHT_GREEN)
+            ("<b><u>T</u></b> / D", Colors.LIGHT_GREEN)
             if status.lower() == "t"
-            else ("T/<b><u>D</u></b>", Colors.LIGHT_RED)
+            else ("T / <b><u>D</u></b>", Colors.LIGHT_RED)
         )
 
     def __load_trust(self):
@@ -127,4 +127,6 @@ SHA256: {fs.sha(trust.path)}"""
 
     def on_addBtn_clicked(self, *args):
         if self.selectedFiles:
-            self.file_added_to_ancillary_trust(*[sfile.path for sfile in self.selectedFiles])
+            self.file_added_to_ancillary_trust(
+                *[sfile.path for sfile in self.selectedFiles]
+            )

--- a/fapolicy_analyzer/ui/trust_file_list.py
+++ b/fapolicy_analyzer/ui/trust_file_list.py
@@ -19,6 +19,7 @@ from time import localtime, mktime, strftime, strptime
 import fapolicy_analyzer.ui.strings as strings
 import gi
 
+from .configs import Colors
 from .searchable_list import SearchableList
 from .strings import FILE_LABEL, FILES_LABEL
 
@@ -79,7 +80,7 @@ class TrustFileList(SearchableList):
         # trust status column
         trustColumn = Gtk.TreeViewColumn(
             strings.FILE_LIST_TRUST_HEADER,
-            Gtk.CellRendererText(background="light gray"),
+            Gtk.CellRendererText(background=Colors.LIGHT_GRAY, xalign=0.5),
             markup=0,
         )
         trustColumn.set_sort_column_id(0)


### PR DESCRIPTION
Adds spaces around the `/` separator for the Trust and Access data columns in the DB Admin tool and the Policy Analysis tool.

closes #354 