### PR TITLE
Updated RPM build to RHEL 8.6 to fix repo issue

### DIFF
--- a/.github/workflows/rpm.yml
+++ b/.github/workflows/rpm.yml
@@ -15,7 +15,7 @@ jobs:
   build:
     strategy:
       matrix:
-        platform: [ 'fedora:34', 'fedora:35', 'registry.access.redhat.com/ubi8/ubi:8.5' ]
+        platform: [ 'fedora:34', 'fedora:35', 'registry.access.redhat.com/ubi8/ubi:8.6' ]
     runs-on: ubuntu-latest
     container: ${{ matrix.platform }}
     name: Create RPM Release

--- a/scripts/rpm/README.md
+++ b/scripts/rpm/README.md
@@ -54,4 +54,4 @@ RPMs for Fedora 34/35 and el8 will end up in `/tmp/rpms` on the host machine.
 
 fapolicyd is not available in ubi, so use rocky for the test run:
 
-`./test.sh /tmp/rpms fedora:34 fedora:35 rockylinux/rockylinux:8.4`
+`./test.sh /tmp/rpms fedora:34 fedora:35 rockylinux/rockylinux:8.6`


### PR DESCRIPTION
The rocky 8.5 repo we were using for build libs for the RHEL 8.5 repo has been removed. I updated our rpm build to RHEL 8.6 and we are good now.