### PR TITLE
Pin Rust to 1.54

### DIFF
--- a/.clippy.toml
+++ b/.clippy.toml
@@ -1,0 +1,1 @@
+single-char-binding-names-threshold = 6

--- a/.clippy.toml
+++ b/.clippy.toml
@@ -1,1 +1,3 @@
+# https://rust-lang.github.io/rust-clippy/
+
 single-char-binding-names-threshold = 6

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -70,11 +70,11 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: 3.9
-      - name: Set up Rust Stable
+      - name: Install Rust 1.54.0
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: stable
+          toolchain: 1.54.0
           override: true
       - name: Install dependencies
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,7 +31,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: stable
+          toolchain: 1.54.0
           override: true
       - uses: actions-rs/cargo@v1
         with:
@@ -47,7 +47,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: stable
+          toolchain: 1.54.0
           override: true
       - uses: actions-rs/cargo@v1
         with:
@@ -163,7 +163,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: stable
+          toolchain: 1.54.0
           override: true
       - run: rustup component add rustfmt
       - uses: actions-rs/cargo@v1
@@ -181,7 +181,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: stable
+          toolchain: 1.54.0
           override: true
       - run: rustup component add clippy
       - uses: actions-rs/cargo@v1

--- a/.github/workflows/rpm.yml
+++ b/.github/workflows/rpm.yml
@@ -33,13 +33,6 @@ jobs:
           pip3 install --no-input jinja2==3.0.3
           pip3 install --no-input jinja2-cli
 
-      - name: Install Rust 1.54.0
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: 1.54.0
-          override: true
-
       - uses: actions/checkout@v2
         with:
           ref: ${{ github.ref }}

--- a/.github/workflows/rpm.yml
+++ b/.github/workflows/rpm.yml
@@ -33,6 +33,13 @@ jobs:
           pip3 install --no-input jinja2==3.0.3
           pip3 install --no-input jinja2-cli
 
+      - name: Install Rust 1.54.0
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: 1.54.0
+          override: true
+
       - uses: actions/checkout@v2
         with:
           ref: ${{ github.ref }}

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ make run
 ## Requirements
 
 - Python 3.9
-- Rust 1.52
+- Rust 1.54
 - fapolicyd 1.0
 
 ### fapolicyd configuration


### PR DESCRIPTION
- Pin CI to 1.54.0 to validate build and unit tests on msrv
- UBI 8 build will validate rpm build for the msrv required by el8 (currently 1.54.0)

closes #441