### PR TITLE
Write rules.d structure

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -290,6 +290,7 @@ version = "0.4.0"
 dependencies = [
  "nom",
  "serde",
+ "tempfile",
  "thiserror",
 ]
 
@@ -331,6 +332,15 @@ dependencies = [
  "data-encoding",
  "ring",
  "thiserror",
+]
+
+[[package]]
+name = "fastrand"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3fcf0cee53519c866c09b5de1f6c56ff9d647101f81c1964fa632e148896cdf"
+dependencies = [
+ "instant",
 ]
 
 [[package]]
@@ -766,6 +776,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "remove_dir_all"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "ring"
 version = "0.16.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -852,6 +871,20 @@ name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+
+[[package]]
+name = "tempfile"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cdb1ef4eaeeaddc8fbd371e5017057064af0911902ef36b39801f67cc6d79e4"
+dependencies = [
+ "cfg-if 1.0.0",
+ "fastrand",
+ "libc",
+ "redox_syscall",
+ "remove_dir_all",
+ "winapi",
+]
 
 [[package]]
 name = "termcolor"

--- a/crates/app/src/sys.rs
+++ b/crates/app/src/sys.rs
@@ -6,59 +6,43 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use std::fs::File;
-use std::io::Write;
+use std::io;
 use std::path::PathBuf;
 
 use serde::Deserialize;
 use serde::Serialize;
 use thiserror::Error;
 
-use fapolicy_daemon::fapolicyd::{
-    COMPILED_RULES_PATH, RPM_DB_PATH, RULES_FILE_PATH, TRUST_DB_PATH, TRUST_FILE_PATH,
-};
+use fapolicy_daemon::fapolicyd::{RPM_DB_PATH, RULES_FILE_PATH, TRUST_DB_PATH, TRUST_FILE_PATH};
 
 use crate::app::State;
-use crate::sys::Error::{WriteAncillaryFail, WriteCompiledRulesFail};
+use crate::sys::Error::{WriteAncillaryFail, WriteRulesFail};
 
 #[derive(Error, Debug)]
 pub enum Error {
-    #[error("{0}")]
-    WriteAncillaryFail(String),
-    #[error("{0}")]
-    WriteCompiledRulesFail(String),
+    #[error("Failed to write trust; {0}")]
+    WriteAncillaryFail(io::Error),
+    #[error("Failed to write rules; {0}")]
+    WriteRulesFail(io::Error),
     #[error("{0}")]
     DaemonError(#[from] fapolicy_daemon::error::Error),
 }
 
 pub fn deploy_app_state(state: &State) -> Result<(), Error> {
-    // determine appropriate output rule path from configuration
-    let rules_file = if PathBuf::from(&state.config.system.rules_file_path).is_dir() {
-        COMPILED_RULES_PATH
-    } else {
-        &state.config.system.rules_file_path
-    };
-
-    // write compiled rules db
-    // todo;; write rules.d files
-    let mut rf = File::create(rules_file)
-        .map_err(|_| WriteCompiledRulesFail("unable to write compiled rules".to_string()))?;
-    for (_, (_, e)) in state.rules_db.iter() {
-        rf.write_all(format!("{}\n", e).as_bytes())
-            .map_err(|_| WriteCompiledRulesFail("unable to write rule entry".to_string()))?;
-    }
+    // write rules model
+    fapolicy_rules::write::db(
+        &state.rules_db,
+        &PathBuf::from(&state.config.system.rules_file_path),
+    )
+    .map_err(WriteRulesFail)?;
 
     // write file trust db
-    let mut tf = File::create(&state.config.system.ancillary_trust_path)
-        .map_err(|_| WriteAncillaryFail("unable to create ancillary trust".to_string()))?;
-    for (path, meta) in state.trust_db.iter() {
-        if meta.is_ancillary() {
-            tf.write_all(
-                format!("{} {} {}\n", path, meta.trusted.size, meta.trusted.hash).as_bytes(),
-            )
-            .map_err(|_| WriteAncillaryFail("unable to write ancillary trust entry".to_string()))?;
-        }
-    }
+    fapolicy_trust::write::file_trust(
+        &state.trust_db,
+        PathBuf::from(&state.config.system.ancillary_trust_path),
+    )
+    .map_err(WriteAncillaryFail)?;
+
     Ok(())
 }
 

--- a/crates/daemon/src/fapolicyd.rs
+++ b/crates/daemon/src/fapolicyd.rs
@@ -19,7 +19,6 @@ pub const TRUST_FILE_PATH: &str = "/etc/fapolicyd/fapolicyd.trust";
 pub const RULES_FILE_PATH: &str = "/etc/fapolicyd/rules.d";
 pub const RPM_DB_PATH: &str = "/var/lib/rpm";
 pub const FIFO_PIPE: &str = "/run/fapolicyd/fapolicyd.fifo";
-pub const COMPILED_RULES_PATH: &str = "/etc/fapolicyd/compiled.rules";
 
 const USR_SHARE_ALLOWED_EXTS: [&str; 15] = [
     "pyc", "pyo", "py", "rb", "pl", "stp", "js", "jar", "m4", "php", "el", "pm", "lua", "class",

--- a/crates/rules/Cargo.toml
+++ b/crates/rules/Cargo.toml
@@ -8,6 +8,9 @@ edition = "2018"
 [lib]
 path = "src/lib.rs"
 
+[dev-dependencies]
+tempfile = "3.3"
+
 [dependencies]
 nom = "6.1.0"
 serde = { version = "1.0", features = ["derive"] }

--- a/crates/rules/src/lib.rs
+++ b/crates/rules/src/lib.rs
@@ -29,10 +29,12 @@ pub mod error;
 pub mod load;
 
 mod permission;
-pub mod read;
 mod rule;
 mod set;
 mod subject;
+
+pub mod read;
+pub mod write;
 
 pub(crate) fn bool_to_c(b: bool) -> char {
     if b {

--- a/crates/rules/src/load.rs
+++ b/crates/rules/src/load.rs
@@ -12,7 +12,7 @@ use crate::parser::marker;
 use crate::parser::parse::StrTrace;
 use std::fs::File;
 use std::io::{BufRead, BufReader};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::{fs, io};
 
 pub(crate) type RuleSource = (PathBuf, String);
@@ -28,7 +28,7 @@ pub fn rules_from_disk(path: &str) -> Result<Vec<RuleSource>, Error> {
 
 pub(crate) fn rules_from(src: RuleFrom) -> Result<Vec<RuleSource>, Error> {
     let r = match src {
-        Disk(path) if path.is_dir() => rules_dir(path)?,
+        Disk(path) if path.is_dir() => rules_dir(&path)?,
         Disk(path) => rules_file(path)?,
         Mem(txt) => rules_text(txt)?,
     };
@@ -45,16 +45,22 @@ fn rules_file(path: PathBuf) -> Result<Vec<RuleSource>, io::Error> {
     Ok(lines)
 }
 
-fn rules_dir(rules_source_path: PathBuf) -> Result<Vec<RuleSource>, io::Error> {
-    let d_files: Result<Vec<PathBuf>, io::Error> = fs::read_dir(&rules_source_path)?
-        .map(|e| e.map(|e| e.path()))
-        .collect();
+pub fn read_sorted_d_files(from: &Path) -> Result<Vec<PathBuf>, io::Error> {
+    let d_files: Result<Vec<PathBuf>, io::Error> =
+        fs::read_dir(from)?.map(|e| e.map(|e| e.path())).collect();
 
     let mut d_files: Vec<PathBuf> = d_files?
         .into_iter()
         .filter(|p| p.is_file() && p.display().to_string().ends_with(".rules"))
         .collect();
+
     d_files.sort_by_key(|p| p.display().to_string());
+
+    Ok(d_files)
+}
+
+fn rules_dir(rules_source_path: &Path) -> Result<Vec<RuleSource>, io::Error> {
+    let d_files = read_sorted_d_files(rules_source_path)?;
 
     let d_files: Result<Vec<(PathBuf, File)>, io::Error> = d_files
         .into_iter()

--- a/crates/rules/src/write.rs
+++ b/crates/rules/src/write.rs
@@ -34,7 +34,7 @@ fn rules_dir(db: &DB, dir: &Path, compiled: &Path) -> Result<(), io::Error> {
     // clear existing rules.d files
     for e in fs::read_dir(dir)? {
         let f = e?.path();
-        if f.ends_with(".rules") {
+        if f.display().to_string().ends_with(".rules") {
             fs::remove_file(f)?;
         }
     }

--- a/crates/rules/src/write.rs
+++ b/crates/rules/src/write.rs
@@ -15,13 +15,14 @@ use std::path::Path;
 
 pub fn db(db: &DB, to: &Path) -> Result<(), io::Error> {
     if to.is_dir() {
-        rules_dir(db, to)
+        let parent = to.parent().expect("Cannot write to /");
+        rules_dir(db, to, &parent.join("compiled.rules"))
     } else {
         rules_file(db, to)
     }
 }
 
-fn rules_dir(db: &DB, dir: &Path) -> Result<(), io::Error> {
+fn rules_dir(db: &DB, dir: &Path, compiled: &Path) -> Result<(), io::Error> {
     let mut files = HashMap::<&str, Vec<String>>::new();
     for (_, (k, v)) in db.iter() {
         if !files.contains_key(k.as_str()) {
@@ -40,7 +41,7 @@ fn rules_dir(db: &DB, dir: &Path) -> Result<(), io::Error> {
 
     // write compiled.rules
     // todo;; get this from config or constants
-    let mut rf = File::create("/etc/fapolicyd/compiled.rules")?;
+    let mut rf = File::create(compiled)?;
     for (_, (_, e)) in db.iter() {
         rf.write_all(format!("{}\n", e).as_bytes())?;
     }

--- a/crates/rules/src/write.rs
+++ b/crates/rules/src/write.rs
@@ -9,9 +9,9 @@
 use crate::db::DB;
 use std::collections::HashMap;
 use std::fs::File;
-use std::io;
 use std::io::Write;
 use std::path::Path;
+use std::{fs, io};
 
 pub fn db(db: &DB, to: &Path) -> Result<(), io::Error> {
     if to.is_dir() {
@@ -29,6 +29,14 @@ fn rules_dir(db: &DB, dir: &Path, compiled: &Path) -> Result<(), io::Error> {
             files.insert(k, vec![]);
         }
         files.get_mut(k.as_str()).unwrap().push(v.to_string());
+    }
+
+    // clear existing rules.d files
+    for e in fs::read_dir(dir)? {
+        let f = e?.path();
+        if f.ends_with(".rules") {
+            fs::remove_file(f)?;
+        }
     }
 
     // write rules.d files

--- a/crates/rules/src/write.rs
+++ b/crates/rules/src/write.rs
@@ -1,0 +1,57 @@
+/*
+ * Copyright Concurrent Technologies Corporation 2021
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+use crate::db::DB;
+use std::collections::HashMap;
+use std::fs::File;
+use std::io;
+use std::io::Write;
+use std::path::Path;
+
+pub fn db(db: &DB, to: &Path) -> Result<(), io::Error> {
+    if to.is_dir() {
+        rules_dir(db, to)
+    } else {
+        rules_file(db, to)
+    }
+}
+
+fn rules_dir(db: &DB, dir: &Path) -> Result<(), io::Error> {
+    let mut files = HashMap::<&str, Vec<String>>::new();
+    for (_, (k, v)) in db.iter() {
+        if !files.contains_key(k.as_str()) {
+            files.insert(k, vec![]);
+        }
+        files.get_mut(k.as_str()).unwrap().push(v.to_string());
+    }
+
+    // write rules.d files
+    for (k, v) in files {
+        let mut rf = File::create(dir.join(k))?;
+        for l in v {
+            rf.write_all(format!("{}\n", l).as_bytes())?;
+        }
+    }
+
+    // write compiled.rules
+    // todo;; get this from config or constants
+    let mut rf = File::create("/etc/fapolicyd/compiled.rules")?;
+    for (_, (_, e)) in db.iter() {
+        rf.write_all(format!("{}\n", e).as_bytes())?;
+    }
+
+    Ok(())
+}
+
+fn rules_file(db: &DB, to: &Path) -> Result<(), io::Error> {
+    let mut rf = File::create(to)?;
+    for (_, (_, e)) in db.iter() {
+        rf.write_all(format!("{}\n", e).as_bytes())?;
+    }
+    Ok(())
+}

--- a/crates/rules/tests/write.rs
+++ b/crates/rules/tests/write.rs
@@ -6,6 +6,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
+use fapolicy_rules::load::read_sorted_d_files;
 use fapolicy_rules::{read, write};
 use std::error::Error;
 use std::fs::{read_dir, File};
@@ -89,8 +90,8 @@ fn test_dir_multi_file() -> Result<(), Box<dyn Error>> {
     write::db(&db, &rules_d)?;
 
     let expected = vec![expected0, expected1];
-    for (i, f) in read_dir(rules_d)?.enumerate() {
-        let actual = read_string(&f.unwrap().path())?.trim().to_string();
+    for (i, f) in read_sorted_d_files(&rules_d)?.iter().enumerate() {
+        let actual = read_string(f)?.trim().to_string();
         println!("{}: expected [{}], actual[{}]", i, expected[i], actual);
         assert_eq!(expected[i], actual);
     }

--- a/crates/rules/tests/write.rs
+++ b/crates/rules/tests/write.rs
@@ -90,7 +90,7 @@ fn test_dir_multi_file() -> Result<(), Box<dyn Error>> {
 
     let expected = vec![expected0, expected1];
     for (i, f) in read_dir(rules_d)?.enumerate() {
-        let actual = read_string(&f.unwrap().path())?.trim();
+        let actual = read_string(&f.unwrap().path())?.trim().to_string();
         println!("{}: expected [{}], actual[{}]", i, expected[i], actual);
         assert_eq!(expected[i], actual);
     }
@@ -124,7 +124,7 @@ fn test_dir_multi_file_multi_rule() -> Result<(), Box<dyn Error>> {
     let concat = format!("{}\n{}", expected0, expected1);
     let expected = vec![concat.as_str(), expected2];
     for (i, f) in read_dir(rules_d)?.enumerate() {
-        let actual = read_string(&f.unwrap().path())?.trim();
+        let actual = read_string(&f.unwrap().path())?.trim().to_string();
         println!("{}: expected [{}], actual[{}]", i, expected[i], actual);
         assert_eq!(expected[i], actual);
     }

--- a/crates/rules/tests/write.rs
+++ b/crates/rules/tests/write.rs
@@ -124,8 +124,8 @@ fn test_dir_multi_file_multi_rule() -> Result<(), Box<dyn Error>> {
 
     let concat = format!("{}\n{}", expected0, expected1);
     let expected = vec![concat.as_str(), expected2];
-    for (i, f) in read_dir(rules_d)?.enumerate() {
-        let actual = read_string(&f.unwrap().path())?.trim().to_string();
+    for (i, f) in read_sorted_d_files(&rules_d)?.iter().enumerate() {
+        let actual = read_string(f)?.trim().to_string();
         println!("{}: expected [{}], actual[{}]", i, expected[i], actual);
         assert_eq!(expected[i], actual);
     }

--- a/crates/rules/tests/write.rs
+++ b/crates/rules/tests/write.rs
@@ -92,7 +92,6 @@ fn test_dir_multi_file() -> Result<(), Box<dyn Error>> {
     let expected = vec![expected0, expected1];
     for (i, f) in read_sorted_d_files(&rules_d)?.iter().enumerate() {
         let actual = read_string(f)?.trim().to_string();
-        println!("{}: expected [{}], actual[{}]", i, expected[i], actual);
         assert_eq!(expected[i], actual);
     }
 
@@ -126,7 +125,6 @@ fn test_dir_multi_file_multi_rule() -> Result<(), Box<dyn Error>> {
     let expected = vec![concat.as_str(), expected2];
     for (i, f) in read_sorted_d_files(&rules_d)?.iter().enumerate() {
         let actual = read_string(f)?.trim().to_string();
-        println!("{}: expected [{}], actual[{}]", i, expected[i], actual);
         assert_eq!(expected[i], actual);
     }
 

--- a/crates/rules/tests/write.rs
+++ b/crates/rules/tests/write.rs
@@ -91,7 +91,7 @@ fn test_dir_multi_file() -> Result<(), Box<dyn Error>> {
     let expected = vec![expected0, expected1];
     for (i, f) in read_dir(rules_d)?.enumerate() {
         let actual = read_string(&f.unwrap().path())?;
-        println!("expected{}: {}", i, actual);
+        println!("{}: expected [{}], actual[{}]", i, expected[i], actual);
         assert_eq!(expected[i], actual.trim());
     }
 
@@ -125,7 +125,7 @@ fn test_dir_multi_file_multi_rule() -> Result<(), Box<dyn Error>> {
     let expected = vec![concat.as_str(), expected2];
     for (i, f) in read_dir(rules_d)?.enumerate() {
         let actual = read_string(&f.unwrap().path())?;
-        println!("expected{}: {}", i, actual);
+        println!("{}: expected [{}], actual[{}]", i, expected[i], actual);
         assert_eq!(expected[i], actual.trim());
     }
 

--- a/crates/rules/tests/write.rs
+++ b/crates/rules/tests/write.rs
@@ -90,9 +90,9 @@ fn test_dir_multi_file() -> Result<(), Box<dyn Error>> {
 
     let expected = vec![expected0, expected1];
     for (i, f) in read_dir(rules_d)?.enumerate() {
-        let actual = read_string(&f.unwrap().path())?;
+        let actual = read_string(&f.unwrap().path())?.trim();
         println!("{}: expected [{}], actual[{}]", i, expected[i], actual);
-        assert_eq!(expected[i], actual.trim());
+        assert_eq!(expected[i], actual);
     }
 
     let compiled = read_string(&etc_fapolicyd.join("compiled.rules"))?;
@@ -124,9 +124,9 @@ fn test_dir_multi_file_multi_rule() -> Result<(), Box<dyn Error>> {
     let concat = format!("{}\n{}", expected0, expected1);
     let expected = vec![concat.as_str(), expected2];
     for (i, f) in read_dir(rules_d)?.enumerate() {
-        let actual = read_string(&f.unwrap().path())?;
+        let actual = read_string(&f.unwrap().path())?.trim();
         println!("{}: expected [{}], actual[{}]", i, expected[i], actual);
-        assert_eq!(expected[i], actual.trim());
+        assert_eq!(expected[i], actual);
     }
 
     let compiled = read_string(&etc_fapolicyd.join("compiled.rules"))?;

--- a/crates/rules/tests/write.rs
+++ b/crates/rules/tests/write.rs
@@ -1,0 +1,125 @@
+/*
+ * Copyright Concurrent Technologies Corporation 2021
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+use fapolicy_rules::{read, write};
+use std::error::Error;
+use std::fs::{read_dir, File};
+use std::io;
+use std::io::{BufReader, Read};
+use std::path::Path;
+use tempfile::NamedTempFile;
+
+#[test]
+fn test_file() -> Result<(), Box<dyn Error>> {
+    let expected = r#"allow perm=any all : all"#;
+    let db = read::deserialize_rules_db(expected)?;
+    let file = NamedTempFile::new()?;
+
+    write::db(&db, &file.path().to_path_buf())?;
+    let actual = read_string(&file.path().to_path_buf())?;
+    assert_eq!(expected, actual.trim());
+
+    Ok(())
+}
+
+#[test]
+fn test_dir_anon_file() -> Result<(), Box<dyn Error>> {
+    let expected = r#"allow perm=any all : all"#;
+    let db = read::deserialize_rules_db(expected)?;
+
+    let file = tempfile::tempdir()?.path().to_path_buf();
+    write::db(&db, &file)?;
+    let actual = read_string(&file)?;
+
+    assert_eq!(expected, actual.trim());
+
+    Ok(())
+}
+
+#[test]
+fn test_dir_single_file() -> Result<(), Box<dyn Error>> {
+    let expected = "allow perm=any all : all";
+    let db = read::deserialize_rules_db(&format!(
+        r#"
+    [foo.rules]
+    {}
+    "#,
+        expected
+    ))?;
+
+    let dir = tempfile::tempdir()?.into_path();
+    write::db(&db, &dir)?;
+
+    for f in read_dir(dir)? {
+        let actual = read_string(&f.unwrap().path())?;
+        assert_eq!(expected, actual.trim());
+    }
+    Ok(())
+}
+
+#[test]
+fn test_dir_multi_file() -> Result<(), Box<dyn Error>> {
+    let expected0 = "allow perm=exec all : all";
+    let expected1 = "allow perm=any all : all";
+    let db = read::deserialize_rules_db(&format!(
+        r#"
+    [00-foo.rules]
+    {}
+    [01-bar.rules]
+    {}
+    "#,
+        expected0, expected1
+    ))?;
+
+    let dir = tempfile::tempdir()?.into_path();
+    write::db(&db, &dir)?;
+
+    let expected = vec![expected0, expected1];
+    for (i, f) in read_dir(dir)?.enumerate() {
+        let actual = read_string(&f.unwrap().path())?;
+        println!("expected{}: {}", i, actual);
+        assert_eq!(expected[i], actual.trim());
+    }
+    Ok(())
+}
+
+#[test]
+fn test_dir_multi_file_multi_rule() -> Result<(), Box<dyn Error>> {
+    let expected0 = "allow perm=any uid=0 : all";
+    let expected1 = "allow perm=exec all : all";
+    let expected2 = "deny perm=any all : all";
+    let db = read::deserialize_rules_db(&format!(
+        r#"
+    [00-foo.rules]
+    {}
+    {}
+    [01-bar.rules]
+    {}
+    "#,
+        expected0, expected1, expected2
+    ))?;
+
+    let dir = tempfile::tempdir()?.into_path();
+    write::db(&db, &dir)?;
+
+    let concat = format!("{}\n{}", expected0, expected1);
+    let expected = vec![concat.as_str(), expected2];
+    for (i, f) in read_dir(dir)?.enumerate() {
+        let actual = read_string(&f.unwrap().path())?;
+        println!("expected{}: {}", i, actual);
+        assert_eq!(expected[i], actual.trim());
+    }
+    Ok(())
+}
+
+fn read_string(from: &Path) -> Result<String, io::Error> {
+    let mut reader = File::open(&from).map(BufReader::new)?;
+    let mut actual = String::new();
+    reader.read_to_string(&mut actual)?;
+    Ok(actual)
+}

--- a/crates/trust/src/lib.rs
+++ b/crates/trust/src/lib.rs
@@ -9,6 +9,8 @@
 pub mod db;
 pub mod error;
 pub mod ops;
-pub mod read;
 pub(crate) mod source;
 pub mod stat;
+
+pub mod read;
+pub mod write;

--- a/crates/trust/src/write.rs
+++ b/crates/trust/src/write.rs
@@ -1,3 +1,11 @@
+/*
+ * Copyright Concurrent Technologies Corporation 2021
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
 use crate::db::DB;
 use std::fs::File;
 use std::io::{Error, Write};

--- a/crates/trust/src/write.rs
+++ b/crates/trust/src/write.rs
@@ -1,0 +1,17 @@
+use crate::db::DB;
+use std::fs::File;
+use std::io::{Error, Write};
+use std::path::PathBuf;
+
+pub fn file_trust(db: &DB, to: PathBuf) -> Result<PathBuf, Error> {
+    // write file trust db
+    let mut tf = File::create(&to)?;
+    for (path, meta) in db.iter() {
+        if meta.is_ancillary() {
+            tf.write_all(
+                format!("{} {} {}\n", path, meta.trusted.size, meta.trusted.hash).as_bytes(),
+            )?;
+        }
+    }
+    Ok(to)
+}

--- a/examples/deploy_rules.py
+++ b/examples/deploy_rules.py
@@ -26,11 +26,11 @@ xs = Changeset()
 
 # demonstrates: rules / sets / multiple markers
 assert xs.set("""
-[foo.rules]
+[05-foo.rules]
 %foo=bar,baz
 allow perm=exec all : all
 
-[bar.rules]
+[10-bar.rules]
 %bing=bam,boom
 deny perm=any all : all
 """)


### PR DESCRIPTION
Write the rules db to disk while separating files based on origin, placing the files under the configured rules.d directory. This is not required for functionality, as the compiled.rules file is already being written.  This instead being done to keep a compliant fapolicyd configuration to ensure the standard fapolicyd workflows will continue to work. 

A side effect of this is that the preexisting rules files under rules.d will be deleted prior to writing the structure from the current rules db.. The original rules files are captured in the predeploy snapshot and can be reverted if needed.

Closes #532