### PR TITLE
Refine Rule Change API

### DIFF
--- a/crates/pyo3/src/rules.rs
+++ b/crates/pyo3/src/rules.rs
@@ -145,18 +145,22 @@ impl PyChangeset {
         rules_to_vec(self.rs.get())
     }
 
-    pub fn set(&mut self, text: String) -> bool {
-        self.rs.set(&text).is_ok()
+    pub fn set(&mut self, text: &str) -> bool {
+        self.rs.set(&text.trim()).is_ok()
     }
 
-    pub fn parse(&mut self, text: String) -> PyResult<()> {
-        match self.rs.set(&text) {
+    pub fn parse(&mut self, text: &str) -> PyResult<()> {
+        match self.rs.set(&text.trim()) {
             Ok(_) => Ok(()),
             Err(MalformedFileMarker(lnum, txt)) => Err(exceptions::PyRuntimeError::new_err(
                 format!("{}:malformed-file-marker:{}", lnum, txt),
             )),
             Err(e) => Err(exceptions::PyRuntimeError::new_err(format!("{:?}", e))),
         }
+    }
+
+    pub fn text(&self) -> Option<&str> {
+        self.rs.src().map(|s| &**s)
     }
 }
 

--- a/crates/pyo3/src/rules.rs
+++ b/crates/pyo3/src/rules.rs
@@ -7,10 +7,11 @@
  */
 
 use pyo3::prelude::*;
-use pyo3::PyObjectProtocol;
+use pyo3::{exceptions, PyObjectProtocol};
 
 use fapolicy_rules::db::Entry::*;
 use fapolicy_rules::db::DB;
+use fapolicy_rules::error::Error::MalformedFileMarker;
 use fapolicy_rules::ops::Changeset;
 use fapolicy_rules::parser::parse::StrTrace;
 use fapolicy_rules::parser::rule::parse_with_error_message;
@@ -26,7 +27,7 @@ pub struct PyRule {
 }
 
 impl PyRule {
-    pub(crate) fn new(
+    pub fn new(
         id: usize,
         text: String,
         origin: String,
@@ -137,11 +138,25 @@ impl PyChangeset {
     }
 
     pub fn get(&self) -> PyResult<Vec<PyRule>> {
+        self.rules()
+    }
+
+    pub fn rules(&self) -> PyResult<Vec<PyRule>> {
         rules_to_vec(self.rs.get())
     }
 
     pub fn set(&mut self, text: String) -> bool {
         self.rs.set(&text).is_ok()
+    }
+
+    pub fn parse(&mut self, text: String) -> PyResult<()> {
+        match self.rs.set(&text) {
+            Ok(_) => Ok(()),
+            Err(MalformedFileMarker(lnum, txt)) => Err(exceptions::PyRuntimeError::new_err(
+                format!("{}:malformed-file-marker:{}", lnum, txt),
+            )),
+            Err(e) => Err(exceptions::PyRuntimeError::new_err(format!("{:?}", e))),
+        }
     }
 }
 

--- a/crates/rules/src/error.rs
+++ b/crates/rules/src/error.rs
@@ -15,6 +15,6 @@ pub enum Error {
     #[error("File IO Error: {0}")]
     FileIoError(#[from] io::Error),
 
-    #[error("Deserialize rule error")]
-    DeserializeRulesError,
+    #[error("Malformed marker @ {0}: {1}")]
+    MalformedFileMarker(usize, String),
 }

--- a/crates/rules/src/ops.rs
+++ b/crates/rules/src/ops.rs
@@ -15,11 +15,16 @@ use crate::read::deserialize_rules_db;
 #[derive(Default, Clone, Debug)]
 pub struct Changeset {
     db: DB,
+    src: Option<String>,
 }
 
 impl Changeset {
     pub fn get(&self) -> &DB {
         &self.db
+    }
+
+    pub fn src(&self) -> Option<&String> {
+        self.src.as_ref()
     }
 
     // todo;; how to properly convey lints and errors in the parse fail?
@@ -34,6 +39,7 @@ impl Changeset {
         match deserialize_rules_db(text) {
             Ok(r) => {
                 self.db = r;
+                self.src = Some(text.to_string());
                 Ok(&self.db)
             }
             Err(e) => Err(e),

--- a/crates/rules/src/ops.rs
+++ b/crates/rules/src/ops.rs
@@ -8,6 +8,7 @@
 
 use crate::db::{RuleEntry, DB};
 
+use crate::error::Error;
 use crate::read::deserialize_rules_db;
 
 // Mutable
@@ -23,7 +24,7 @@ impl Changeset {
 
     // todo;; how to properly convey lints and errors in the parse fail?
     //        perhaps just roll it up to a _simple_ Error/Warn/Ok result enum
-    pub fn set(&mut self, text: &str) -> Result<&DB, String> {
+    pub fn set(&mut self, text: &str) -> Result<&DB, Error> {
         // todo;; what to do with the source text here?
         //        writing it out verbatim to the disk at deploy would be ideal
         //        but it has to be stashed somewhere until writing at deploy time
@@ -35,7 +36,7 @@ impl Changeset {
                 self.db = r;
                 Ok(&self.db)
             }
-            Err(_) => Err("failed to deserialize db".to_string()),
+            Err(e) => Err(e),
         }
     }
 

--- a/examples/change_rules.py
+++ b/examples/change_rules.py
@@ -28,28 +28,28 @@ xs1 = Changeset()
 txt = """
 foo bar baz
 """
-assert xs1.set(txt)
+xs1.parse(txt)
 
 # a valid rule without marker
 txt = """
 allow perm=any all : all
 """
-assert xs1.set(txt)
+xs1.parse(txt)
+
 
 # markers are relative to the rules.d dir
 # if using fapolicyd.rules markers are not supported
 
-# a valid rule with marker
+print("# a valid rule with marker")
 txt = """
 [foo.rules]
 allow perm=any all : all
 """
-assert xs1.set(txt)
-for r in xs1.get():
+xs1.parse(txt)
+for r in xs1.rules():
     print(r)
 
-print("---")
-# multiple valid rules with markers
+print("# multiple valid rules with markers")
 txt = """
 [foo.rules]
 allow perm=exec all : all
@@ -57,29 +57,40 @@ allow perm=exec all : all
 [bar.rules]
 deny perm=any all : all
 """
-assert xs1.set(txt)
-for r in xs1.get():
+xs1.parse(txt)
+for r in xs1.rules():
     print(r)
 
-print("---")
-# valid rules under single marker
+print("# valid rules under single marker")
 txt = """
 [foo.rules]
 allow perm=exec all : all
 deny perm=any all : all
 """
-assert xs1.set(txt)
-for r in xs1.get():
+xs1.parse(txt)
+for r in xs1.rules():
     print(r)
 
-print("---")
-# empty marker
+print("# empty marker")
 txt = """
 [foo.rules]
 allow perm=exec all : all
 
 [bar.rules]
 """
-assert xs1.set(txt)
-for r in xs1.get():
+xs1.parse(txt)
+for r in xs1.rules():
     print(r)
+
+print("# malformed marker")
+txt = """
+[foo.rules
+"""
+try:
+    xs1.parse(txt)
+except RuntimeError as e:
+    # todo;; we need those custom exceptions... without them we
+    #        are reduced to makeshift string based protocols
+    (line, msg, src) = str(e).split(":", 2)
+    print(f"failed to deserialize: {msg}")
+    print(f"\tline {line}: {src}")

--- a/examples/change_rules.py
+++ b/examples/change_rules.py
@@ -28,13 +28,13 @@ xs1 = Changeset()
 txt = """
 foo bar baz
 """
-assert not xs1.set(txt)
+assert xs1.set(txt)
 
 # a valid rule without marker
 txt = """
 allow perm=any all : all
 """
-assert not xs1.set(txt)
+assert xs1.set(txt)
 
 # markers are relative to the rules.d dir
 # if using fapolicyd.rules markers are not supported

--- a/examples/change_rules.py
+++ b/examples/change_rules.py
@@ -24,18 +24,24 @@ s1 = System()
 # changeset deserializes rule text into applicable rules
 xs1 = Changeset()
 
-# an invalid rule
+# a changeset has no source prior to parsing
+assert xs1.text() is None
+
+print("# an invalid rule")
 txt = """
 foo bar baz
 """
 xs1.parse(txt)
 
-# a valid rule without marker
+# the source text is available on successful parse
+print(xs1.text())
+
+print("# a valid rule without marker")
 txt = """
 allow perm=any all : all
 """
 xs1.parse(txt)
-
+print(xs1.text())
 
 # markers are relative to the rules.d dir
 # if using fapolicyd.rules markers are not supported
@@ -48,6 +54,7 @@ allow perm=any all : all
 xs1.parse(txt)
 for r in xs1.rules():
     print(r)
+print(xs1.text())
 
 print("# multiple valid rules with markers")
 txt = """
@@ -60,6 +67,7 @@ deny perm=any all : all
 xs1.parse(txt)
 for r in xs1.rules():
     print(r)
+print(xs1.text())
 
 print("# valid rules under single marker")
 txt = """
@@ -70,6 +78,7 @@ deny perm=any all : all
 xs1.parse(txt)
 for r in xs1.rules():
     print(r)
+print(xs1.text())
 
 print("# empty marker")
 txt = """
@@ -81,6 +90,8 @@ allow perm=exec all : all
 xs1.parse(txt)
 for r in xs1.rules():
     print(r)
+print(xs1.text())
+prev = xs1.text()
 
 print("# malformed marker")
 txt = """
@@ -94,3 +105,8 @@ except RuntimeError as e:
     (line, msg, src) = str(e).split(":", 2)
     print(f"failed to deserialize: {msg}")
     print(f"\tline {line}: {src}")
+
+# since the last parse failed, the changeset was never
+# updated, the source will remain set to the last successful
+# parse or None if there had not been a successful parse
+assert prev == xs1.text()


### PR DESCRIPTION
Several refinements and additions to the rule change api

- Adds a `parse(str)` method to the RuleChangeset to expose marker parsing errors
- Adds a new accessor for clarity, `rules()` to replace `get()`.
    - `get()` should be considered deprecated
- Retains the text from the previous successful parse and provides accessor `text()`
- Updates the `change_rules.py` example

The changes to the API should be non-breaking, `get()` should be removed either in this PR or after.

#495 