### PR TITLE
Fixing CI pipeline with apt-get update, and specific docker image version

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,7 +27,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Install requirements
-        run: sudo apt-get install libdbus-1-dev
+        run: |
+          sudo apt-get update
+          sudo apt-get install libdbus-1-dev
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
@@ -43,7 +45,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Install requirements
-        run: sudo apt-get install libdbus-1-dev
+        run: |
+          sudo apt-get update
+          sudo apt-get install libdbus-1-dev
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
@@ -183,7 +187,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Install requirements
-        run: sudo apt-get install libdbus-1-dev
+        run: |
+          sudo apt-get update
+          sudo apt-get install libdbus-1-dev
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal

--- a/.github/workflows/rpm.yml
+++ b/.github/workflows/rpm.yml
@@ -15,7 +15,7 @@ jobs:
   build:
     strategy:
       matrix:
-        platform: [ 'fedora:33', 'fedora:34', 'registry.access.redhat.com/ubi8/ubi:8.5-239' ]
+        platform: [ 'fedora:33', 'fedora:34', 'registry.access.redhat.com/ubi8/ubi:8.5' ]
     runs-on: ubuntu-latest
     container: ${{ matrix.platform }}
     name: Create RPM Release

--- a/.github/workflows/rpm.yml
+++ b/.github/workflows/rpm.yml
@@ -15,7 +15,7 @@ jobs:
   build:
     strategy:
       matrix:
-        platform: [ 'fedora:33', 'fedora:34', 'registry.access.redhat.com/ubi8/ubi:8.5' ]
+        platform: [ 'fedora:33', 'fedora:34', 'registry.access.redhat.com/ubi8/ubi:8.5-239' ]
     runs-on: ubuntu-latest
     container: ${{ matrix.platform }}
     name: Create RPM Release


### PR DESCRIPTION
Updated RHEL image version to fix rpm builds. Added `apt-get update` to refresh the rpm version info prior to installing the failing libdbus-1-dev pkg.