### PR TITLE
Fix Rule Sort

### DIFF
--- a/crates/pyo3/src/system.rs
+++ b/crates/pyo3/src/system.rs
@@ -172,7 +172,7 @@ impl PySystem {
     fn rules_text(&self) -> PyResult<String> {
         self.rules()
             .map(|x| {
-                x.into_iter().rfold((None, String::new()), |x, r| match x {
+                x.into_iter().fold((None, String::new()), |x, r| match x {
                     // no origin established yet
                     (None, _) => (
                         Some(r.origin.clone()),

--- a/crates/rules/src/load.rs
+++ b/crates/rules/src/load.rs
@@ -41,7 +41,6 @@ fn rules_dir(rules_source_path: PathBuf) -> Result<Vec<RuleSource>, io::Error> {
         .filter(|p| p.is_file() && p.display().to_string().ends_with(".rules"))
         .collect();
     d_files.sort_by_key(|p| p.display().to_string());
-    d_files.reverse();
 
     let d_files: Result<Vec<(PathBuf, File)>, io::Error> = d_files
         .into_iter()


### PR DESCRIPTION
The rule text generator was using an rfold and a reverse was added elsewhere to compensate. This straightens all that out with a fold and no reverse.

Closes #471