### PR TITLE
Fixed broken typing and tests in python 3.6

### DIFF
--- a/fapolicy_analyzer/tests/test_fs.py
+++ b/fapolicy_analyzer/tests/test_fs.py
@@ -13,9 +13,10 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import subprocess
 import os
-from util.fs import sha
+import subprocess
+
+from fapolicy_analyzer.util.fs import sha
 
 
 def test_sha():
@@ -32,7 +33,10 @@ def test_sha():
 
         # Independently generate the sha256 hash from a utility for the same path
         strSha256CmdStdout = subprocess.run(
-            ["sha256sum", strTmpFilepath], capture_output=True, text=True
+            ["sha256sum", strTmpFilepath],
+            universal_newlines=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
         ).stdout.split()[0]
     finally:
         fp.close()

--- a/fapolicy_analyzer/tests/test_session_manager.py
+++ b/fapolicy_analyzer/tests/test_session_manager.py
@@ -13,23 +13,25 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+import glob
+import json
+import os
+import time
+from datetime import datetime as DT
+from unittest.mock import call, mock_open
+
+import pytest
+from callee import Attr, EndsWith, InstanceOf, StartsWith
+from fapolicy_analyzer import Changeset
 from fapolicy_analyzer.ui.actions import (
     ADD_NOTIFICATION,
     APPLY_CHANGESETS,
     RESTORE_SYSTEM_CHECKPOINT,
 )
-import context  # noqa: F401
-import os
-import pytest
-import json
-import glob
-import time
-from callee import Attr, InstanceOf, StartsWith, EndsWith
-from datetime import datetime as DT
-from unittest.mock import call, mock_open
-from fapolicy_analyzer import Changeset
 from redux import Action
 from ui.session_manager import SessionManager
+
+import context  # noqa: F401
 
 test_changes = [
     {"/data_space/man_from_mars.txt": "Add"},
@@ -108,9 +110,10 @@ def test_open_edit_session(uut, mock_dispatch, mocker):
     # verify changesets
     expected = test_changes
     # parse changesets to json string to compare
+    args, _ = mock_dispatch.call_args_list[1]
     actual = [
         {path: action for path, action in c.get_path_action_map().items()}
-        for c in mock_dispatch.call_args_list[1].args[0].payload
+        for c in args[0].payload
     ]
 
     assert actual == expected
@@ -271,9 +274,10 @@ def test_restore_previous_session(uut_autosave_enabled, autosaved_files, mock_di
     # verify changesets
     expected = test_changes
     # parse changesets to json string to compare
+    args, _ = mock_dispatch.call_args_list[1]
     actual = [
         {path: action for path, action in c.get_path_action_map().items()}
-        for c in mock_dispatch.call_args_list[1].args[0].payload
+        for c in args[0].payload
     ]
 
     assert actual == expected

--- a/fapolicy_analyzer/ui/rules/rules_list_view.py
+++ b/fapolicy_analyzer/ui/rules/rules_list_view.py
@@ -13,7 +13,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-from typing import Sequence
+from typing import Sequence, Tuple
 
 import gi
 from fapolicy_analyzer import Rule
@@ -52,10 +52,10 @@ class RulesListView(SearchableList):
                 cell_background=2,
                 foreground=3,
                 weight=4,
-            )
+            ),
         ]
 
-    def __rule_text_style(self, rule: Rule) -> tuple[str, int]:
+    def __rule_text_style(self, rule: Rule) -> Tuple[str, int]:
         info_cats = [i.category for i in rule.info]
         return (
             (Colors.RED, FontWeights.BOLD)
@@ -82,7 +82,15 @@ class RulesListView(SearchableList):
             row_color = Colors.WHITE if idx % 2 else Colors.SHADED
             text_style = self.__rule_text_style(rule)
             parent = store.append(
-                None, [rule.text, rule.id, row_color, text_style[0], text_style[1], str(rule.id)]
+                None,
+                [
+                    rule.text,
+                    rule.id,
+                    row_color,
+                    text_style[0],
+                    text_style[1],
+                    str(rule.id),
+                ],
             )
             if rule.info:
                 for info in rule.info:
@@ -94,7 +102,7 @@ class RulesListView(SearchableList):
                             row_color,
                             self.__info_cat_text_color(info.category),
                             FontWeights.NORMAL,
-                            ""
+                            "",
                         ],
                     )
 


### PR DESCRIPTION
Fixed some bad typing in `rules_list_view.py` that worked in python 3.9 but not 3.6.  Also fixed some tests that break in python 3.6 because of changes in the pytest `call` objects API.

closes #486 