### PR TITLE
Rule change diff

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -282,6 +282,7 @@ dependencies = [
  "fapolicy-rules",
  "fapolicy-trust",
  "pyo3",
+ "similar",
 ]
 
 [[package]]
@@ -830,6 +831,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "similar"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e24979f63a11545f5f2c60141afe249d4f19f84581ea2138065e400941d83d3"
 
 [[package]]
 name = "smallvec"

--- a/crates/pyo3/Cargo.toml
+++ b/crates/pyo3/Cargo.toml
@@ -10,6 +10,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 pyo3 = { version="0.15", features = ["abi3-py36"] }
+similar = "2.1"
 
 fapolicy-api = { version = "*", path = "../api" }
 fapolicy-analyzer = { version = "*", path = "../analyzer" }

--- a/crates/pyo3/src/rules.rs
+++ b/crates/pyo3/src/rules.rs
@@ -137,11 +137,11 @@ impl PyChangeset {
         PyChangeset::default()
     }
 
-    pub fn get(&self) -> PyResult<Vec<PyRule>> {
+    pub fn get(&self) -> Vec<PyRule> {
         self.rules()
     }
 
-    pub fn rules(&self) -> PyResult<Vec<PyRule>> {
+    pub fn rules(&self) -> Vec<PyRule> {
         rules_to_vec(self.rs.get())
     }
 
@@ -172,9 +172,8 @@ fn rule_text_error_check(txt: &str) -> Option<String> {
     }
 }
 
-pub(crate) fn rules_to_vec(db: &DB) -> PyResult<Vec<PyRule>> {
-    Ok(db
-        .rules()
+pub(crate) fn rules_to_vec(db: &DB) -> Vec<PyRule> {
+    db.rules()
         .iter()
         .map(|e| {
             let (valid, text, info) = if e.valid {
@@ -194,12 +193,11 @@ pub(crate) fn rules_to_vec(db: &DB) -> PyResult<Vec<PyRule>> {
             };
             PyRule::new(e.id, text, e.origin.clone(), info, valid)
         })
-        .collect())
+        .collect()
 }
 
-pub(crate) fn entries_to_vec(db: &DB) -> PyResult<Vec<PyRule>> {
-    Ok(db
-        .iter()
+pub(crate) fn entries_to_vec(db: &DB) -> Vec<PyRule> {
+    db.iter()
         .map(|(id, (origin, e))| {
             let (valid, text, info) = match e {
                 Invalid { text, error } => {
@@ -215,7 +213,7 @@ pub(crate) fn entries_to_vec(db: &DB) -> PyResult<Vec<PyRule>> {
             };
             PyRule::new(*id, text, origin.to_string(), info, valid)
         })
-        .collect())
+        .collect()
 }
 
 // #[pyfunction]

--- a/examples/deploy_rules.py
+++ b/examples/deploy_rules.py
@@ -25,7 +25,7 @@ print("building changeset")
 xs = Changeset()
 
 # demonstrates: rules / sets / multiple markers
-assert xs.set("""
+rule_text = """
 [05-foo.rules]
 %foo=bar,baz
 allow perm=exec all : all
@@ -33,7 +33,8 @@ allow perm=exec all : all
 [10-bar.rules]
 %bing=bam,boom
 deny perm=any all : all
-""")
+"""
+assert xs.set(rule_text)
 
 print("applying changes")
 s2 = s1.apply_rule_changes(xs)
@@ -42,3 +43,9 @@ print(f"system2 has {len(s2.rules())} rules defined")
 
 print("deploying system")
 s2.deploy_only()
+
+assert xs.set(rule_text.replace("bar", "fizz"))
+
+print("diffing additional changes")
+s3 = s2.apply_rule_changes(xs)
+print(rules_difference(s2, s3))

--- a/examples/deploy_rules.py
+++ b/examples/deploy_rules.py
@@ -44,8 +44,16 @@ print(f"system2 has {len(s2.rules())} rules defined")
 print("deploying system")
 s2.deploy_only()
 
+# display a diff of the rules
+
 assert xs.set(rule_text.replace("bar", "fizz"))
 
-print("diffing additional changes")
+print("diffing additional changes\n")
 s3 = s2.apply_rule_changes(xs)
-print(rules_difference(s2, s3))
+for ln in rules_difference(s2, s3).split("\n"):
+    if ln.startswith("+"):
+        print('\033[92m', end='')
+    elif ln.startswith("-"):
+        print('\033[91m', end='')
+
+    print(f"{ln}  \033[0m")

--- a/examples/show_rules.py
+++ b/examples/show_rules.py
@@ -17,8 +17,8 @@ from fapolicy_analyzer import *
 import argparse
 import sys
 
-green = '\033[91m'
-red = '\033[92m'
+red = '\033[91m'
+green = '\033[92m'
 yellow = '\033[93m'
 blue = '\033[96m'
 gray = '\033[33m'
@@ -41,7 +41,7 @@ def main(*argv):
                 print(gray, end='')
                 print(f"🗎 [{origin}]\033[0m")
 
-            print(red if r.is_valid else green, end='')
+            print(green if r.is_valid else red, end='')
             print(f"{r.id} {r.text} \033[0m")
             for info in r.info:
                 marker = f'[{info.category}]' if info.category != 'e' else ''


### PR DESCRIPTION
Provide a diff formatted summarization of changes between two rule databases.  Taking the approach of diffing the text as it appears in the editor.  This provides diffs in our application context, including file markers, and avoids rule number diffs.

This commit adds a function to the bindings with the signature of `rules_difference(System, System)` which allows you to pass in two systems and receive a string similar to the `System#rules_text()`.  The diff adds prefixes of `+` and `-` to all changed lines. 

Closes #538 