### PR TITLE
Updated text are red backgrounds to be white

### DIFF
--- a/fapolicy_analyzer/tests/test_ancillary_trust_file_list.py
+++ b/fapolicy_analyzer/tests/test_ancillary_trust_file_list.py
@@ -75,6 +75,9 @@ def test_uses_custom_markup_func():
     assert [Colors.LIGHT_RED, Colors.LIGHT_GREEN, Colors.ORANGE] == [
         x[4] for x in view.get_model()
     ]
+    assert [Colors.WHITE, Colors.BLACK, Colors.BLACK] == [
+        x[5] for x in view.get_model()
+    ]
 
 
 def test_fires_files_added(widget, mocker):
@@ -108,7 +111,7 @@ def test_trust_add_actions_in_view(widget):
     widget.load_trust(_trust)
     model = widget.get_object("treeView").get_model()
     row = next(iter([x for x in model if x[2] == "/tmp/1"]))
-    assert CHANGESET_ACTION_ADD == row[5]
+    assert CHANGESET_ACTION_ADD == row[6]
 
 
 def test_trust_delete_actions_in_view(widget):
@@ -119,4 +122,4 @@ def test_trust_delete_actions_in_view(widget):
     widget.load_trust(_trust)
     model = widget.get_object("treeView").get_model()
     row = next(iter([x for x in model if x[2] == "/tmp/foz"]))
-    assert CHANGESET_ACTION_DEL == row[5]
+    assert CHANGESET_ACTION_DEL == row[6]

--- a/fapolicy_analyzer/tests/test_object_list.py
+++ b/fapolicy_analyzer/tests/test_object_list.py
@@ -66,7 +66,7 @@ def test_loads_store(widget):
     ]
     assert [t.file for t in sortedObjects] == [x[2] for x in view.get_model()]
     assert [t.mode for t in sortedObjects] == [
-        strip_markup(x[5]) for x in view.get_model()
+        strip_markup(x[6]) for x in view.get_model()
     ]
 
 
@@ -120,34 +120,34 @@ def test_mode_markup(widget):
     view = widget.get_object("treeView")
     # Read
     widget.load_store([_mock_object(mode="R")])
-    assert view.get_model()[0][5] == "<u><b>R</b></u>WX"
+    assert view.get_model()[0][6] == "<u><b>R</b></u>WX"
     # Write
     widget.load_store([_mock_object(mode="W")])
-    assert view.get_model()[0][5] == "R<u><b>W</b></u>X"
+    assert view.get_model()[0][6] == "R<u><b>W</b></u>X"
     # Execute
     widget.load_store([_mock_object(mode="X")])
-    assert view.get_model()[0][5] == "RW<u><b>X</b></u>"
+    assert view.get_model()[0][6] == "RW<u><b>X</b></u>"
     # Read/Write
     widget.load_store([_mock_object(mode="RW")])
-    assert view.get_model()[0][5] == "<u><b>R</b></u><u><b>W</b></u>X"
+    assert view.get_model()[0][6] == "<u><b>R</b></u><u><b>W</b></u>X"
     # Read/Execute
     widget.load_store([_mock_object(mode="RX")])
-    assert view.get_model()[0][5] == "<u><b>R</b></u>W<u><b>X</b></u>"
+    assert view.get_model()[0][6] == "<u><b>R</b></u>W<u><b>X</b></u>"
     # Write/Execute
     widget.load_store([_mock_object(mode="WX")])
-    assert view.get_model()[0][5] == "R<u><b>W</b></u><u><b>X</b></u>"
+    assert view.get_model()[0][6] == "R<u><b>W</b></u><u><b>X</b></u>"
     # Full Access
     widget.load_store([_mock_object(mode="RWX")])
-    assert view.get_model()[0][5] == "<u><b>R</b></u><u><b>W</b></u><u><b>X</b></u>"
+    assert view.get_model()[0][6] == "<u><b>R</b></u><u><b>W</b></u><u><b>X</b></u>"
     # Bad data
     widget.load_store([_mock_object(mode="foo")])
-    assert view.get_model()[0][5] == "RWX"
+    assert view.get_model()[0][6] == "RWX"
     # Empty data
     widget.load_store([_mock_object()])
-    assert view.get_model()[0][5] == "RWX"
+    assert view.get_model()[0][6] == "RWX"
     # Lowercase
     widget.load_store([_mock_object(mode="r")])
-    assert view.get_model()[0][5] == "<u><b>R</b></u>WX"
+    assert view.get_model()[0][6] == "<u><b>R</b></u>WX"
 
 
 def test_access_markup(widget):
@@ -181,21 +181,27 @@ def test_path_color(widget):
     # Denied
     widget.load_store([_mock_object(access="D", mode="RWX")])
     assert view.get_model()[0][4] == Colors.LIGHT_RED
+    assert view.get_model()[0][5] == Colors.WHITE
     # Full Access
     widget.load_store([_mock_object(access="A", mode="RWX")])
     assert view.get_model()[0][4] == Colors.LIGHT_GREEN
+    assert view.get_model()[0][5] == Colors.BLACK
     # Partical Access
     widget.load_store([_mock_object(access="A", mode="R")])
     assert view.get_model()[0][4] == Colors.ORANGE
+    assert view.get_model()[0][5] == Colors.BLACK
     # Bad data
     widget.load_store([_mock_object(access="foo")])
     assert view.get_model()[0][4] == Colors.LIGHT_RED
+    assert view.get_model()[0][5] == Colors.WHITE
     # Empty data
     widget.load_store([_mock_object()])
     assert view.get_model()[0][4] == Colors.LIGHT_RED
+    assert view.get_model()[0][5] == Colors.WHITE
     # Lowercase
     widget.load_store([_mock_object(access="a", mode="rwx")])
     assert view.get_model()[0][4] == Colors.LIGHT_GREEN
+    assert view.get_model()[0][5] == Colors.BLACK
 
 
 def test_update_tree_count(widget):

--- a/fapolicy_analyzer/tests/test_subject_list.py
+++ b/fapolicy_analyzer/tests/test_subject_list.py
@@ -154,21 +154,27 @@ def test_path_color(widget):
     # Allowed
     widget.load_store([_mock_subject(access="A")])
     assert view.get_model()[0][4] == Colors.LIGHT_GREEN
+    assert view.get_model()[0][5] == Colors.BLACK
     # Partial
     widget.load_store([_mock_subject(access="P")])
     assert view.get_model()[0][4] == Colors.ORANGE
+    assert view.get_model()[0][5] == Colors.BLACK
     # Denied
     widget.load_store([_mock_subject(access="D")])
     assert view.get_model()[0][4] == Colors.LIGHT_RED
+    assert view.get_model()[0][5] == Colors.WHITE
     # Bad data
     widget.load_store([_mock_subject(access="foo")])
     assert view.get_model()[0][4] == Colors.LIGHT_RED
+    assert view.get_model()[0][5] == Colors.WHITE
     # Empty data
     widget.load_store([_mock_subject()])
     assert view.get_model()[0][4] == Colors.LIGHT_RED
+    assert view.get_model()[0][5] == Colors.WHITE
     # Lowercase
     widget.load_store([_mock_subject(access="a")])
     assert view.get_model()[0][4] == Colors.LIGHT_GREEN
+    assert view.get_model()[0][5] == Colors.BLACK
 
 
 def test_update_tree_count(widget):

--- a/fapolicy_analyzer/tests/test_system_trust_database_admin.py
+++ b/fapolicy_analyzer/tests/test_system_trust_database_admin.py
@@ -69,6 +69,7 @@ def test_status_markup(widget):
     assert widget._SystemTrustDatabaseAdmin__status_markup("foo") == (
         "T / <b><u>D</u></b>",
         Colors.LIGHT_RED,
+        Colors.WHITE,
     )
 
 

--- a/fapolicy_analyzer/ui/ancillary_trust_file_list.py
+++ b/fapolicy_analyzer/ui/ancillary_trust_file_list.py
@@ -42,7 +42,7 @@ class AncillaryTrustFileList(TrustFileList):
         return (
             ("<b><u>T</u></b> / D", Colors.LIGHT_GREEN)
             if s == "t"
-            else ("T / <b><u>D</u></b>", Colors.LIGHT_RED)
+            else ("T / <b><u>D</u></b>", Colors.LIGHT_RED, Colors.WHITE)
             if s == "d"
             else ("T / D", Colors.ORANGE)
         )
@@ -66,9 +66,9 @@ class AncillaryTrustFileList(TrustFileList):
         self._changesColumn = Gtk.TreeViewColumn(
             strings.FILE_LIST_CHANGES_HEADER,
             Gtk.CellRendererText(background=Colors.LIGHT_GRAY),
-            text=5,
+            text=6,
         )
-        self._changesColumn.set_sort_column_id(5)
+        self._changesColumn.set_sort_column_id(6)
         return [self._changesColumn, *super()._columns()]
 
     def set_changesets(self, changesets):
@@ -80,19 +80,17 @@ class AncillaryTrustFileList(TrustFileList):
             self._changesetMap["Add"] or self._changesetMap["Del"]
         )
 
-        store = Gtk.ListStore(str, str, str, object, str, str)
-        for i, data in enumerate(trust):
-            status, *rest = self.markup_func(data.status)
-            bgColor = rest[0] if rest else "white"
+        store = Gtk.ListStore(str, str, str, object, str, str, str)
+        for _, data in enumerate(trust):
+            status, bg_color, txt_color, date_time = self._base_row_data(data)
             changes = (
                 strings.CHANGESET_ACTION_ADD
                 if data.path in self._changesetMap["Add"]
                 else ""
             )
-
-            secsEpoch = data.actual.last_modified if data.actual else None
-            strDateTime = epoch_to_string(secsEpoch)
-            store.append([status, strDateTime, data.path, data, bgColor, changes])
+            store.append(
+                [status, date_time, data.path, data, bg_color, txt_color, changes]
+            )
 
         for pth in self._changesetMap["Del"]:
             secsEpoch = int(os.path.getmtime(pth)) if os.path.isfile(pth) else None
@@ -103,7 +101,8 @@ class AncillaryTrustFileList(TrustFileList):
                     strDateTime,
                     pth,
                     SimpleNamespace(path=pth),
-                    "white",
+                    Colors.WHITE,
+                    Colors.BLACK,
                     strings.CHANGESET_ACTION_DEL,
                 ]
             )

--- a/fapolicy_analyzer/ui/object_list.py
+++ b/fapolicy_analyzer/ui/object_list.py
@@ -28,9 +28,9 @@ class ObjectList(SubjectList):
         columns = super()._columns()
         modeCell = Gtk.CellRendererText(background=Colors.LIGHT_GRAY, xalign=0.5)
         modeColumn = Gtk.TreeViewColumn(
-            strings.FILE_LIST_MODE_HEADER, modeCell, markup=5
+            strings.FILE_LIST_MODE_HEADER, modeCell, markup=6
         )
-        modeColumn.set_sort_column_id(5)
+        modeColumn.set_sort_column_id(6)
         columns.insert(1, modeColumn)
         return columns
 
@@ -42,23 +42,20 @@ class ObjectList(SubjectList):
         matches = set(options).intersection(valueSet)
         return seperator.join([wrap(o) if o in matches else o for o in options])
 
-    def __color(self, access, mode):
+    def __colors(self, access, mode):
+        green = (Colors.LIGHT_GREEN, Colors.BLACK)
+        orange = (Colors.ORANGE, Colors.BLACK)
+        red = (Colors.LIGHT_RED, Colors.WHITE)
         if access.upper() != "A":
-            return Colors.LIGHT_RED
+            return red
 
         numModes = len(set(mode.upper()).intersection({"R", "W", "X"}))
-        return (
-            Colors.LIGHT_GREEN
-            if numModes == 3
-            else Colors.ORANGE
-            if numModes > 0
-            else Colors.LIGHT_RED
-        )
+        return green if numModes == 3 else orange if numModes > 0 else red
 
     def load_store(self, objects, **kwargs):
         self._systemTrust = kwargs.get("systemTrust", [])
         self._ancillaryTrust = kwargs.get("ancillaryTrust", [])
-        store = Gtk.ListStore(str, str, str, object, str, str)
+        store = Gtk.ListStore(str, str, str, object, str, str, str)
         for o in objects:
             status = self._trust_markup(o)
             mode = self.__markup(
@@ -68,8 +65,8 @@ class ObjectList(SubjectList):
                 multiValue=True,
             )
             access = self.__markup(o.access.upper(), ["A", "D"])
-            bgColor = self.__color(o.access, o.mode)
-            store.append([status, access, o.file, o, bgColor, mode])
+            bg_color, txt_color = self.__colors(o.access, o.mode)
+            store.append([status, access, o.file, o, bg_color, txt_color, mode])
 
         # call grandfather SearchableList's load_store method
         super(SubjectList, self).load_store(store)

--- a/fapolicy_analyzer/ui/system_trust_database_admin.py
+++ b/fapolicy_analyzer/ui/system_trust_database_admin.py
@@ -59,7 +59,7 @@ class SystemTrustDatabaseAdmin(UIConnectedWidget, Events):
         return (
             ("<b><u>T</u></b> / D", Colors.LIGHT_GREEN)
             if status.lower() == "t"
-            else ("T / <b><u>D</u></b>", Colors.LIGHT_RED)
+            else ("T / <b><u>D</u></b>", Colors.LIGHT_RED, Colors.WHITE)
         )
 
     def __load_trust(self):


### PR DESCRIPTION
Update the text in data table cells with red background colors to be white for easier reading. This includes data tables in the system and ancillary trust database admin tools as well as the policy event analysis tool.

closes #353