### PR TITLE
Reverted the use of python 3.9 ThreadPoolExecutor arguments

### DIFF
--- a/fapolicy_analyzer/ui/features/system_feature.py
+++ b/fapolicy_analyzer/ui/features/system_feature.py
@@ -103,7 +103,7 @@ def create_system_feature(
             _checkpoint = _system
 
             if executor:
-                executor.shutdown(cancel_futures=True)
+                executor.shutdown()
 
             if system:
                 dispatch(system_initialized())

--- a/fapolicy_analyzer/ui/trust_file_list.py
+++ b/fapolicy_analyzer/ui/trust_file_list.py
@@ -129,7 +129,7 @@ class TrustFileList(SearchableList):
     def on_destroy(self, *args):
         global _executorCanceled
         _executorCanceled = True
-        self.__executor.shutdown(cancel_futures=True)
+        self.__executor.shutdown()
         return False
 
     def refresh(self):


### PR DESCRIPTION
Removed the use of the cancel_futures parameter to the ThreadPoolExecutor because it is not available in python 3.6. I've tested this and I think we are good with turning off this cancel functionality. I think it was an issue when you closed the application before the System Trust data loaded completely. The process would hang until the thread pulling the trust data completed, but this isn't an issue now because the rust layer is pre-caching this data during startup. We should be good to revert to the older python 3.6 version now.

To test this you can start up the application. Then close the UI window before the system trust is fully loaded. It should close cleanly without hanging.

closes #422 