### PR TITLE
Support relative paths in markers

### DIFF
--- a/crates/rules/src/linter/lint.rs
+++ b/crates/rules/src/linter/lint.rs
@@ -44,7 +44,7 @@ mod tests {
     fn lint_simple() -> Result<(), Box<dyn Error>> {
         let db = deserialize_rules_db(
             r#"
-        [/foo.bar]
+        [foo.bar]
         allow perm=any all : all
         "#,
         )?;

--- a/crates/rules/src/ops.rs
+++ b/crates/rules/src/ops.rs
@@ -48,12 +48,12 @@ mod tests {
     use std::error::Error;
 
     #[test]
-    fn deserialize_absolute() -> Result<(), Box<dyn Error>> {
+    fn deserialize() -> Result<(), Box<dyn Error>> {
         let mut cs = Changeset::default();
-        let txt = "[/foo.rules]\ndeny_audit perm=open all : all";
+        let txt = "[foo.rules]\ndeny_audit perm=open all : all";
         let _x1 = cs.set(txt);
 
-        let txt = "[/foo.rules]\nfffdeny_audit perm=open all : all";
+        let txt = "[foo.rules]\nfffdeny_audit perm=open all : all";
         let _x2 = cs.set(txt)?;
 
         Ok(())

--- a/crates/rules/src/parser/marker.rs
+++ b/crates/rules/src/parser/marker.rs
@@ -14,5 +14,6 @@ use nom::sequence::delimited;
 use crate::parser::parse::{StrTrace, TraceResult};
 
 pub(crate) fn parse(i: StrTrace) -> TraceResult<PathBuf> {
+    // todo;; fail if the path contains a directory component; we should expect filename only in the marker
     delimited(tag("["), is_not("]"), tag("]"))(i).map(|(r, path)| (r, PathBuf::from(path.current)))
 }

--- a/crates/rules/src/read.rs
+++ b/crates/rules/src/read.rs
@@ -96,7 +96,7 @@ fn read_rules_db(xs: Vec<RuleSource>) -> Result<DB, Error> {
                     .rsplit_once('/')
                     .map(|(_, rhs)| rhs.to_string())
                     // if there was no / separator then use the full path
-                    .unwrap_or(p.display().to_string()),
+                    .unwrap_or_else(|| p.display().to_string()),
                 s,
             )
         })

--- a/crates/rules/tests/deserialize.rs
+++ b/crates/rules/tests/deserialize.rs
@@ -13,7 +13,7 @@ use std::error::Error;
 fn one_file_one_rule() -> Result<(), Box<dyn Error>> {
     let db = deserialize_rules_db(
         r#"
-        [/foo.bar]
+        [foo.bar]
         allow perm=any all : all
         "#,
     )?;
@@ -27,7 +27,7 @@ fn one_file_one_rule() -> Result<(), Box<dyn Error>> {
 fn one_file_two_rules() -> Result<(), Box<dyn Error>> {
     let db = deserialize_rules_db(
         r#"
-        [/foo.bar]
+        [foo.bar]
         deny perm=execute all : all
         allow perm=any all : all
         "#,
@@ -41,9 +41,9 @@ fn one_file_two_rules() -> Result<(), Box<dyn Error>> {
 fn two_files() -> Result<(), Box<dyn Error>> {
     let db = deserialize_rules_db(
         r#"
-        [/foo.rules]
+        [foo.rules]
         allow perm=execute all : all
-        [/bar.rules]
+        [bar.rules]
         allow perm=any all : all
         "#,
     )?;
@@ -56,7 +56,7 @@ fn two_files() -> Result<(), Box<dyn Error>> {
 fn only_empty_file() -> Result<(), Box<dyn Error>> {
     let db = deserialize_rules_db(
         r#"
-        [/foo.rules]
+        [foo.rules]
         "#,
     )?;
     assert!(db.is_empty());
@@ -67,8 +67,8 @@ fn only_empty_file() -> Result<(), Box<dyn Error>> {
 fn leading_empty_file() -> Result<(), Box<dyn Error>> {
     let db = deserialize_rules_db(
         r#"
-        [/foo.rules]
-        [/bar.rules]
+        [foo.rules]
+        [bar.rules]
         allow perm=execute all : all
         "#,
     )?;
@@ -81,9 +81,9 @@ fn leading_empty_file() -> Result<(), Box<dyn Error>> {
 fn trailing_empty_file() -> Result<(), Box<dyn Error>> {
     let db = deserialize_rules_db(
         r#"
-        [/foo.rules]
+        [foo.rules]
         allow perm=execute all : all
-        [/bar.rules]
+        [bar.rules]
         "#,
     )?;
     assert_eq!(db.len(), 1);
@@ -95,7 +95,7 @@ fn trailing_empty_file() -> Result<(), Box<dyn Error>> {
 fn single_string_set() -> Result<(), Box<dyn Error>> {
     let db = deserialize_rules_db(
         r#"
-        [/foo.bar]
+        [foo.bar]
         %foo=bar
         allow perm=any all : all
         "#,
@@ -111,7 +111,7 @@ fn single_string_set() -> Result<(), Box<dyn Error>> {
 fn multi_string_set() -> Result<(), Box<dyn Error>> {
     let db = deserialize_rules_db(
         r#"
-        [/foo.bar]
+        [foo.bar]
         %foo=bar,baz
         allow perm=any all : all
         "#,
@@ -127,7 +127,7 @@ fn multi_string_set() -> Result<(), Box<dyn Error>> {
 fn single_int_set() -> Result<(), Box<dyn Error>> {
     let db = deserialize_rules_db(
         r#"
-        [/foo.bar]
+        [foo.bar]
         %foo=1
         allow perm=any all : all
         "#,
@@ -143,7 +143,7 @@ fn single_int_set() -> Result<(), Box<dyn Error>> {
 fn multi_int_set() -> Result<(), Box<dyn Error>> {
     let db = deserialize_rules_db(
         r#"
-        [/foo.bar]
+        [foo.bar]
         %foo=1,2
         allow perm=any all : all
         "#,
@@ -159,7 +159,7 @@ fn multi_int_set() -> Result<(), Box<dyn Error>> {
 fn invalid_set() -> Result<(), Box<dyn Error>> {
     let db = deserialize_rules_db(
         r#"
-        [/foo.bar]
+        [foo.bar]
         %foo:1,2
         allow perm=any all : all
         "#,

--- a/examples/change_rules.py
+++ b/examples/change_rules.py
@@ -36,9 +36,12 @@ allow perm=any all : all
 """
 assert not xs1.set(txt)
 
+# markers are relative to the rules.d dir
+# if using fapolicyd.rules markers are not supported
+
 # a valid rule with marker
 txt = """
-[/etc/fapolicyd/rules.d/foo.rules]
+[foo.rules]
 allow perm=any all : all
 """
 assert xs1.set(txt)
@@ -48,10 +51,10 @@ for r in xs1.get():
 print("---")
 # multiple valid rules with markers
 txt = """
-[/etc/fapolicyd/rules.d/foo.rules]
+[foo.rules]
 allow perm=exec all : all
 
-[/etc/fapolicyd/rules.d/bar.rules]
+[bar.rules]
 deny perm=any all : all
 """
 assert xs1.set(txt)
@@ -61,7 +64,7 @@ for r in xs1.get():
 print("---")
 # valid rules under single marker
 txt = """
-[/etc/fapolicyd/rules.d/foo.rules]
+[foo.rules]
 allow perm=exec all : all
 deny perm=any all : all
 """
@@ -72,10 +75,10 @@ for r in xs1.get():
 print("---")
 # empty marker
 txt = """
-[/etc/fapolicyd/rules.d/foo.rules]
+[foo.rules]
 allow perm=exec all : all
 
-[/etc/fapolicyd/rules.d/bar.rules]
+[bar.rules]
 """
 assert xs1.set(txt)
 for r in xs1.get():


### PR DESCRIPTION
Markers were previously being serialized with paths relative to the fapolicyd configuration, however the deserialization machinery expected absolute paths.

This updates the deserialization to handle relative paths, but not enforce that they are relative.  A future change will expect relative path in the marker, producing a parse error if a marker uses a directory component in the path.

- #450