### PR TITLE
Add rule file markers to guided rule editor

### DIFF
--- a/fapolicy_analyzer/tests/rules/test_rules_list_view.py
+++ b/fapolicy_analyzer/tests/rules/test_rules_list_view.py
@@ -84,8 +84,8 @@ def test_renders_origin_files(widget):
     model.foreach(get_origin_rows)
     assert sorted(set([f"[{r.origin}]" for r in mock_rules])) == [x[0] for x in origins]
     assert set([-1]) == set([x[1] for x in origins])
-    assert set([Colors.DARK_GRAY]) == set([x[2] for x in origins])
-    assert set([Colors.WHITE]) == set([x[3] for x in origins])
+    assert set([Colors.WHITE]) == set([x[2] for x in origins])
+    assert set([Colors.DARK_GRAY]) == set([x[3] for x in origins])
 
 
 def test_renders_rules(widget):
@@ -101,9 +101,7 @@ def test_renders_rules(widget):
     model.foreach(get_rule_rows)
     assert [r.text for r in mock_rules] == [x[0] for x in rules]
     assert [r.id for r in mock_rules] == [x[1] for x in rules]
-    assert [Colors.WHITE, Colors.SHADED, Colors.WHITE, Colors.SHADED] == [
-        x[2] for x in rules
-    ]
+    assert set([Colors.WHITE]) == set([x[2] for x in rules])
     assert [Colors.BLACK, Colors.BLUE, Colors.ORANGE, Colors.RED] == [
         x[3] for x in rules
     ]

--- a/fapolicy_analyzer/ui/configs.py
+++ b/fapolicy_analyzer/ui/configs.py
@@ -16,6 +16,7 @@
 
 class Colors:
     BLACK = "black"
+    DARK_GRAY = "dark gray"
     GREEN = "#008000"
     LIGHT_RED = "#FF3333"
     LIGHT_GRAY = "light gray"

--- a/fapolicy_analyzer/ui/rules/rules_list_view.py
+++ b/fapolicy_analyzer/ui/rules/rules_list_view.py
@@ -13,6 +13,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+from itertools import groupby
 from typing import Sequence, Tuple
 
 import gi
@@ -71,39 +72,66 @@ class RulesListView(SearchableList):
         color_map = {"e": Colors.RED, "w": Colors.ORANGE, "i": Colors.BLUE}
         return color_map.get(cat, Colors.BLACK)
 
+    def __append_origin(self, store, origin):
+        return store.append(
+            None,
+            [
+                f"[{origin}]",
+                -1,
+                Colors.DARK_GRAY,
+                Colors.WHITE,
+                FontWeights.NORMAL,
+                "",
+            ],
+        )
+
+    def __append_rule(self, store, rule, parent):
+        row_color = Colors.SHADED if store.iter_n_children(parent) % 2 else Colors.WHITE
+        return store.append(
+            parent,
+            [
+                rule.text,
+                rule.id,
+                row_color,
+                *self.__rule_text_style(rule),
+                str(rule.id),
+            ],
+        )
+
+    def __append_info(self, store, rule, info, parent_row):
+        return store.append(
+            parent_row,
+            [
+                f"[{info.category}] {info.message}",
+                rule.id,
+                store.get_value(parent_row, 2),  # parent row color
+                self.__info_cat_text_color(info.category),
+                FontWeights.NORMAL,
+                "",
+            ],
+        )
+
+    def __expand_rows_at_root(self, store):
+        iter = store.get_iter_first()
+        while iter:
+            self.treeView.expand_row(store.get_path(iter), False)
+            iter = store.iter_next(iter)
+
     def _update_tree_count(self, count):
         label = RULE_LABEL if count == 1 else RULES_LABEL
         self.treeCount.set_text(" ".join([str(count), label]))
 
     def render_rules(self, rules: Sequence[Rule]):
         store = Gtk.TreeStore(str, int, str, str, int, str)
+        rule_map = {o: list(r) for o, r in groupby(rules or [], lambda r: r.origin)}
 
-        for idx, rule in enumerate(rules):
-            row_color = Colors.WHITE if idx % 2 else Colors.SHADED
-            text_style = self.__rule_text_style(rule)
-            parent = store.append(
-                None,
-                [
-                    rule.text,
-                    rule.id,
-                    row_color,
-                    text_style[0],
-                    text_style[1],
-                    str(rule.id),
-                ],
-            )
-            if rule.info:
-                for info in rule.info:
-                    store.append(
-                        parent,
-                        [
-                            f"[{info.category}] {info.message}",
-                            rule.id,
-                            row_color,
-                            self.__info_cat_text_color(info.category),
-                            FontWeights.NORMAL,
-                            "",
-                        ],
-                    )
+        for origin in rule_map.keys():
+            origin_row = self.__append_origin(store, origin)
+            for rule in rule_map[origin]:
+                rule_row = self.__append_rule(store, rule, origin_row)
+                if rule.info:
+                    for info in rule.info:
+                        self.__append_info(store, rule, info, rule_row)
 
         self.load_store(store)
+        self.__expand_rows_at_root(store)


### PR DESCRIPTION
This adds the rule file marker rows to the table view in the Rules Admin tool's Guided Editor. I'm not sold on the color scheme here, but with adding the collapsible rows for the rule file markers a simple alternating white/light gray pattern didn't look right. 

closes #458