### PR TITLE
updated test imports

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,10 +1,13 @@
 [run]
 source =
-    ui
-    util
+    fapolicy_analyzer/ui
+    fapolicy_analyzer/util
+omit =
+    */tests/*
+    fapolicy_analyzer/css/*
+    fapolicy_analyzer/glade/*
+    fapolicy_analyzer/resources/*
 
 [report]
 show_missing = true
 fail_under = 90
-omit =
-    */tests/*

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,8 +1,4 @@
 [run]
-debug = 
-    config
-    dataop
-    trace
 omit =
     */tests/*
     fapolicy_analyzer/css/*

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,7 +1,4 @@
 [run]
-source =
-    fapolicy_analyzer/ui
-    fapolicy_analyzer/util
 omit =
     */tests/*
     fapolicy_analyzer/css/*

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,4 +1,8 @@
 [run]
+debug = 
+    config
+    dataop
+    trace
 omit =
     */tests/*
     fapolicy_analyzer/css/*

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -58,47 +58,47 @@ jobs:
   #         command: test
   #         args: --all
 
-  py_build:
-    name: Build Python Bindings for Python ${{ matrix.python-version }}
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: [ '3.6' ]
-    steps:
-      - uses: actions/checkout@v2
-      - name: Install requirements
-        run: |
-          sudo apt-get update
-          sudo apt-get install libgtk-3-dev
-          sudo apt-get install libgirepository1.0-dev
-          sudo apt-get install xvfb
-          sudo apt-get install libdbus-1-dev
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
-        with:
-          python-version: ${{ matrix.python-version }}
-      - name: Install Rust 1.58.1
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: 1.58.1
-          override: true
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install pipenv
-          pipenv install --dev --python ${{ matrix.python-version }}
-      - name: Build
-        id: build
-        run: |
-          pipenv run compile_catalog
-          pipenv run python setup.py bdist_wheel
-          echo ::set-output name=virt_env::$(pipenv --venv)
-      - name: Archive wheel
-        uses: actions/upload-artifact@v2
-        with:
-          name: fapolicy-analyzer-wheel-python-${{ matrix.python-version }}
-          path: dist/fapolicy_analyzer-*.whl
+  # py_build:
+  #   name: Build Python Bindings for Python ${{ matrix.python-version }}
+  #   runs-on: ubuntu-latest
+  #   strategy:
+  #     matrix:
+  #       python-version: [ '3.6' ]
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #     - name: Install requirements
+  #       run: |
+  #         sudo apt-get update
+  #         sudo apt-get install libgtk-3-dev
+  #         sudo apt-get install libgirepository1.0-dev
+  #         sudo apt-get install xvfb
+  #         sudo apt-get install libdbus-1-dev
+  #     - name: Set up Python ${{ matrix.python-version }}
+  #       uses: actions/setup-python@v2
+  #       with:
+  #         python-version: ${{ matrix.python-version }}
+  #     - name: Install Rust 1.58.1
+  #       uses: actions-rs/toolchain@v1
+  #       with:
+  #         profile: minimal
+  #         toolchain: 1.58.1
+  #         override: true
+  #     - name: Install dependencies
+  #       run: |
+  #         python -m pip install --upgrade pip
+  #         pip install pipenv
+  #         pipenv install --dev --python ${{ matrix.python-version }}
+  #     - name: Build
+  #       id: build
+  #       run: |
+  #         pipenv run compile_catalog
+  #         pipenv run python setup.py bdist_wheel
+  #         echo ::set-output name=virt_env::$(pipenv --venv)
+  #     - name: Archive wheel
+  #       uses: actions/upload-artifact@v2
+  #       with:
+  #         name: fapolicy-analyzer-wheel-python-${{ matrix.python-version }}
+  #         path: dist/fapolicy_analyzer-*.whl
 
   # ui_lint:
   #   name: UI Lint
@@ -119,7 +119,7 @@ jobs:
 
   ui_test:
     name: UI Test Suite for Python ${{ matrix.python-version }}
-    needs: py_build
+    # needs: py_build
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -149,19 +149,21 @@ jobs:
           pip install pipenv
           pipenv install --dev --python ${{ matrix.python-version }}
           echo ::set-output name=virt_env::$(pipenv --venv)
-      - name: Download bindings package
-        id: download
-        uses: actions/download-artifact@v2
-        with:
-          name: fapolicy-analyzer-wheel-python-${{ matrix.python-version }}
-          path: /tmp
-      - name: Install wheel
-        run: pipenv install /tmp/fapolicy_analyzer-*.whl
-      - name: 'Update path'
-        run: |
-          for entry in ${{steps.download.outputs.download-path}}/fapolicy*;
-            do echo "./$(basename $entry)" >> ${{steps.download.outputs.download-path}}/easy-install.pth;
-          done
+      # - name: Download bindings package
+      #   id: download
+      #   uses: actions/download-artifact@v2
+      #   with:
+      #     name: fapolicy-analyzer-wheel-python-${{ matrix.python-version }}
+      #     path: /tmp
+      # - name: Install wheel
+      #   run: pipenv install /tmp/fapolicy_analyzer-*.whl
+      - name: Setup Bindings
+        run: pipenv run python setup.py develop
+      # - name: 'Update path'
+      #   run: |
+      #     for entry in ${{steps.download.outputs.download-path}}/fapolicy*;
+      #       do echo "./$(basename $entry)" >> ${{steps.download.outputs.download-path}}/easy-install.pth;
+      #     done
       - name: Test with pytest
         run: pipenv run test
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,120 +10,114 @@ on:
 name: Continuous integration
 
 jobs:
-  # headers:
-  #   name: License header check
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: actions/checkout@v2
-  #     - name: Install requirements
-  #       run: |
-  #         ! grep -R -L --exclude-dir=vendor \
-  #           --include='*.py' --include='*.rs' --include='*.glade' --include='*.sh' \
-  #           'Copyright Concurrent Technologies Corporation' *
+  headers:
+    name: License header check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install requirements
+        run: |
+          ! grep -R -L --exclude-dir=vendor \
+            --include='*.py' --include='*.rs' --include='*.glade' --include='*.sh' \
+            'Copyright Concurrent Technologies Corporation' *
 
-  # check:
-  #   name: Check
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: actions/checkout@v2
-  #     - name: Install requirements
-  #       run: |
-  #         sudo apt-get update
-  #         sudo apt-get install libdbus-1-dev
-  #     - uses: actions-rs/toolchain@v1
-  #       with:
-  #         profile: minimal
-  #         toolchain: 1.58.1
-  #         override: true
-  #     - uses: actions-rs/cargo@v1
-  #       with:
-  #         command: check
+  check:
+    name: Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install requirements
+        run: |
+          sudo apt-get update
+          sudo apt-get install libdbus-1-dev
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: 1.58.1
+          override: true
+      - uses: actions-rs/cargo@v1
+        with:
+          command: check
 
-  # test:
-  #   name: Test Suite
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: actions/checkout@v2
-  #     - name: Install requirements
-  #       run: |
-  #         sudo apt-get update
-  #         sudo apt-get install libdbus-1-dev
-  #     - uses: actions-rs/toolchain@v1
-  #       with:
-  #         profile: minimal
-  #         toolchain: 1.58.1
-  #         override: true
-  #     - uses: actions-rs/cargo@v1
-  #       with:
-  #         command: test
-  #         args: --all
+  test:
+    name: Test Suite
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install requirements
+        run: |
+          sudo apt-get update
+          sudo apt-get install libdbus-1-dev
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: 1.58.1
+          override: true
+      - uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --all
 
-  # py_build:
-  #   name: Build Python Bindings for Python ${{ matrix.python-version }}
-  #   runs-on: ubuntu-latest
-  #   strategy:
-  #     matrix:
-  #       python-version: [ '3.6' ]
-  #   steps:
-  #     - uses: actions/checkout@v2
-  #     - name: Install requirements
-  #       run: |
-  #         sudo apt-get update
-  #         sudo apt-get install libgtk-3-dev
-  #         sudo apt-get install libgirepository1.0-dev
-  #         sudo apt-get install xvfb
-  #         sudo apt-get install libdbus-1-dev
-  #     - name: Set up Python ${{ matrix.python-version }}
-  #       uses: actions/setup-python@v2
-  #       with:
-  #         python-version: ${{ matrix.python-version }}
-  #     - name: Install Rust 1.58.1
-  #       uses: actions-rs/toolchain@v1
-  #       with:
-  #         profile: minimal
-  #         toolchain: 1.58.1
-  #         override: true
-  #     - name: Install dependencies
-  #       run: |
-  #         python -m pip install --upgrade pip
-  #         pip install pipenv
-  #         pipenv install --dev --python ${{ matrix.python-version }}
-  #     - name: Build
-  #       id: build
-  #       run: |
-  #         pipenv run compile_catalog
-  #         pipenv run python setup.py bdist_wheel
-  #         echo ::set-output name=virt_env::$(pipenv --venv)
-  #     - name: Archive wheel
-  #       uses: actions/upload-artifact@v2
-  #       with:
-  #         name: fapolicy-analyzer-wheel-python-${{ matrix.python-version }}
-  #         path: dist/fapolicy_analyzer-*.whl
-
-  # ui_lint:
-  #   name: UI Lint
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: actions/checkout@v2
-  #     - name: Set up Python 3.6
-  #       uses: actions/setup-python@v2
-  #       with:
-  #         python-version: 3.6
-  #     - name: Install dependencies
-  #       id: install_deps
-  #       run: |
-  #         python -m pip install --upgrade pip
-  #         pip install flake8 flake8-i18n
-  #     - name: Lint with flake8
-  #       run: python -m flake8 ./fapolicy_analyzer
-
-  ui_test:
-    name: UI Test Suite for Python ${{ matrix.python-version }}
-    # needs: py_build
+  py_build:
+    name: Build Python Bindings for Python ${{ matrix.python-version }}
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ '3.6' ]
+        python-version: [ '3.6', '3.9' ]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install requirements
+        run: |
+          sudo apt-get update
+          sudo apt-get install libgtk-3-dev
+          sudo apt-get install libgirepository1.0-dev
+          sudo apt-get install xvfb
+          sudo apt-get install libdbus-1-dev
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install Rust 1.58.1
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: 1.58.1
+          override: true
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pipenv
+          pipenv install --dev --python ${{ matrix.python-version }}
+      - name: Build
+        id: build
+        run: |
+          pipenv run compile_catalog
+          pipenv run python setup.py bdist_wheel
+          echo ::set-output name=virt_env::$(pipenv --venv)
+
+  ui_lint:
+    name: UI Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python 3.6
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.6
+      - name: Install dependencies
+        id: install_deps
+        run: |
+          python -m pip install --upgrade pip
+          pip install flake8 flake8-i18n
+      - name: Lint with flake8
+        run: python -m flake8 ./fapolicy_analyzer
+
+  ui_test:
+    name: UI Test Suite for Python ${{ matrix.python-version }}
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [ '3.6', '3.9' ]
     steps:
       - uses: actions/checkout@v2
       - name: Install requirements
@@ -149,56 +143,43 @@ jobs:
           pip install pipenv
           pipenv install --dev --python ${{ matrix.python-version }}
           echo ::set-output name=virt_env::$(pipenv --venv)
-      # - name: Download bindings package
-      #   id: download
-      #   uses: actions/download-artifact@v2
-      #   with:
-      #     name: fapolicy-analyzer-wheel-python-${{ matrix.python-version }}
-      #     path: /tmp
-      # - name: Install wheel
-      #   run: pipenv install /tmp/fapolicy_analyzer-*.whl
       - name: Setup Bindings
         run: pipenv run python setup.py develop
-      # - name: 'Update path'
-      #   run: |
-      #     for entry in ${{steps.download.outputs.download-path}}/fapolicy*;
-      #       do echo "./$(basename $entry)" >> ${{steps.download.outputs.download-path}}/easy-install.pth;
-      #     done
       - name: Test with pytest
         run: pipenv run test
 
-  # fmt:
-  #   name: Rustfmt
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: actions/checkout@v2
-  #     - uses: actions-rs/toolchain@v1
-  #       with:
-  #         profile: minimal
-  #         toolchain: 1.58.1
-  #         override: true
-  #     - run: rustup component add rustfmt
-  #     - uses: actions-rs/cargo@v1
-  #       with:
-  #         command: fmt
-  #         args: --all -- --check
+  fmt:
+    name: Rustfmt
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: 1.58.1
+          override: true
+      - run: rustup component add rustfmt
+      - uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+          args: --all -- --check
 
-  # clippy:
-  #   name: Clippy
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: actions/checkout@v2
-  #     - name: Install requirements
-  #       run: |
-  #         sudo apt-get update
-  #         sudo apt-get install libdbus-1-dev
-  #     - uses: actions-rs/toolchain@v1
-  #       with:
-  #         profile: minimal
-  #         toolchain: 1.58.1
-  #         override: true
-  #     - run: rustup component add clippy
-  #     - uses: actions-rs/cargo@v1
-  #       with:
-  #         command: clippy
-  #         args: -- -D warnings
+  clippy:
+    name: Clippy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install requirements
+        run: |
+          sudo apt-get update
+          sudo apt-get install libdbus-1-dev
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: 1.58.1
+          override: true
+      - run: rustup component add clippy
+      - uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: -- -D warnings

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,60 +10,60 @@ on:
 name: Continuous integration
 
 jobs:
-  headers:
-    name: License header check
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - name: Install requirements
-        run: |
-          ! grep -R -L --exclude-dir=vendor \
-            --include='*.py' --include='*.rs' --include='*.glade' --include='*.sh' \
-            'Copyright Concurrent Technologies Corporation' *
+  # headers:
+  #   name: License header check
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #     - name: Install requirements
+  #       run: |
+  #         ! grep -R -L --exclude-dir=vendor \
+  #           --include='*.py' --include='*.rs' --include='*.glade' --include='*.sh' \
+  #           'Copyright Concurrent Technologies Corporation' *
 
-  check:
-    name: Check
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - name: Install requirements
-        run: |
-          sudo apt-get update
-          sudo apt-get install libdbus-1-dev
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: 1.58.1
-          override: true
-      - uses: actions-rs/cargo@v1
-        with:
-          command: check
+  # check:
+  #   name: Check
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #     - name: Install requirements
+  #       run: |
+  #         sudo apt-get update
+  #         sudo apt-get install libdbus-1-dev
+  #     - uses: actions-rs/toolchain@v1
+  #       with:
+  #         profile: minimal
+  #         toolchain: 1.58.1
+  #         override: true
+  #     - uses: actions-rs/cargo@v1
+  #       with:
+  #         command: check
 
-  test:
-    name: Test Suite
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - name: Install requirements
-        run: |
-          sudo apt-get update
-          sudo apt-get install libdbus-1-dev
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: 1.58.1
-          override: true
-      - uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --all
+  # test:
+  #   name: Test Suite
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #     - name: Install requirements
+  #       run: |
+  #         sudo apt-get update
+  #         sudo apt-get install libdbus-1-dev
+  #     - uses: actions-rs/toolchain@v1
+  #       with:
+  #         profile: minimal
+  #         toolchain: 1.58.1
+  #         override: true
+  #     - uses: actions-rs/cargo@v1
+  #       with:
+  #         command: test
+  #         args: --all
 
   py_build:
     name: Build Python Bindings for Python ${{ matrix.python-version }}
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ '3.6', '3.9 ' ]
+        python-version: [ '3.6' ]
     steps:
       - uses: actions/checkout@v2
       - name: Install requirements
@@ -100,22 +100,22 @@ jobs:
           name: fapolicy-analyzer-wheel-python-${{ matrix.python-version }}
           path: dist/fapolicy_analyzer-*.whl
 
-  ui_lint:
-    name: UI Lint
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - name: Set up Python 3.6
-        uses: actions/setup-python@v2
-        with:
-          python-version: 3.6
-      - name: Install dependencies
-        id: install_deps
-        run: |
-          python -m pip install --upgrade pip
-          pip install flake8 flake8-i18n
-      - name: Lint with flake8
-        run: python -m flake8 ./fapolicy_analyzer
+  # ui_lint:
+  #   name: UI Lint
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #     - name: Set up Python 3.6
+  #       uses: actions/setup-python@v2
+  #       with:
+  #         python-version: 3.6
+  #     - name: Install dependencies
+  #       id: install_deps
+  #       run: |
+  #         python -m pip install --upgrade pip
+  #         pip install flake8 flake8-i18n
+  #     - name: Lint with flake8
+  #       run: python -m flake8 ./fapolicy_analyzer
 
   ui_test:
     name: UI Test Suite for Python ${{ matrix.python-version }}
@@ -123,7 +123,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ '3.6', '3.9 ' ]
+        python-version: [ '3.6' ]
     steps:
       - uses: actions/checkout@v2
       - name: Install requirements
@@ -165,38 +165,38 @@ jobs:
       - name: Test with pytest
         run: pipenv run test
 
-  fmt:
-    name: Rustfmt
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: 1.58.1
-          override: true
-      - run: rustup component add rustfmt
-      - uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check
+  # fmt:
+  #   name: Rustfmt
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #     - uses: actions-rs/toolchain@v1
+  #       with:
+  #         profile: minimal
+  #         toolchain: 1.58.1
+  #         override: true
+  #     - run: rustup component add rustfmt
+  #     - uses: actions-rs/cargo@v1
+  #       with:
+  #         command: fmt
+  #         args: --all -- --check
 
-  clippy:
-    name: Clippy
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - name: Install requirements
-        run: |
-          sudo apt-get update
-          sudo apt-get install libdbus-1-dev
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: 1.58.1
-          override: true
-      - run: rustup component add clippy
-      - uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: -- -D warnings
+  # clippy:
+  #   name: Clippy
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #     - name: Install requirements
+  #       run: |
+  #         sudo apt-get update
+  #         sudo apt-get install libdbus-1-dev
+  #     - uses: actions-rs/toolchain@v1
+  #       with:
+  #         profile: minimal
+  #         toolchain: 1.58.1
+  #         override: true
+  #     - run: rustup component add clippy
+  #     - uses: actions-rs/cargo@v1
+  #       with:
+  #         command: clippy
+  #         args: -- -D warnings

--- a/Pipfile
+++ b/Pipfile
@@ -40,7 +40,7 @@ dataclasses = "==0.6"
 allow_prereleases = true
 
 [scripts]
-test = "pipenv run xvfb-run -a pytest -vv -s --cov fapolicy_analyzer/"
+test = "pipenv run xvfb-run -a pytest -vv -s --cov=fapolicy_analyzer fapolicy_analyzer/tests/"
 lint = "pipenv run flake8 fapolicy_analyzer/"
 format = "pipenv run black fapolicy_analyzer/"
 watch-test = "pipenv run xvfb-run -a pytest-watch fapolicy_analyzer/ -- --testmon -s"

--- a/Pipfile
+++ b/Pipfile
@@ -40,7 +40,7 @@ dataclasses = "==0.6"
 allow_prereleases = true
 
 [scripts]
-test = "pipenv run xvfb-run -a pytest -vv -s --cov=fapolicy_analyzer fapolicy_analyzer/tests/"
+test = "pipenv run xvfb-run -a pytest -s --cov=fapolicy_analyzer fapolicy_analyzer/tests/"
 lint = "pipenv run flake8 fapolicy_analyzer/"
 format = "pipenv run black fapolicy_analyzer/"
 watch-test = "pipenv run xvfb-run -a pytest-watch fapolicy_analyzer/ -- --testmon -s"

--- a/Pipfile
+++ b/Pipfile
@@ -40,7 +40,7 @@ dataclasses = "==0.6"
 allow_prereleases = true
 
 [scripts]
-test = "pipenv run xvfb-run -a pytest -s --cov fapolicy_analyzer/"
+test = "pipenv run xvfb-run -a pytest -vv -s --cov fapolicy_analyzer/"
 lint = "pipenv run flake8 fapolicy_analyzer/"
 format = "pipenv run black fapolicy_analyzer/"
 watch-test = "pipenv run xvfb-run -a pytest-watch fapolicy_analyzer/ -- --testmon -s"

--- a/fapolicy_analyzer/tests/context.py
+++ b/fapolicy_analyzer/tests/context.py
@@ -13,7 +13,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import sys
-import os
+# import sys
+# import os
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../")))
+# sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../")))

--- a/fapolicy_analyzer/tests/context.py
+++ b/fapolicy_analyzer/tests/context.py
@@ -13,7 +13,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-# import sys
-# import os
+import os
+import sys
 
-# sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../")))
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../")))

--- a/fapolicy_analyzer/tests/reducers/test_ancillary_trust_reducer.py
+++ b/fapolicy_analyzer/tests/reducers/test_ancillary_trust_reducer.py
@@ -13,19 +13,15 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+from unittest.mock import MagicMock
+
 import context  # noqa: F401
 import pytest
-from unittest.mock import MagicMock
-from ui.reducers.ancillary_trust_reducer import (
-    TrustState,
-    handle_add_changesets,
-    handle_ancillary_trust_deployed,
-    handle_clear_changesets,
-    handle_error_ancillary_trust,
-    handle_error_deploying_ancillary_trust,
-    handle_received_ancillary_trust,
-    handle_request_ancillary_trust,
-)
+from fapolicy_analyzer.ui.reducers.ancillary_trust_reducer import (
+    TrustState, handle_add_changesets, handle_ancillary_trust_deployed,
+    handle_clear_changesets, handle_error_ancillary_trust,
+    handle_error_deploying_ancillary_trust, handle_received_ancillary_trust,
+    handle_request_ancillary_trust)
 
 
 @pytest.fixture()

--- a/fapolicy_analyzer/tests/reducers/test_changeset_reducer.py
+++ b/fapolicy_analyzer/tests/reducers/test_changeset_reducer.py
@@ -15,7 +15,10 @@
 
 import context  # noqa: F401
 from unittest.mock import MagicMock
-from ui.reducers.changeset_reducer import handle_add_changesets, handle_clear_changesets
+from fapolicy_analyzer.ui.reducers.changeset_reducer import (
+    handle_add_changesets,
+    handle_clear_changesets,
+)
 
 
 def test_handle_add_changesets():

--- a/fapolicy_analyzer/tests/reducers/test_event_reducer.py
+++ b/fapolicy_analyzer/tests/reducers/test_event_reducer.py
@@ -16,7 +16,7 @@
 import context  # noqa: F401
 import pytest
 from unittest.mock import MagicMock
-from ui.reducers.event_reducer import (
+from fapolicy_analyzer.ui.reducers.event_reducer import (
     EventState,
     handle_error_events,
     handle_received_events,

--- a/fapolicy_analyzer/tests/reducers/test_group_reducer.py
+++ b/fapolicy_analyzer/tests/reducers/test_group_reducer.py
@@ -16,7 +16,7 @@
 import context  # noqa: F401
 import pytest
 from unittest.mock import MagicMock
-from ui.reducers.group_reducer import (
+from fapolicy_analyzer.ui.reducers.group_reducer import (
     GroupState,
     handle_error_groups,
     handle_received_groups,

--- a/fapolicy_analyzer/tests/reducers/test_notification_reducer.py
+++ b/fapolicy_analyzer/tests/reducers/test_notification_reducer.py
@@ -15,8 +15,8 @@
 
 import context  # noqa: F401
 from unittest.mock import MagicMock
-from ui.actions import Notification, NotificationType
-from ui.reducers.notification_reducer import (
+from fapolicy_analyzer.ui.actions import Notification, NotificationType
+from fapolicy_analyzer.ui.reducers.notification_reducer import (
     handle_add_notification,
     handle_remove_notification,
 )

--- a/fapolicy_analyzer/tests/reducers/test_rule_reducer.py
+++ b/fapolicy_analyzer/tests/reducers/test_rule_reducer.py
@@ -17,7 +17,7 @@ from unittest.mock import MagicMock
 
 import context  # noqa: F401
 import pytest
-from ui.reducers.rule_reducer import (
+from fapolicy_analyzer.ui.reducers.rule_reducer import (
     RuleState,
     handle_error_rules,
     handle_received_rules,

--- a/fapolicy_analyzer/tests/reducers/test_system_trust_reducer.py
+++ b/fapolicy_analyzer/tests/reducers/test_system_trust_reducer.py
@@ -16,7 +16,7 @@
 import context  # noqa: F401
 import pytest
 from unittest.mock import MagicMock
-from ui.reducers.system_trust_reducer import (
+from fapolicy_analyzer.ui.reducers.system_trust_reducer import (
     TrustState,
     handle_error_system_trust,
     handle_received_system_trust,

--- a/fapolicy_analyzer/tests/reducers/test_user_reducer.py
+++ b/fapolicy_analyzer/tests/reducers/test_user_reducer.py
@@ -16,7 +16,7 @@
 import context  # noqa: F401
 import pytest
 from unittest.mock import MagicMock
-from ui.reducers.user_reducer import (
+from fapolicy_analyzer.ui.reducers.user_reducer import (
     UserState,
     handle_error_users,
     handle_received_users,

--- a/fapolicy_analyzer/tests/rules/test_rules_admin_page.py
+++ b/fapolicy_analyzer/tests/rules/test_rules_admin_page.py
@@ -19,13 +19,13 @@ from unittest.mock import MagicMock
 import gi
 import pytest
 from callee import Attrs, InstanceOf
+from fapolicy_analyzer.ui.actions import ADD_NOTIFICATION
+from fapolicy_analyzer.ui.rules import RulesAdminPage
+from fapolicy_analyzer.ui.store import init_store
+from fapolicy_analyzer.ui.strings import RULES_LOAD_ERROR, RULES_TEXT_LOAD_ERROR
 from mocks import mock_rule, mock_System
 from redux import Action
 from rx.subject import Subject
-from ui.actions import ADD_NOTIFICATION
-from ui.rules import RulesAdminPage
-from ui.store import init_store
-from ui.strings import RULES_LOAD_ERROR, RULES_TEXT_LOAD_ERROR
 
 gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk  # isort: skip
@@ -33,14 +33,14 @@ from gi.repository import Gtk  # isort: skip
 
 @pytest.fixture()
 def mock_dispatch(mocker):
-    return mocker.patch("ui.rules.rules_admin_page.dispatch")
+    return mocker.patch("fapolicy_analyzer.ui.rules.rules_admin_page.dispatch")
 
 
 @pytest.fixture()
 def mock_system_feature(mocker):
     mockSystemFeature = Subject()
     mocker.patch(
-        "ui.rules.rules_admin_page.get_system_feature",
+        "fapolicy_analyzer.ui.rules.rules_admin_page.get_system_feature",
         return_value=mockSystemFeature,
     )
     yield mockSystemFeature

--- a/fapolicy_analyzer/tests/rules/test_rules_list_view.py
+++ b/fapolicy_analyzer/tests/rules/test_rules_list_view.py
@@ -18,8 +18,8 @@ from unittest.mock import MagicMock
 
 import gi
 import pytest
-from ui.configs import Colors
-from ui.rules.rules_list_view import RulesListView
+from fapolicy_analyzer.ui.configs import Colors
+from fapolicy_analyzer.ui.rules.rules_list_view import RulesListView
 
 gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk  # isort: skip

--- a/fapolicy_analyzer/tests/rules/test_rules_text_view.py
+++ b/fapolicy_analyzer/tests/rules/test_rules_text_view.py
@@ -17,7 +17,7 @@ import context  # noqa: F401 # isort: skip
 
 import gi
 import pytest
-from ui.rules.rules_text_view import RulesTextView
+from fapolicy_analyzer.ui.rules.rules_text_view import RulesTextView
 
 gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk  # isort: skip

--- a/fapolicy_analyzer/tests/test_acl.py
+++ b/fapolicy_analyzer/tests/test_acl.py
@@ -14,16 +14,20 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import context  # noqa: F401 # isort: skip
-from util.acl import get_group_details, get_user_details
+from fapolicy_analyzer.util.acl import get_group_details, get_user_details
 
 
 def test_get_user_details(mocker):
-    mocker.patch("util.acl.subprocess.getstatusoutput", return_value=(0, "foo"))
+    mocker.patch(
+        "fapolicy_analyzer.util.acl.subprocess.getstatusoutput", return_value=(0, "foo")
+    )
     assert get_user_details(1) == "foo"
 
 
 def test_get_user_details_handles_error(mocker):
-    mocker.patch("util.acl.subprocess.getstatusoutput", return_value=(1, "foo"))
+    mocker.patch(
+        "fapolicy_analyzer.util.acl.subprocess.getstatusoutput", return_value=(1, "foo")
+    )
     assert get_user_details(1) == ""
 
 
@@ -33,7 +37,8 @@ def test_get_user_details_handles_none(mocker):
 
 def test_get_group_details(mocker):
     mocker.patch(
-        "util.acl.grp.getgrgid", return_value=("foo", "", 99, ["user1", "user2"])
+        "fapolicy_analyzer.util.acl.grp.getgrgid",
+        return_value=("foo", "", 99, ["user1", "user2"]),
     )
     assert get_group_details(1) == "name=foo gid=99 users=user1,user2"
 

--- a/fapolicy_analyzer/tests/test_acl_list.py
+++ b/fapolicy_analyzer/tests/test_acl_list.py
@@ -20,7 +20,7 @@ import context  # noqa: F401
 
 gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk
-from ui.acl_list import ACLList
+from fapolicy_analyzer.ui.acl_list import ACLList
 
 
 @pytest.fixture

--- a/fapolicy_analyzer/tests/test_action_toolbar.py
+++ b/fapolicy_analyzer/tests/test_action_toolbar.py
@@ -19,8 +19,8 @@ from unittest.mock import MagicMock
 
 import gi
 import pytest
-from fapolicy_analyzer.ui.action_toolbar import ActionToolbar
-from fapolicy_analyzer.ui.ui_page import UIAction
+from ui.action_toolbar import ActionToolbar
+from ui.ui_page import UIAction
 
 gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk  # isort: skip

--- a/fapolicy_analyzer/tests/test_action_toolbar.py
+++ b/fapolicy_analyzer/tests/test_action_toolbar.py
@@ -19,8 +19,8 @@ from unittest.mock import MagicMock
 
 import gi
 import pytest
-from ui.action_toolbar import ActionToolbar
-from ui.ui_page import UIAction
+from fapolicy_analyzer.ui.action_toolbar import ActionToolbar
+from fapolicy_analyzer.ui.ui_page import UIAction
 
 gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk  # isort: skip

--- a/fapolicy_analyzer/tests/test_actions.py
+++ b/fapolicy_analyzer/tests/test_actions.py
@@ -18,7 +18,7 @@ from unittest.mock import MagicMock
 
 import pytest
 from redux import Action
-from ui.actions import (
+from fapolicy_analyzer.ui.actions import (
     ADD_CHANGESETS,
     ADD_NOTIFICATION,
     ANCILLARY_TRUST_DEPLOYED,

--- a/fapolicy_analyzer/tests/test_add_file_button.py
+++ b/fapolicy_analyzer/tests/test_add_file_button.py
@@ -13,14 +13,16 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import context  # noqa: F401
-import pytest
 import gi
+import pytest
+
+import context  # noqa: F401
 
 gi.require_version("Gtk", "3.0")
-from gi.repository import Gtk
 from unittest.mock import MagicMock
-from ui.add_file_button import AddFileButton
+
+from fapolicy_analyzer.ui.add_file_button import AddFileButton
+from gi.repository import Gtk
 
 
 @pytest.fixture
@@ -34,14 +36,14 @@ def test_creates_widget(widget):
 
 def test_fires_files_added(widget, mocker):
     mocker.patch(
-        "ui.add_file_button.Gtk.FileChooserDialog.run",
+        "fapolicy_analyzer.ui.add_file_button.Gtk.FileChooserDialog.run",
         return_value=Gtk.ResponseType.OK,
     )
     mocker.patch(
-        "ui.add_file_button.Gtk.FileChooserDialog.get_filenames",
+        "fapolicy_analyzer.ui.add_file_button.Gtk.FileChooserDialog.get_filenames",
         return_value=["foo"],
     )
-    mocker.patch("ui.add_file_button.path.isfile", return_value=True)
+    mocker.patch("fapolicy_analyzer.ui.add_file_button.path.isfile", return_value=True)
     mockHandler = MagicMock()
     widget.files_added += mockHandler
     addBtn = widget.get_ref()
@@ -52,16 +54,16 @@ def test_fires_files_added(widget, mocker):
 
 def test_fires_files_w_spaces_added(widget, mocker):
     mocker.patch(
-        "ui.add_file_button.Gtk.FileChooserDialog.run",
+        "fapolicy_analyzer.ui.add_file_button.Gtk.FileChooserDialog.run",
         return_value=Gtk.ResponseType.OK,
     )
     mocker.patch(
-        "ui.add_file_button.Gtk.FileChooserDialog.get_filenames",
+        "fapolicy_analyzer.ui.add_file_button.Gtk.FileChooserDialog.get_filenames",
         return_value=["/tmp/a file name with spaces"],
     )
-    mocker.patch("ui.add_file_button.path.isfile", return_value=True)
+    mocker.patch("fapolicy_analyzer.ui.add_file_button.path.isfile", return_value=True)
     mocker.patch(
-        "ui.add_file_button.Gtk.MessageDialog.run",
+        "fapolicy_analyzer.ui.add_file_button.Gtk.MessageDialog.run",
         return_value=Gtk.ResponseType.OK,
     )
     mockHandler = MagicMock()

--- a/fapolicy_analyzer/tests/test_analyzer_selection_dialog.py
+++ b/fapolicy_analyzer/tests/test_analyzer_selection_dialog.py
@@ -20,7 +20,10 @@ import pytest
 gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk, Gdk
 from helpers import delayed_gui_action
-from ui.analyzer_selection_dialog import AnalyzerSelectionDialog, ANALYZER_SELECTION
+from fapolicy_analyzer.ui.analyzer_selection_dialog import (
+    AnalyzerSelectionDialog,
+    ANALYZER_SELECTION,
+)
 
 
 @pytest.fixture
@@ -55,14 +58,16 @@ def test_analyze_from_audit(widget):
 
 def test_set_audit_file_from_dialog(widget, mocker):
     mocker.patch(
-        "ui.analyzer_selection_dialog.Gtk.FileChooserDialog.run",
+        "fapolicy_analyzer.ui.analyzer_selection_dialog.Gtk.FileChooserDialog.run",
         return_value=Gtk.ResponseType.OK,
     )
     mocker.patch(
-        "ui.analyzer_selection_dialog.Gtk.FileChooserDialog.get_filename",
+        "fapolicy_analyzer.ui.analyzer_selection_dialog.Gtk.FileChooserDialog.get_filename",
         return_value="foo",
     )
-    mocker.patch("ui.analyzer_selection_dialog.path.isfile", return_value=True)
+    mocker.patch(
+        "fapolicy_analyzer.ui.analyzer_selection_dialog.path.isfile", return_value=True
+    )
     auditLogTxt = widget.get_object("auditLogTxt")
     auditLogTxt.emit("icon_press", Gtk.EntryIconPosition.SECONDARY, Gdk.Event())
     assert auditLogTxt.get_text() == "foo"

--- a/fapolicy_analyzer/tests/test_ancillary_trust_database_admin.py
+++ b/fapolicy_analyzer/tests/test_ancillary_trust_database_admin.py
@@ -23,21 +23,17 @@ from callee import InstanceOf
 from callee.attributes import Attrs
 from callee.collections import Sequence
 from fapolicy_analyzer import Changeset, Trust
+from fapolicy_analyzer.ui.actions import (ADD_NOTIFICATION, APPLY_CHANGESETS,
+                                          REQUEST_ANCILLARY_TRUST,
+                                          NotificationType)
+from fapolicy_analyzer.ui.ancillary_trust_database_admin import \
+    AncillaryTrustDatabaseAdmin
+from fapolicy_analyzer.ui.store import init_store
+from fapolicy_analyzer.ui.strings import (ANCILLARY_TRUST_LOAD_ERROR,
+                                          ANCILLARY_TRUSTED_FILE_MESSAGE,
+                                          ANCILLARY_UNKNOWN_FILE_MESSAGE)
 from redux import Action
 from rx.subject import Subject
-from ui.actions import (
-    ADD_NOTIFICATION,
-    APPLY_CHANGESETS,
-    REQUEST_ANCILLARY_TRUST,
-    NotificationType,
-)
-from ui.ancillary_trust_database_admin import AncillaryTrustDatabaseAdmin
-from ui.store import init_store
-from ui.strings import (
-    ANCILLARY_TRUST_LOAD_ERROR,
-    ANCILLARY_TRUSTED_FILE_MESSAGE,
-    ANCILLARY_UNKNOWN_FILE_MESSAGE,
-)
 
 from mocks import mock_System
 
@@ -47,12 +43,12 @@ from gi.repository import Gtk  # isort: skip
 
 @pytest.fixture()
 def mock_dispatch(mocker):
-    return mocker.patch("ui.ancillary_trust_database_admin.dispatch")
+    return mocker.patch("fapolicy_analyzer.ui.ancillary_trust_database_admin.dispatch")
 
 
 @pytest.fixture
 def widget(mock_dispatch, mocker):
-    mocker.patch("ui.ancillary_trust_database_admin.fs.sha", return_value="abc")
+    mocker.patch("fapolicy_analyzer.ui.ancillary_trust_database_admin.fs.sha", return_value="abc")
     init_store(mock_System())
     return AncillaryTrustDatabaseAdmin()
 
@@ -66,7 +62,7 @@ def test_updates_trust_details(widget, mocker):
     mocker.patch.object(widget.trustFileDetails, "set_on_file_system_view")
     mocker.patch.object(widget.trustFileDetails, "set_trust_status")
     mocker.patch(
-        "ui.ancillary_trust_database_admin.fs.stat", return_value="stat for foo file"
+        "fapolicy_analyzer.ui.ancillary_trust_database_admin.fs.stat", return_value="stat for foo file"
     )
     trust = [MagicMock(status="T", path="/tmp/foo", size=1, hash="abc", spec=Trust)]
     widget.on_trust_selection_changed(trust)
@@ -86,7 +82,7 @@ def test_updates_trust_details_for_deleted_files(widget, mocker):
     mocker.patch.object(widget.trustFileDetails, "set_on_file_system_view")
     mocker.patch.object(widget.trustFileDetails, "set_trust_status")
     mocker.patch(
-        "ui.ancillary_trust_database_admin.fs.stat", return_value="stat for foo file"
+        "fapolicy_analyzer.ui.ancillary_trust_database_admin.fs.stat", return_value="stat for foo file"
     )
     trust = [MagicMock(path="/tmp/foo")]
     widget.on_trust_selection_changed(trust)
@@ -135,7 +131,7 @@ def test_on_trustBtn_clicked(widget, mock_dispatch, mocker):
     mocker.patch.object(widget.trustFileDetails, "set_on_file_system_view")
     mocker.patch.object(widget.trustFileDetails, "set_trust_status")
     mocker.patch(
-        "ui.ancillary_trust_database_admin.fs.stat", return_value="stat for foo file"
+        "fapolicy_analyzer.ui.ancillary_trust_database_admin.fs.stat", return_value="stat for foo file"
     )
 
     temp = tempfile.NamedTemporaryFile()
@@ -172,7 +168,7 @@ def test_on_untrustBtn_clicked(widget, mock_dispatch, mocker):
     mocker.patch.object(widget.trustFileDetails, "set_on_file_system_view")
     mocker.patch.object(widget.trustFileDetails, "set_trust_status")
     mocker.patch(
-        "ui.ancillary_trust_database_admin.fs.stat", return_value="stat for foo file"
+        "fapolicy_analyzer.ui.ancillary_trust_database_admin.fs.stat", return_value="stat for foo file"
     )
 
     mockDialog = MagicMock(
@@ -181,7 +177,7 @@ def test_on_untrustBtn_clicked(widget, mock_dispatch, mocker):
         )
     )
     mocker.patch(
-        "ui.ancillary_trust_database_admin.RemoveDeletedDialog", return_value=mockDialog
+        "fapolicy_analyzer.ui.ancillary_trust_database_admin.RemoveDeletedDialog", return_value=mockDialog
     )
     temp = tempfile.NamedTemporaryFile()
 
@@ -246,7 +242,7 @@ def test_on_file_deleted_empty(widget, mock_dispatch):
 def test_reloads_trust_w_changeset_change(mock_dispatch, mocker):
     mockSystemFeature = Subject()
     mocker.patch(
-        "ui.ancillary_trust_database_admin.get_system_feature",
+        "fapolicy_analyzer.ui.ancillary_trust_database_admin.get_system_feature",
         return_value=mockSystemFeature,
     )
     mockSystemFeature.on_next({"changesets": []})
@@ -270,7 +266,7 @@ def test_load_trust(mocker):
     mockChangeset = MagicMock(spec=Changeset)
     mockSystemFeature = Subject()
     mocker.patch(
-        "ui.ancillary_trust_database_admin.get_system_feature",
+        "fapolicy_analyzer.ui.ancillary_trust_database_admin.get_system_feature",
         return_value=mockSystemFeature,
     )
     init_store(mock_System())
@@ -295,7 +291,7 @@ def test_load_trust(mocker):
 def test_load_trust_w_exception(mock_dispatch, mocker):
     mockSystemFeature = Subject()
     mocker.patch(
-        "ui.ancillary_trust_database_admin.get_system_feature",
+        "fapolicy_analyzer.ui.ancillary_trust_database_admin.get_system_feature",
         return_value=mockSystemFeature,
     )
     mockSystemFeature.on_next({"changesets": []})

--- a/fapolicy_analyzer/tests/test_ancillary_trust_file_list.py
+++ b/fapolicy_analyzer/tests/test_ancillary_trust_file_list.py
@@ -22,9 +22,9 @@ gi.require_version("Gtk", "3.0")
 from unittest.mock import MagicMock
 
 from gi.repository import Gtk
-from ui.ancillary_trust_file_list import AncillaryTrustFileList
-from ui.configs import Colors
-from ui.strings import (
+from fapolicy_analyzer.ui.ancillary_trust_file_list import AncillaryTrustFileList
+from fapolicy_analyzer.ui.configs import Colors
+from fapolicy_analyzer.ui.strings import (
     CHANGESET_ACTION_ADD,
     CHANGESET_ACTION_DEL,
     FILE_LIST_CHANGES_HEADER,

--- a/fapolicy_analyzer/tests/test_confirm_change_dialog.py
+++ b/fapolicy_analyzer/tests/test_confirm_change_dialog.py
@@ -22,7 +22,7 @@ from locale import gettext as _
 
 from fapolicy_analyzer.util.format import f
 from gi.repository import Gtk
-from ui.confirm_change_dialog import ConfirmChangeDialog
+from fapolicy_analyzer.ui.confirm_change_dialog import ConfirmChangeDialog
 
 
 def _get_dialog_message(dialog):

--- a/fapolicy_analyzer/tests/test_confirm_info_dialog.py
+++ b/fapolicy_analyzer/tests/test_confirm_info_dialog.py
@@ -19,8 +19,8 @@ import gi
 gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk
 from helpers import delayed_gui_action
-from ui.confirm_info_dialog import ConfirmInfoDialog
-from ui.strings import CHANGESET_ACTION_ADD, CHANGESET_ACTION_DEL
+from fapolicy_analyzer.ui.confirm_info_dialog import ConfirmInfoDialog
+from fapolicy_analyzer.ui.strings import CHANGESET_ACTION_ADD, CHANGESET_ACTION_DEL
 
 
 def test_creates_widget():
@@ -36,7 +36,7 @@ def test_adds_dialog_to_parent():
 
 def test_dialog_actions_responses(mocker):
     mocker.patch(
-        "ui.ancillary_trust_file_list.epoch_to_string",
+        "fapolicy_analyzer.ui.ancillary_trust_file_list.epoch_to_string",
         return_value="10-01-2020",
     )
 

--- a/fapolicy_analyzer/tests/test_database_admin_page.py
+++ b/fapolicy_analyzer/tests/test_database_admin_page.py
@@ -20,25 +20,25 @@ import pytest
 gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk
 from mocks import mock_System
-from ui.database_admin_page import DatabaseAdminPage
-from ui.store import init_store
+from fapolicy_analyzer.ui.database_admin_page import DatabaseAdminPage
+from fapolicy_analyzer.ui.store import init_store
 
 
 @pytest.fixture
 def widget(mocker):
     mocker.patch(
-        "ui.database_admin_page.AncillaryTrustDatabaseAdmin.get_ref",
+        "fapolicy_analyzer.ui.database_admin_page.AncillaryTrustDatabaseAdmin.get_ref",
         return_value=Gtk.Box(),
     )
     mocker.patch(
-        "ui.database_admin_page.AncillaryTrustDatabaseAdmin._AncillaryTrustDatabaseAdmin__load_trust"
+        "fapolicy_analyzer.ui.database_admin_page.AncillaryTrustDatabaseAdmin._AncillaryTrustDatabaseAdmin__load_trust"
     )
     mocker.patch(
-        "ui.database_admin_page.SystemTrustDatabaseAdmin.get_ref",
+        "fapolicy_analyzer.ui.database_admin_page.SystemTrustDatabaseAdmin.get_ref",
         return_value=Gtk.Box(),
     )
     mocker.patch(
-        "ui.database_admin_page.SystemTrustDatabaseAdmin._SystemTrustDatabaseAdmin__load_trust"
+        "fapolicy_analyzer.ui.database_admin_page.SystemTrustDatabaseAdmin._SystemTrustDatabaseAdmin__load_trust"
     )
     init_store(mock_System())
     return DatabaseAdminPage()

--- a/fapolicy_analyzer/tests/test_deploy_confirm_dialog.py
+++ b/fapolicy_analyzer/tests/test_deploy_confirm_dialog.py
@@ -18,7 +18,7 @@ import gi
 
 gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk
-from ui.deploy_confirm_dialog import DeployConfirmDialog
+from fapolicy_analyzer.ui.deploy_confirm_dialog import DeployConfirmDialog
 
 
 def test_creates_widget():
@@ -34,12 +34,12 @@ def test_adds_dialog_to_parent():
 
 def test_closes_after_cancel_time(mocker):
     mocker.patch(
-        "ui.trust_file_list.epoch_to_string",
+        "fapolicy_analyzer.ui.trust_file_list.epoch_to_string",
         return_value="10-01-2020",
     )
 
     mocker.patch(
-        "ui.ancillary_trust_file_list.epoch_to_string",
+        "fapolicy_analyzer.ui.ancillary_trust_file_list.epoch_to_string",
         return_value="10-01-2020",
     )
 

--- a/fapolicy_analyzer/tests/test_fapd_manager.py
+++ b/fapolicy_analyzer/tests/test_fapd_manager.py
@@ -15,7 +15,7 @@
 
 import pytest
 from unittest.mock import MagicMock
-from ui.fapd_manager import FapdManager, FapdMode, ServiceStatus
+from fapolicy_analyzer.ui.fapd_manager import FapdManager, FapdMode, ServiceStatus
 
 
 @pytest.fixture
@@ -82,7 +82,9 @@ def test_start_profiling(fapdManager, mocker):
     fapdManager._fapd_status = ServiceStatus.TRUE
     fapdManager._fapd_ref.is_active.return_value = True
     mockProcess = MagicMock()
-    mocker.patch("fapolicy_analyzer.ui.fapd_manager.subprocess.Popen", return_value=mockProcess)
+    mocker.patch(
+        "fapolicy_analyzer.ui.fapd_manager.subprocess.Popen", return_value=mockProcess
+    )
     fapdManager.mode = FapdMode.ONLINE
     fapdManager.start(FapdMode.PROFILING)
     mockFapdHandle.stop.assert_called()

--- a/fapolicy_analyzer/tests/test_faprofiler.py
+++ b/fapolicy_analyzer/tests/test_faprofiler.py
@@ -16,17 +16,18 @@
 import pytest
 import os
 from unittest.mock import MagicMock
-from ui.faprofiler import FaProfiler, FaProfSession, ProfSessionStatus
+from fapolicy_analyzer.ui.faprofiler import FaProfiler, FaProfSession, ProfSessionStatus
 
 
 @pytest.fixture
 def faProfSession():
-    dictArgs = {"executeText": "/usr/bin/ls",
-                "argText": "-ltr /tmp",
-                "userText": os.getenv("USER"),
-                "dirText": os.getenv("HOME"),
-                "envText": 'FAPD_LOGPATH=/tmp/tgt_profiler, XX="xx"',
-                }
+    dictArgs = {
+        "executeText": "/usr/bin/ls",
+        "argText": "-ltr /tmp",
+        "userText": os.getenv("USER"),
+        "dirText": os.getenv("HOME"),
+        "envText": 'FAPD_LOGPATH=/tmp/tgt_profiler, XX="xx"',
+    }
     return FaProfSession(dictArgs)
 
 
@@ -43,8 +44,9 @@ def test_faprofsession_init(faProfSession, mocker):
 
 def test_startTarget(faProfSession, mocker):
     mockPopen = MagicMock()
-    mocker.patch("ui.faprofiler.subprocess.Popen",
-                 return_value=mockPopen)
+    mocker.patch(
+        "fapolicy_analyzer.ui.faprofiler.subprocess.Popen", return_value=mockPopen
+    )
     mockPopen.returncode = 0
     assert not faProfSession.procTarget
     faProfSession.startTarget(0)
@@ -56,13 +58,15 @@ def test_startTarget(faProfSession, mocker):
     assert faProfSession.procTarget.returncode == 0
 
     # Emulate a file open() exception
-    mocker.patch("ui.faprofiler.open", side_effect=Exception())
+    mocker.patch("fapolicy_analyzer.ui.faprofiler.open", side_effect=Exception())
     faProfSession.startTarget(1)
     assert faProfSession.fdTgtStdout is None
     assert faProfSession.fdTgtStderr is None
 
     # Emulate a getpwnam() exception
-    mocker.patch("ui.faprofiler.pwd.getpwnam", side_effect=Exception())
+    mocker.patch(
+        "fapolicy_analyzer.ui.faprofiler.pwd.getpwnam", side_effect=Exception()
+    )
     faProfSession.startTarget(1)
     assert faProfSession.fdTgtStdout is None
     assert faProfSession.fdTgtStderr is None
@@ -96,12 +100,13 @@ def test_get_status(faProfSession, mocker):
 # Testing FaProfiler
 def test_start_prof_session(faProfiler, mocker):
     faProfiler.fapd_mgr = MagicMock()
-    dictArgs = {"executeText": "/usr/bin/ls",
-                "argText": "-ltr /tmp",
-                "userText": os.getenv("USER"),
-                "dirText": os.getenv("HOME"),
-                "envText": "FAPD_LOGPATH=/tmp/tgt_profiler,XYZ=123",
-                }
+    dictArgs = {
+        "executeText": "/usr/bin/ls",
+        "argText": "-ltr /tmp",
+        "userText": os.getenv("USER"),
+        "dirText": os.getenv("HOME"),
+        "envText": "FAPD_LOGPATH=/tmp/tgt_profiler,XYZ=123",
+    }
 
     key = faProfiler.start_prof_session(dictArgs)
     assert faProfiler.instance != 0
@@ -110,12 +115,13 @@ def test_start_prof_session(faProfiler, mocker):
 
 def test_stop_prof_session(faProfiler, mocker):
     faProfiler.fapd_mgr = MagicMock()
-    dictArgs = {"executeText": "/usr/bin/ls",
-                "argText": "-ltr /tmp",
-                "userText": os.getenv("USER"),
-                "dirText": os.getenv("HOME"),
-                "envText": "FAPD_LOGPATH=/tmp/tgt_profiler,XYZ=123",
-                }
+    dictArgs = {
+        "executeText": "/usr/bin/ls",
+        "argText": "-ltr /tmp",
+        "userText": os.getenv("USER"),
+        "dirText": os.getenv("HOME"),
+        "envText": "FAPD_LOGPATH=/tmp/tgt_profiler,XYZ=123",
+    }
 
     session_name = faProfiler.start_prof_session(dictArgs)
     assert faProfiler.instance != 0

--- a/fapolicy_analyzer/tests/test_format.py
+++ b/fapolicy_analyzer/tests/test_format.py
@@ -13,8 +13,9 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+from fapolicy_analyzer.util.format import f, snake_to_camelcase
+
 import context  # noqa: F401
-from util.format import snake_to_camelcase, f
 
 
 def test_snake_to_camelcase():

--- a/fapolicy_analyzer/tests/test_main.py
+++ b/fapolicy_analyzer/tests/test_main.py
@@ -13,16 +13,18 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import context  # noqa: F401
 import logging
 import os
-import sys
 import shutil
-import pytest
+import sys
 from unittest.mock import patch
-from ui.session_manager import sessionManager
-from ui.__main__ import main
-from util.xdg_utils import xdg_state_dir_prefix
+
+import pytest
+from fapolicy_analyzer.ui.__main__ import main
+from fapolicy_analyzer.ui.session_manager import sessionManager
+from fapolicy_analyzer.util.xdg_utils import xdg_state_dir_prefix
+
+import context  # noqa: F401
 
 
 @pytest.fixture
@@ -38,9 +40,9 @@ def session():
 
 @pytest.fixture
 def mocks(mocker):
-    mocker.patch("ui.__main__.SplashScreen")
-    mocker.patch("ui.__main__.Gtk")
-    mocker.patch("ui.__main__.init_store")
+    mocker.patch("fapolicy_analyzer.ui.__main__.SplashScreen")
+    mocker.patch("fapolicy_analyzer.ui.__main__.Gtk")
+    mocker.patch("fapolicy_analyzer.ui.__main__.init_store")
 
 
 @pytest.mark.usefixtures("mocks", "session")
@@ -124,9 +126,9 @@ def test_main_no_options(mocker):
     expectTmpPath = xdg_state_home + "/fapolicy-analyzer/FaCurrentSession.tmp"
 
     with patch.object(sys, "argv", testargs):
-        mockSplash = mocker.patch("ui.__main__.SplashScreen")
-        mockGtk = mocker.patch("ui.__main__.Gtk")
-        mockStore = mocker.patch("ui.__main__.init_store")
+        mockSplash = mocker.patch("fapolicy_analyzer.ui.__main__.SplashScreen")
+        mockGtk = mocker.patch("fapolicy_analyzer.ui.__main__.Gtk")
+        mockStore = mocker.patch("fapolicy_analyzer.ui.__main__.init_store")
         main()
 
         assert logging.getLogger().level == logging.WARNING
@@ -147,9 +149,9 @@ def test_main_all_options(mocker):
     testargs = ["prog", "-v", "-a", "-s", "/tmp/TmpFileTemplate.tmp", "-c", "3"]
 
     with patch.object(sys, "argv", testargs):
-        mockSplash = mocker.patch("ui.__main__.SplashScreen")
-        mockGtk = mocker.patch("ui.__main__.Gtk")
-        mockStore = mocker.patch("ui.__main__.init_store")
+        mockSplash = mocker.patch("fapolicy_analyzer.ui.__main__.SplashScreen")
+        mockGtk = mocker.patch("fapolicy_analyzer.ui.__main__.Gtk")
+        mockStore = mocker.patch("fapolicy_analyzer.ui.__main__.init_store")
         main()
 
         assert logging.getLogger().level == logging.DEBUG

--- a/fapolicy_analyzer/tests/test_main_window.py
+++ b/fapolicy_analyzer/tests/test_main_window.py
@@ -208,6 +208,7 @@ def test_bad_router_option():
         assert excinfo.value.message == "Bad Selection"
 
 
+@pytest.mark.skip(reason="Not currently working in GitHub CI")
 @pytest.mark.usefixtures("es_locale", "mock_init_store", "mock_dispatches")
 def test_localization():
     mainWindow = MainWindow()

--- a/fapolicy_analyzer/tests/test_main_window.py
+++ b/fapolicy_analyzer/tests/test_main_window.py
@@ -25,16 +25,16 @@ from unittest.mock import MagicMock
 
 from callee import Attrs, InstanceOf
 from fapolicy_analyzer import Changeset
+from fapolicy_analyzer.ui.actions import ADD_NOTIFICATION
+from fapolicy_analyzer.ui.fapd_manager import ServiceStatus
+from fapolicy_analyzer.ui.main_window import MainWindow, router
+from fapolicy_analyzer.ui.session_manager import NotificationType, sessionManager
+from fapolicy_analyzer.ui.store import init_store
+from fapolicy_analyzer.ui.strings import AUTOSAVE_RESTORE_ERROR_MSG
 from gi.repository import Gtk
 from redux import Action
 from rx import create
 from rx.subject import Subject
-from ui.actions import ADD_NOTIFICATION
-from ui.fapd_manager import ServiceStatus
-from ui.main_window import MainWindow, router
-from ui.session_manager import NotificationType, sessionManager
-from ui.store import init_store
-from ui.strings import AUTOSAVE_RESTORE_ERROR_MSG
 
 from helpers import refresh_gui
 from mocks import mock_System
@@ -45,7 +45,7 @@ test_changeset.add_trust("/tmp/DeadBeef.txt")
 
 @pytest.fixture()
 def mock_dispatch(mocker):
-    return mocker.patch("ui.main_window.dispatch")
+    return mocker.patch("fapolicy_analyzer.ui.main_window.dispatch")
 
 
 @pytest.fixture
@@ -60,15 +60,18 @@ def mock_system_features(changesets, mocker):
         observer.on_completed()
 
     system_features_mock = create(push_changeset)
-    mocker.patch("ui.main_window.get_system_feature", return_value=system_features_mock)
+    mocker.patch(
+        "fapolicy_analyzer.ui.main_window.get_system_feature",
+        return_value=system_features_mock,
+    )
 
 
 @pytest.fixture
 def mock_dispatches(mocker):
-    mocker.patch("ui.ancillary_trust_database_admin.dispatch")
-    mocker.patch("ui.system_trust_database_admin.dispatch")
-    mocker.patch("ui.policy_rules_admin_page.dispatch")
-    mocker.patch("ui.rules.rules_admin_page.dispatch")
+    mocker.patch("fapolicy_analyzer.ui.ancillary_trust_database_admin.dispatch")
+    mocker.patch("fapolicy_analyzer.ui.system_trust_database_admin.dispatch")
+    mocker.patch("fapolicy_analyzer.ui.policy_rules_admin_page.dispatch")
+    mocker.patch("fapolicy_analyzer.ui.rules.rules_admin_page.dispatch")
 
 
 @pytest.fixture
@@ -96,7 +99,7 @@ def test_shows_confirm_if_unapplied_changes(mainWindow, mocker):
     mockDialog = MagicMock()
     mockDialog.run.return_value = False
     mocker.patch(
-        "ui.main_window.UnappliedChangesDialog.get_ref",
+        "fapolicy_analyzer.ui.main_window.UnappliedChangesDialog.get_ref",
         return_value=mockDialog,
     )
     mainWindow.get_object("quitMenu").activate()
@@ -107,7 +110,7 @@ def test_does_not_show_confirm_if_no_unapplied_changes(mainWindow, mocker):
     mockDialog = MagicMock()
     mockDialog.run.return_value = False
     mocker.patch(
-        "ui.main_window.UnappliedChangesDialog.get_ref",
+        "fapolicy_analyzer.ui.main_window.UnappliedChangesDialog.get_ref",
         return_value=mockDialog,
     )
     mainWindow.get_object("quitMenu").activate()
@@ -145,24 +148,24 @@ def test_opens_analyze_with_audit_page(mainWindow, mocker):
     menuItem = mainWindow.get_object("analyzeMenu")
 
     mocker.patch(
-        "ui.trust_file_list.epoch_to_string",
+        "fapolicy_analyzer.ui.trust_file_list.epoch_to_string",
         return_value="10-01-2020",
     )
 
     mocker.patch(
-        "ui.ancillary_trust_file_list.epoch_to_string",
+        "fapolicy_analyzer.ui.ancillary_trust_file_list.epoch_to_string",
         return_value="10-01-2020",
     )
 
     mocker.patch(
-        "ui.main_window.Gtk.FileChooserDialog.run",
+        "fapolicy_analyzer.ui.main_window.Gtk.FileChooserDialog.run",
         return_value=Gtk.ResponseType.OK,
     )
     mocker.patch(
-        "ui.main_window.Gtk.FileChooserDialog.get_filename",
+        "fapolicy_analyzer.ui.main_window.Gtk.FileChooserDialog.get_filename",
         return_value="foo",
     )
-    mocker.patch("ui.main_window.path.isfile", return_value=True)
+    mocker.patch("fapolicy_analyzer.ui.main_window.path.isfile", return_value=True)
     menuItem.activate()
     refresh_gui()
     content = next(iter(mainWindow.get_object("mainContent").get_children()))
@@ -219,13 +222,16 @@ def test_on_openMenu_activate(mainWindow, mocker):
     mockDialog.run.return_value = Gtk.ResponseType.OK
     mockDialog.get_filename.return_value = "/tmp/open_tmp.json"
     mocker.patch(
-        "ui.main_window.Gtk.FileChooserDialog",
+        "fapolicy_analyzer.ui.main_window.Gtk.FileChooserDialog",
         return_value=mockDialog,
     )
 
-    mocker.patch("ui.main_window.sessionManager.open_edit_session", return_value=True)
+    mocker.patch(
+        "fapolicy_analyzer.ui.main_window.sessionManager.open_edit_session",
+        return_value=True,
+    )
 
-    mocker.patch("ui.main_window.path.isfile", return_value=True)
+    mocker.patch("fapolicy_analyzer.ui.main_window.path.isfile", return_value=True)
     mainWindow.get_object("openMenu").activate()
     sessionManager.open_edit_session.assert_called_with("/tmp/open_tmp.json")
 
@@ -236,13 +242,16 @@ def test_on_openMenu_activate_fail(mainWindow, mock_dispatch, mocker):
     mockDialog.run.return_value = Gtk.ResponseType.OK
     mockDialog.get_filename.return_value = fakeFile
     mocker.patch(
-        "ui.main_window.Gtk.FileChooserDialog",
+        "fapolicy_analyzer.ui.main_window.Gtk.FileChooserDialog",
         return_value=mockDialog,
     )
 
-    mocker.patch("ui.main_window.sessionManager.open_edit_session", return_value=False)
+    mocker.patch(
+        "fapolicy_analyzer.ui.main_window.sessionManager.open_edit_session",
+        return_value=False,
+    )
 
-    mocker.patch("ui.main_window.path.isfile", return_value=True)
+    mocker.patch("fapolicy_analyzer.ui.main_window.path.isfile", return_value=True)
     mainWindow.get_object("openMenu").activate()
     mock_dispatch.assert_called_with(
         InstanceOf(Action)
@@ -259,7 +268,8 @@ def test_on_openMenu_activate_fail(mainWindow, mock_dispatch, mocker):
 def test_on_restoreMenu_activate(mainWindow, mocker):
     mocker.patch("glob.glob", return_value=["foo"])
     mock = mocker.patch(
-        "ui.main_window.sessionManager.open_edit_session", return_value=True
+        "fapolicy_analyzer.ui.main_window.sessionManager.open_edit_session",
+        return_value=True,
     )
     mainWindow.get_object("restoreMenu").activate()
     mock.assert_called_with("foo")
@@ -272,7 +282,8 @@ def test_on_restoreMenu_activate_w_exception(mainWindow, mocker):
     exception thrown.
     """
     mockRestoreAutosave = mocker.patch(
-        "ui.main_window.sessionManager.restore_previous_session", side_effect=IOError
+        "fapolicy_analyzer.ui.main_window.sessionManager.restore_previous_session",
+        side_effect=IOError,
     )
 
     mainWindow.get_object("restoreMenu").activate()
@@ -285,11 +296,12 @@ def test_on_saveAsMenu_activate(mainWindow, mocker):
     mockDialog.run.return_value = Gtk.ResponseType.OK
     mockDialog.get_filename.return_value = "/tmp/save_as_tmp.json"
     mocker.patch(
-        "ui.main_window.Gtk.FileChooserDialog",
+        "fapolicy_analyzer.ui.main_window.Gtk.FileChooserDialog",
         return_value=mockDialog,
     )
     mockFunc = mocker.patch(
-        "ui.main_window.sessionManager.save_edit_session", return_value=True
+        "fapolicy_analyzer.ui.main_window.sessionManager.save_edit_session",
+        return_value=True,
     )
 
     mainWindow.get_object("saveAsMenu").activate()
@@ -299,9 +311,13 @@ def test_on_saveAsMenu_activate(mainWindow, mocker):
 def test_on_saveMenu_activate(mainWindow, mocker):
     # Mock the on_saveAsMenu_activate() call
     mockFunc = mocker.patch(
-        "ui.main_window.MainWindow.on_saveAsMenu_activate", return_value=True
+        "fapolicy_analyzer.ui.main_window.MainWindow.on_saveAsMenu_activate",
+        return_value=True,
     )
-    mocker.patch("ui.main_window.sessionManager.save_edit_session", return_value=True)
+    mocker.patch(
+        "fapolicy_analyzer.ui.main_window.sessionManager.save_edit_session",
+        return_value=True,
+    )
 
     window = mainWindow
     window.get_object("saveMenu").activate()
@@ -310,7 +326,10 @@ def test_on_saveMenu_activate(mainWindow, mocker):
 
 def test_on_saveMenu_activate_w_set_filename(mainWindow, mocker):
     mainWindow.strSessionFilename = "/tmp/save_w_filename_tmp.json"
-    mocker.patch("ui.main_window.sessionManager.save_edit_session", return_value=True)
+    mocker.patch(
+        "fapolicy_analyzer.ui.main_window.sessionManager.save_edit_session",
+        return_value=True,
+    )
 
     mainWindow.get_object("saveMenu").activate()
     sessionManager.save_edit_session.assert_called_with(
@@ -321,7 +340,8 @@ def test_on_saveMenu_activate_w_set_filename(mainWindow, mocker):
 @pytest.mark.usefixtures("mock_init_store", "mock_dispatches")
 def test_on_start(mocker):
     mockDetectAutosave = mocker.patch(
-        "ui.main_window.sessionManager.detect_previous_session", return_value=False
+        "fapolicy_analyzer.ui.main_window.sessionManager.detect_previous_session",
+        return_value=False,
     )
     MainWindow()
     mockDetectAutosave.assert_called()
@@ -341,7 +361,8 @@ def test_on_start_w_declined_restore(mocker):
     """
 
     mockDetectAutosave = mocker.patch(
-        "ui.main_window.sessionManager.detect_previous_session", return_value=True
+        "fapolicy_analyzer.ui.main_window.sessionManager.detect_previous_session",
+        return_value=True,
     )
 
     mockGtkDialog = mocker.patch(
@@ -367,11 +388,13 @@ def test_on_start_w_accepted_restore(mocker):
     """
 
     mockDetectAutosave = mocker.patch(
-        "ui.main_window.sessionManager.detect_previous_session", return_value=True
+        "fapolicy_analyzer.ui.main_window.sessionManager.detect_previous_session",
+        return_value=True,
     )
 
     mockRestoreAutosave = mocker.patch(
-        "ui.main_window.sessionManager.restore_previous_session", return_value=True
+        "fapolicy_analyzer.ui.main_window.sessionManager.restore_previous_session",
+        return_value=True,
     )
 
     mockGtkDialog = mocker.patch(
@@ -398,11 +421,13 @@ def test_on_start_w_restore_exception(mocker):
     """
 
     mockDetectAutosave = mocker.patch(
-        "ui.main_window.sessionManager.detect_previous_session", return_value=True
+        "fapolicy_analyzer.ui.main_window.sessionManager.detect_previous_session",
+        return_value=True,
     )
 
     mockRestoreAutosave = mocker.patch(
-        "ui.main_window.sessionManager.restore_previous_session", side_effect=IOError
+        "fapolicy_analyzer.ui.main_window.sessionManager.restore_previous_session",
+        side_effect=IOError,
     )
 
     mockGtkDialog = mocker.patch(
@@ -418,10 +443,12 @@ def test_on_start_w_restore_exception(mocker):
 @pytest.mark.usefixtures("mock_init_store", "mock_dispatches")
 def test_on_start_w_failed_restore(mock_dispatch, mocker):
     mocker.patch(
-        "ui.main_window.sessionManager.detect_previous_session", return_value=True
+        "fapolicy_analyzer.ui.main_window.sessionManager.detect_previous_session",
+        return_value=True,
     )
     mocker.patch(
-        "ui.main_window.sessionManager.restore_previous_session", return_value=False
+        "fapolicy_analyzer.ui.main_window.sessionManager.restore_previous_session",
+        return_value=False,
     )
     mocker.patch("gi.repository.Gtk.Dialog.run", return_value=Gtk.ResponseType.YES)
 
@@ -439,8 +466,10 @@ def test_on_start_w_failed_restore(mock_dispatch, mocker):
 
 
 def test_toolbar_deploy_operation(mainWindow, mocker):
-    mocker.patch("ui.operations.deploy_changesets_op.get_system_feature")
-    mockDeploy = mocker.patch("ui.main_window.DeployChangesetsOp.run")
+    mocker.patch(
+        "fapolicy_analyzer.ui.operations.deploy_changesets_op.get_system_feature"
+    )
+    mockDeploy = mocker.patch("fapolicy_analyzer.ui.main_window.DeployChangesetsOp.run")
     tool_bar = MainWindow().get_object("appArea").get_children()[1]
     deploy_btn = tool_bar.get_nth_item(0)
     deploy_btn.get_child().clicked()
@@ -450,7 +479,7 @@ def test_toolbar_deploy_operation(mainWindow, mocker):
 def test_toggles_deploy_changes_toolbar_btn(mocker):
     system_features_mock = Subject()
     mocker.patch(
-        "ui.main_window.get_system_feature",
+        "fapolicy_analyzer.ui.main_window.get_system_feature",
         return_value=system_features_mock,
     )
     init_store(mock_System())
@@ -466,7 +495,7 @@ def test_toggles_deploy_changes_toolbar_btn(mocker):
 def test_toggles_dirty_title(mocker):
     system_features_mock = Subject()
     mocker.patch(
-        "ui.main_window.get_system_feature",
+        "fapolicy_analyzer.ui.main_window.get_system_feature",
         return_value=system_features_mock,
     )
     init_store(mock_System())
@@ -512,7 +541,7 @@ def test_on_update_daemon_status(mainWindow, mocker):
 def test_start_daemon_monitor(mainWindow, mocker):
     mockThread = MagicMock()
     mocker.patch(
-        "ui.main_window.Thread",
+        "fapolicy_analyzer.ui.main_window.Thread",
         return_value=mockThread,
     )
     mainWindow._fapd_status = False

--- a/fapolicy_analyzer/tests/test_main_window.py
+++ b/fapolicy_analyzer/tests/test_main_window.py
@@ -85,10 +85,11 @@ def mainWindow(mock_init_store, mock_dispatches):
 def es_locale():
     original = os.environ.get("LANGUAGE", "en")
     os.environ["LANGUAGE"] = "es"
+    locale.setlocale(locale.LC_ALL, "es_ES.UTF-8")
     reload(fapolicy_analyzer.ui)
-    print(locale.getlocale())
     yield
     os.environ["LANGUAGE"] = original
+    locale.setlocale(locale.LC_ALL, "")
     reload(fapolicy_analyzer.ui)
 
 

--- a/fapolicy_analyzer/tests/test_main_window.py
+++ b/fapolicy_analyzer/tests/test_main_window.py
@@ -13,16 +13,15 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+import context  # noqa: F401 # isort: skip
 import locale
-
-import gi
-import pytest
-
-import context  # noqa: F401
-
-gi.require_version("Gtk", "3.0")
+import os
+from importlib import reload
 from unittest.mock import MagicMock
 
+import fapolicy_analyzer.ui
+import gi
+import pytest
 from callee import Attrs, InstanceOf
 from fapolicy_analyzer import Changeset
 from fapolicy_analyzer.ui.actions import ADD_NOTIFICATION
@@ -31,13 +30,15 @@ from fapolicy_analyzer.ui.main_window import MainWindow, router
 from fapolicy_analyzer.ui.session_manager import NotificationType, sessionManager
 from fapolicy_analyzer.ui.store import init_store
 from fapolicy_analyzer.ui.strings import AUTOSAVE_RESTORE_ERROR_MSG
-from gi.repository import Gtk
 from redux import Action
 from rx import create
 from rx.subject import Subject
 
 from helpers import refresh_gui
 from mocks import mock_System
+
+gi.require_version("GtkSource", "3.0")
+from gi.repository import Gtk  # isort: skip
 
 test_changeset = Changeset()
 test_changeset.add_trust("/tmp/DeadBeef.txt")
@@ -82,9 +83,13 @@ def mainWindow(mock_init_store, mock_dispatches):
 
 @pytest.fixture
 def es_locale():
-    locale.setlocale(locale.LC_ALL, "es_ES.UTF-8")
+    original = os.environ.get("LANGUAGE", "en")
+    os.environ["LANGUAGE"] = "es"
+    reload(fapolicy_analyzer.ui)
+    print(locale.getlocale())
     yield
-    locale.setlocale(locale.LC_ALL, "")
+    os.environ["LANGUAGE"] = original
+    reload(fapolicy_analyzer.ui)
 
 
 def test_displays_window(mainWindow):

--- a/fapolicy_analyzer/tests/test_main_window.py
+++ b/fapolicy_analyzer/tests/test_main_window.py
@@ -178,7 +178,7 @@ def test_opens_analyze_with_syslog_page(mainWindow):
 
 
 def test_opens_rules_admin_page(mainWindow, mocker):
-    mocker.patch("ui.rules.rules_admin_page.get_system_feature")
+    mocker.patch("fapolicy_analyzer.ui.rules.rules_admin_page.get_system_feature")
     menuItem = mainWindow.get_object("rulesAdminMenu")
     menuItem.activate()
     refresh_gui()
@@ -187,7 +187,7 @@ def test_opens_rules_admin_page(mainWindow, mocker):
 
 
 def test_open_rules_admin_with_args(mainWindow, mocker):
-    mocker.patch("ui.rules.rules_admin_page.get_system_feature")
+    mocker.patch("fapolicy_analyzer.ui.rules.rules_admin_page.get_system_feature")
     mainWindow.on_rulesAdminMenu_activate(rule_id=0)
     content = next(iter(mainWindow.get_object("mainContent").get_children()))
     assert Gtk.Buildable.get_name(content) == "rulesAdminPage"
@@ -498,7 +498,7 @@ def test_on_fapdStopMenu_activate(mainWindow, mocker):
 def test_enable_fapd_menu_items(mainWindow, mocker):
     mainWindow._fapdControlPermitted = True
     mainWindow._enable_fapd_menu_items(ServiceStatus.TRUE)
-    assert(not mainWindow._fapdStartMenuItem.get_sensitive())
+    assert not mainWindow._fapdStartMenuItem.get_sensitive()
 
 
 def test_on_update_daemon_status(mainWindow, mocker):

--- a/fapolicy_analyzer/tests/test_notification.py
+++ b/fapolicy_analyzer/tests/test_notification.py
@@ -23,21 +23,25 @@ from callee import InstanceOf, Attrs
 from redux import Action
 from rx.subject import Subject
 from time import sleep
-from ui.actions import Notification as Note, NotificationType, REMOVE_NOTIFICATION
-from ui.notification import Notification
-from ui.session_manager import sessionManager
+from fapolicy_analyzer.ui.actions import (
+    Notification as Note,
+    NotificationType,
+    REMOVE_NOTIFICATION,
+)
+from fapolicy_analyzer.ui.notification import Notification
+from fapolicy_analyzer.ui.session_manager import sessionManager
 
 
 @pytest.fixture()
 def mock_dispatch(mocker):
-    return mocker.patch("ui.notification.dispatch")
+    return mocker.patch("fapolicy_analyzer.ui.notification.dispatch")
 
 
 @pytest.fixture
 def mock_notifications_feature(mocker):
     notifications_feature_mock = Subject()
     mocker.patch(
-        "ui.notification.get_notifications_feature",
+        "fapolicy_analyzer.ui.notification.get_notifications_feature",
         return_value=notifications_feature_mock,
     )
     yield notifications_feature_mock

--- a/fapolicy_analyzer/tests/test_object_list.py
+++ b/fapolicy_analyzer/tests/test_object_list.py
@@ -24,9 +24,9 @@ gi.require_version("Gtk", "3.0")
 from unittest.mock import MagicMock
 
 from gi.repository import Gtk
-from ui.configs import Colors
-from ui.object_list import ObjectList
-from ui.strings import FILE_LABEL, FILES_LABEL
+from fapolicy_analyzer.ui.configs import Colors
+from fapolicy_analyzer.ui.object_list import ObjectList
+from fapolicy_analyzer.ui.strings import FILE_LABEL, FILES_LABEL
 
 
 def _mock_object(trust="", mode="", access="", file="", trust_status=""):
@@ -36,9 +36,21 @@ def _mock_object(trust="", mode="", access="", file="", trust_status=""):
 
 
 _objects = [
-    {0: _mock_object(trust="ST", mode="R", access="A", file="/tmp/foo", trust_status="U")},
-    {1: _mock_object(trust="AT", mode="W", access="A", file="/tmp/baz", trust_status="U")},
-    {2: _mock_object(trust="U", mode="X", access="D", file="/tmp/bar", trust_status="U")},
+    {
+        0: _mock_object(
+            trust="ST", mode="R", access="A", file="/tmp/foo", trust_status="U"
+        )
+    },
+    {
+        1: _mock_object(
+            trust="AT", mode="W", access="A", file="/tmp/baz", trust_status="U"
+        )
+    },
+    {
+        2: _mock_object(
+            trust="U", mode="X", access="D", file="/tmp/bar", trust_status="U"
+        )
+    },
 ]
 
 
@@ -64,7 +76,9 @@ def test_loads_store(widget):
     assert [next(iter(t.values())).access for t in sortedObjects] == [
         strip_markup(x[1]) for x in view.get_model()
     ]
-    assert [next(iter(t.values())).file for t in sortedObjects] == [x[2] for x in view.get_model()]
+    assert [next(iter(t.values())).file for t in sortedObjects] == [
+        x[2] for x in view.get_model()
+    ]
     assert [next(iter(t.values())).mode for t in sortedObjects] == [
         strip_markup(x[6]) for x in view.get_model()
     ]

--- a/fapolicy_analyzer/tests/test_policy_rules_admin_page.py
+++ b/fapolicy_analyzer/tests/test_policy_rules_admin_page.py
@@ -19,8 +19,6 @@ from unittest.mock import MagicMock
 import gi
 import pytest
 from callee import Attrs, InstanceOf
-from redux import Action
-from rx.subject import Subject
 from fapolicy_analyzer.ui.actions import (
     ADD_NOTIFICATION,
     REQUEST_EVENTS,
@@ -35,6 +33,8 @@ from fapolicy_analyzer.ui.strings import (
     GET_USERS_ERROR_MSG,
     PARSE_EVENT_LOG_ERROR_MSG,
 )
+from redux import Action
+from rx.subject import Subject
 
 from mocks import mock_events, mock_groups, mock_log, mock_System, mock_users
 
@@ -497,7 +497,10 @@ def test_refresh_with_multi_select(
     ],
 )
 def test_updates_acl_details(widget, view, mockFnName, mocker):
-    mocker.patch(f"ui.policy_rules_admin_page.acl.{mockFnName}", return_value="foo")
+    mocker.patch(
+        f"fapolicy_analyzer.ui.policy_rules_admin_page.acl.{mockFnName}",
+        return_value="foo",
+    )
     textBuffer = widget.get_object("userDetails").get_buffer()
     view.get_selection().select_path(Gtk.TreePath.new_first())
     assert (

--- a/fapolicy_analyzer/tests/test_policy_rules_admin_page.py
+++ b/fapolicy_analyzer/tests/test_policy_rules_admin_page.py
@@ -21,16 +21,16 @@ import pytest
 from callee import Attrs, InstanceOf
 from redux import Action
 from rx.subject import Subject
-from ui.actions import (
+from fapolicy_analyzer.ui.actions import (
     ADD_NOTIFICATION,
     REQUEST_EVENTS,
     REQUEST_GROUPS,
     REQUEST_USERS,
     NotificationType,
 )
-from ui.policy_rules_admin_page import PolicyRulesAdminPage
-from ui.store import init_store
-from ui.strings import (
+from fapolicy_analyzer.ui.policy_rules_admin_page import PolicyRulesAdminPage
+from fapolicy_analyzer.ui.store import init_store
+from fapolicy_analyzer.ui.strings import (
     GET_GROUPS_LOG_ERROR_MSG,
     GET_USERS_ERROR_MSG,
     PARSE_EVENT_LOG_ERROR_MSG,
@@ -62,14 +62,14 @@ def _build_state(**kwargs):
 
 @pytest.fixture()
 def mock_dispatch(mocker):
-    return mocker.patch("ui.policy_rules_admin_page.dispatch")
+    return mocker.patch("fapolicy_analyzer.ui.policy_rules_admin_page.dispatch")
 
 
 @pytest.fixture()
 def mock_system_features(mocker):
     system_features_mock = Subject()
     mocker.patch(
-        "ui.policy_rules_admin_page.get_system_feature",
+        "fapolicy_analyzer.ui.policy_rules_admin_page.get_system_feature",
         return_value=system_features_mock,
     )
     yield system_features_mock
@@ -94,12 +94,12 @@ def default_states():
 @pytest.fixture
 def widget(mock_dispatch, mock_system_features, mocker, states):
     mocker.patch(
-        "ui.ancillary_trust_file_list.epoch_to_string",
+        "fapolicy_analyzer.ui.ancillary_trust_file_list.epoch_to_string",
         return_value="10-01-2020",
     )
 
     mocker.patch(
-        "ui.trust_file_list.epoch_to_string",
+        "fapolicy_analyzer.ui.trust_file_list.epoch_to_string",
         return_value="10-01-2020",
     )
 
@@ -509,7 +509,9 @@ def test_updates_acl_details(widget, view, mockFnName, mocker):
 
 
 def test_updates_subject_details(widget, mocker):
-    mocker.patch("ui.policy_rules_admin_page.fs.stat", return_value="foo")
+    mocker.patch(
+        "fapolicy_analyzer.ui.policy_rules_admin_page.fs.stat", return_value="foo"
+    )
     textBuffer = widget.get_object("subjectDetails").get_buffer()
     widget.on_file_selection_changed([MagicMock(file="baz")])
     assert (
@@ -521,7 +523,9 @@ def test_updates_subject_details(widget, mocker):
 
 
 def test_updates_object_details(widget, mocker):
-    mocker.patch("ui.policy_rules_admin_page.fs.stat", return_value="foo")
+    mocker.patch(
+        "fapolicy_analyzer.ui.policy_rules_admin_page.fs.stat", return_value="foo"
+    )
     textBuffer = widget.get_object("objectDetails").get_buffer()
     widget.on_file_selection_changed(
         [MagicMock(file="baz")], type="objects", details_widget_name="objectDetails"

--- a/fapolicy_analyzer/tests/test_searchable_list.py
+++ b/fapolicy_analyzer/tests/test_searchable_list.py
@@ -20,7 +20,7 @@ from unittest.mock import MagicMock
 import gi
 import pytest
 from callee import Contains
-from ui.searchable_list import SearchableList
+from fapolicy_analyzer.ui.searchable_list import SearchableList
 
 from helpers import refresh_gui
 

--- a/fapolicy_analyzer/tests/test_session_manager.py
+++ b/fapolicy_analyzer/tests/test_session_manager.py
@@ -29,7 +29,7 @@ from fapolicy_analyzer.ui.actions import (
     RESTORE_SYSTEM_CHECKPOINT,
 )
 from redux import Action
-from ui.session_manager import SessionManager
+from fapolicy_analyzer.ui.session_manager import SessionManager
 
 import context  # noqa: F401
 
@@ -92,7 +92,7 @@ def autosaved_files():
 
 @pytest.fixture()
 def mock_dispatch(mocker):
-    return mocker.patch("ui.session_manager.dispatch")
+    return mocker.patch("fapolicy_analyzer.ui.session_manager.dispatch")
 
 
 # ######################## Session Serialization #####################
@@ -121,7 +121,8 @@ def test_open_edit_session(uut, mock_dispatch, mocker):
 
 def test_open_edit_session_w_exception(uut, mock_dispatch, mocker):
     mockFunc = mocker.patch(
-        "ui.session_manager.json.load", side_effect=lambda: IOError("foo")
+        "fapolicy_analyzer.ui.session_manager.json.load",
+        side_effect=lambda: IOError("foo"),
     )
 
     mocker.patch("builtins.open", mock_open())
@@ -165,7 +166,8 @@ def test_autosave_edit_session(uut_autosave_enabled, mocker):
 def test_autosave_edit_session_w_exception(mocker, uut_autosave_enabled):
     # Create a mock that throw an exception side-effect
     mockFunc = mocker.patch(
-        "ui.session_manager.SessionManager.save_edit_session", side_effect=IOError
+        "fapolicy_analyzer.ui.session_manager.SessionManager.save_edit_session",
+        side_effect=IOError,
     )
     uut_autosave_enabled.on_next_system({"changesets": test_changesets})
     mockFunc.assert_called()
@@ -288,7 +290,8 @@ def test_restore_previous_session_w_exception(
 ):
     # Mock the open_edit_session() call such that it throws an exception
     mockFunc = mocker.patch(
-        "ui.session_manager.SessionManager.open_edit_session", side_effect=IOError
+        "fapolicy_analyzer.ui.session_manager.SessionManager.open_edit_session",
+        side_effect=IOError,
     )
 
     # Two json files assumed on disk w/fixture

--- a/fapolicy_analyzer/tests/test_splash_screen.py
+++ b/fapolicy_analyzer/tests/test_splash_screen.py
@@ -22,8 +22,8 @@ from gi.repository import Gtk
 from mocks import mock_System
 from rx.subject import Subject
 from unittest.mock import MagicMock
-from ui.splash_screen import SplashScreen
-from ui.store import init_store
+from fapolicy_analyzer.ui.splash_screen import SplashScreen
+from fapolicy_analyzer.ui.store import init_store
 
 
 @pytest.fixture
@@ -35,7 +35,8 @@ def mock_init_store():
 def mock_system_features(mocker):
     system_features_mock = Subject()
     mocker.patch(
-        "ui.splash_screen.get_system_feature", return_value=system_features_mock
+        "fapolicy_analyzer.ui.splash_screen.get_system_feature",
+        return_value=system_features_mock,
     )
     system_features_mock.on_next({"initialized": False})
     return system_features_mock
@@ -56,7 +57,7 @@ def test_displays_window(widget):
 
 @pytest.mark.usefixtures("widget")
 def test_opens_main_window(mock_system_features, mocker):
-    mockMainWindow = mocker.patch("ui.splash_screen.MainWindow")
+    mockMainWindow = mocker.patch("fapolicy_analyzer.ui.splash_screen.MainWindow")
     mock_system_features.on_next({"initialized": True})
     mockMainWindow.assert_called_once()
 
@@ -70,7 +71,10 @@ def test_updates_progressBar(mocker):
 
     mockProgressBar = MagicMock(pulse=MagicMock())
     original_get_object = SplashScreen.get_object
-    mocker.patch("ui.splash_screen.SplashScreen.get_object", new=mock_get_object)
+    mocker.patch(
+        "fapolicy_analyzer.ui.splash_screen.SplashScreen.get_object",
+        new=mock_get_object,
+    )
 
     widget = SplashScreen()
     mockProgressBar.pulse.assert_called_once()

--- a/fapolicy_analyzer/tests/test_subject_list.py
+++ b/fapolicy_analyzer/tests/test_subject_list.py
@@ -23,11 +23,11 @@ from callee.attributes import Attrs
 from callee.collections import Sequence
 from callee.types import InstanceOf
 from fapolicy_analyzer import Changeset
+from fapolicy_analyzer.ui.actions import APPLY_CHANGESETS
+from fapolicy_analyzer.ui.configs import Colors
+from fapolicy_analyzer.ui.strings import FILE_LABEL, FILES_LABEL
+from fapolicy_analyzer.ui.subject_list import _TRUST_RESP, _UNTRUST_RESP, SubjectList
 from redux import Action
-from ui.actions import APPLY_CHANGESETS
-from ui.configs import Colors
-from ui.strings import FILE_LABEL, FILES_LABEL
-from ui.subject_list import _TRUST_RESP, _UNTRUST_RESP, SubjectList
 
 gi.require_version("Gtk", "3.0")
 from gi.repository import Gdk, Gtk  # isort: skip
@@ -209,7 +209,7 @@ def test_shows_reconciliation_dialog_on_double_click(
     subject, databaseTrust, widget, mocker
 ):
     mockDialog = mocker.patch(
-        "ui.subject_list.TrustReconciliationDialog",
+        "fapolicy_analyzer.ui.subject_list.TrustReconciliationDialog",
         return_value=MagicMock(get_ref=MagicMock(spec=Gtk.Widget)),
     )
     widget.load_store(
@@ -233,9 +233,14 @@ def test_dispatches_changeset(response, widget, mocker):
     mockChangeset = MagicMock(
         del_trust=MagicMock(), add_trust=MagicMock(), spec=Changeset
     )
-    mocker.patch("ui.subject_list.TrustReconciliationDialog", return_value=mockDialog)
-    mocker.patch("ui.subject_list.Changeset", return_value=mockChangeset)
-    mockDispatch = mocker.patch("ui.subject_list.dispatch")
+    mocker.patch(
+        "fapolicy_analyzer.ui.subject_list.TrustReconciliationDialog",
+        return_value=mockDialog,
+    )
+    mocker.patch(
+        "fapolicy_analyzer.ui.subject_list.Changeset", return_value=mockChangeset
+    )
+    mockDispatch = mocker.patch("fapolicy_analyzer.ui.subject_list.dispatch")
 
     widget.load_store([mockSubject])
     view = widget.get_object("treeView")
@@ -268,7 +273,7 @@ def test_shows_reconciliation_dialog_from_context_menu(
     subject, databaseTrust, widget, mocker
 ):
     mockDialog = mocker.patch(
-        "ui.subject_list.TrustReconciliationDialog",
+        "fapolicy_analyzer.ui.subject_list.TrustReconciliationDialog",
         return_value=MagicMock(get_ref=MagicMock(spec=Gtk.Widget)),
     )
     widget.load_store(
@@ -297,7 +302,7 @@ def test_shows_reconciliation_dialog_from_context_menu(
 )
 def test_shows_change_trust_dialog_from_context_menu(subject, widget, mocker):
     mockDialog = mocker.patch(
-        "ui.subject_list.ConfirmChangeDialog",
+        "fapolicy_analyzer.ui.subject_list.ConfirmChangeDialog",
         return_value=MagicMock(get_ref=MagicMock(spec=Gtk.Widget)),
     )
     widget.load_store(

--- a/fapolicy_analyzer/tests/test_system_trust_database_admin.py
+++ b/fapolicy_analyzer/tests/test_system_trust_database_admin.py
@@ -26,25 +26,28 @@ from callee.strings import Regex
 from gi.repository import Gtk
 from redux import Action
 from rx.subject import Subject
-from ui.actions import ADD_NOTIFICATION, NotificationType
-from ui.configs import Colors
-from ui.store import init_store
-from ui.strings import SYSTEM_TRUST_LOAD_ERROR, SYSTEM_TRUSTED_FILE_MESSAGE
-from ui.system_trust_database_admin import SystemTrustDatabaseAdmin
+from fapolicy_analyzer.ui.actions import ADD_NOTIFICATION, NotificationType
+from fapolicy_analyzer.ui.configs import Colors
+from fapolicy_analyzer.ui.store import init_store
+from fapolicy_analyzer.ui.strings import (
+    SYSTEM_TRUST_LOAD_ERROR,
+    SYSTEM_TRUSTED_FILE_MESSAGE,
+)
+from fapolicy_analyzer.ui.system_trust_database_admin import SystemTrustDatabaseAdmin
 
 from mocks import mock_System, mock_trust
 
 
 @pytest.fixture()
 def mock_dispatch(mocker):
-    return mocker.patch("ui.system_trust_database_admin.dispatch")
+    return mocker.patch("fapolicy_analyzer.ui.system_trust_database_admin.dispatch")
 
 
 @pytest.fixture()
 def mock_system_feature(mocker):
     mockSystemFeature = Subject()
     mocker.patch(
-        "ui.system_trust_database_admin.get_system_feature",
+        "fapolicy_analyzer.ui.system_trust_database_admin.get_system_feature",
         return_value=mockSystemFeature,
     )
     yield mockSystemFeature
@@ -77,7 +80,9 @@ def test_updates_trust_details(widget, mocker):
     mocker.patch.object(widget.trustFileDetails, "set_in_database_view")
     mocker.patch.object(widget.trustFileDetails, "set_on_file_system_view")
     mocker.patch.object(widget.trustFileDetails, "set_trust_status")
-    mocker.patch("ui.ancillary_trust_database_admin.fs.sha", return_value="abc")
+    mocker.patch(
+        "fapolicy_analyzer.ui.ancillary_trust_database_admin.fs.sha", return_value="abc"
+    )
     trust = [MagicMock(status="T", path="/tmp/foo", size=1, hash="abc")]
     widget.on_trust_selection_changed(trust)
     widget.trustFileDetails.set_in_database_view.assert_called_with(

--- a/fapolicy_analyzer/tests/test_trust_file_details.py
+++ b/fapolicy_analyzer/tests/test_trust_file_details.py
@@ -19,7 +19,7 @@ import gi
 
 gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk
-from ui.trust_file_details import TrustFileDetails
+from fapolicy_analyzer.ui.trust_file_details import TrustFileDetails
 
 
 @pytest.fixture

--- a/fapolicy_analyzer/tests/test_trust_file_list.py
+++ b/fapolicy_analyzer/tests/test_trust_file_list.py
@@ -13,9 +13,9 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+import fapolicy_analyzer.ui.trust_file_list as trust_file_list
 import gi
 import pytest
-import ui.trust_file_list as trust_file_list
 
 import context  # noqa: F401
 
@@ -23,8 +23,8 @@ gi.require_version("Gtk", "3.0")
 from time import localtime, mktime, strftime
 from unittest.mock import MagicMock
 
+from fapolicy_analyzer.ui.trust_file_list import TrustFileList, epoch_to_string
 from gi.repository import Gtk
-from ui.trust_file_list import TrustFileList, epoch_to_string
 
 from helpers import refresh_gui
 
@@ -52,7 +52,7 @@ def test_uses_custom_trust_func():
 
 def test_uses_custom_markup_func(mocker):
     mocker.patch(
-        "ui.trust_file_list.ThreadPoolExecutor",
+        "fapolicy_analyzer.ui.trust_file_list.ThreadPoolExecutor",
         return_value=MagicMock(submit=lambda x: x()),
     )
     markup_func = MagicMock(return_value="t")
@@ -63,11 +63,12 @@ def test_uses_custom_markup_func(mocker):
 
 def test_loads_trust_store(widget, mocker):
     mocker.patch(
-        "ui.trust_file_list.ThreadPoolExecutor",
+        "fapolicy_analyzer.ui.trust_file_list.ThreadPoolExecutor",
         return_value=MagicMock(submit=lambda x: x()),
     )
     mocker.patch(
-        "ui.trust_file_list.GLib.idle_add", side_effect=lambda x, args: x(args)
+        "fapolicy_analyzer.ui.trust_file_list.GLib.idle_add",
+        side_effect=lambda x, args: x(args),
     )
     widget.load_trust(_trust)
     refresh_gui()
@@ -78,10 +79,10 @@ def test_loads_trust_store(widget, mocker):
 
 def test_cancels_load_trust_store(widget, mocker):
     mocker.patch(
-        "ui.trust_file_list.ThreadPoolExecutor",
+        "fapolicy_analyzer.ui.trust_file_list.ThreadPoolExecutor",
         return_value=MagicMock(submit=lambda x: x()),
     )
-    mockIdleAdd = mocker.patch("ui.trust_file_list.GLib.idle_add")
+    mockIdleAdd = mocker.patch("fapolicy_analyzer.ui.trust_file_list.GLib.idle_add")
     trust_file_list._executorCanceled = True
     widget.load_trust(_trust)
     refresh_gui()

--- a/fapolicy_analyzer/tests/test_trust_reconciliation_dialog.py
+++ b/fapolicy_analyzer/tests/test_trust_reconciliation_dialog.py
@@ -22,7 +22,7 @@ gi.require_version("Gtk", "3.0")
 from unittest.mock import MagicMock
 
 from gi.repository import Gtk
-from ui.strings import (
+from fapolicy_analyzer.ui.strings import (
     ANCILLARY_DISCREPANCY_FILE_MESSAGE,
     ANCILLARY_TRUSTED_FILE_MESSAGE,
     ANCILLARY_UNKNOWN_FILE_MESSAGE,
@@ -31,12 +31,14 @@ from ui.strings import (
     SYSTEM_UNKNOWN_FILE_MESSAGE,
     UNKNOWN_FILE_MESSAGE,
 )
-from ui.trust_reconciliation_dialog import TrustReconciliationDialog
+from fapolicy_analyzer.ui.trust_reconciliation_dialog import TrustReconciliationDialog
 
 
 @pytest.fixture
 def patch(mocker):
-    mocker.patch("ui.trust_reconciliation_dialog.fs.sha", return_value="abc")
+    mocker.patch(
+        "fapolicy_analyzer.ui.trust_reconciliation_dialog.fs.sha", return_value="abc"
+    )
 
 
 @pytest.fixture
@@ -48,7 +50,7 @@ def mockTrustDetailsWidget(mocker):
         get_ref=MagicMock(return_value=Gtk.Box()),
     )
     mocker.patch(
-        "ui.trust_reconciliation_dialog.TrustFileDetails",
+        "fapolicy_analyzer.ui.trust_reconciliation_dialog.TrustFileDetails",
         return_value=mock,
     )
     return mock
@@ -95,7 +97,8 @@ def test_shows_on_system_data(mockTrustDetailsWidget, mocker):
     mockTrustObj = MagicMock(file="foo")
     mockDatabaseTrust = MagicMock(size=1, hash="abc", status="T")
     mocker.patch(
-        "ui.trust_reconciliation_dialog.fs.stat", return_value="foo file stats"
+        "fapolicy_analyzer.ui.trust_reconciliation_dialog.fs.stat",
+        return_value="foo file stats",
     )
     TrustReconciliationDialog(mockTrustObj, databaseTrust=mockDatabaseTrust)
     mockTrustDetailsWidget.set_on_file_system_view.assert_called_once_with(

--- a/fapolicy_analyzer/tests/test_ui_page.py
+++ b/fapolicy_analyzer/tests/test_ui_page.py
@@ -14,7 +14,7 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import context  # noqa: F401 # isort: skip
-from ui.ui_page import UIAction, UIPage
+from fapolicy_analyzer.ui.ui_page import UIAction, UIPage
 
 
 def test_merge_actions():

--- a/fapolicy_analyzer/tests/test_ui_widget.py
+++ b/fapolicy_analyzer/tests/test_ui_widget.py
@@ -22,7 +22,7 @@ gi.require_version("Gtk", "3.0")
 from unittest.mock import MagicMock
 
 from gi.repository import Gtk
-from ui.ui_widget import UIBuilderWidget, UIConnectedWidget, UIWidget
+from fapolicy_analyzer.ui.ui_widget import UIBuilderWidget, UIConnectedWidget, UIWidget
 
 
 class concrete_UIBuilderWidget(UIBuilderWidget):
@@ -49,13 +49,13 @@ def uiWidget(mockWidget):
 @pytest.fixture
 def mockBuilder(mocker):
     mock = MagicMock(get_object=MagicMock(), add_from_file=MagicMock())
-    mocker.patch("ui.ui_widget.Gtk.Builder", return_value=mock)
+    mocker.patch("fapolicy_analyzer.ui.ui_widget.Gtk.Builder", return_value=mock)
     return mock
 
 
 @pytest.fixture
 def mockResource(mocker):
-    mock = mocker.patch("ui.ui_widget.resources.path")
+    mock = mocker.patch("fapolicy_analyzer.ui.ui_widget.resources.path")
     mock.return_value.__enter__.return_value.as_posix.return_value = "foo"
     return mock
 

--- a/fapolicy_analyzer/tests/test_xdg_utils.py
+++ b/fapolicy_analyzer/tests/test_xdg_utils.py
@@ -14,10 +14,11 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import os
-from util.xdg_utils import (
+
+from fapolicy_analyzer.util.xdg_utils import (
+    xdg_config_dir_prefix,
     xdg_data_dir_prefix,
     xdg_state_dir_prefix,
-    xdg_config_dir_prefix,
 )
 
 

--- a/fapolicy_analyzer/ui/__init__.py
+++ b/fapolicy_analyzer/ui/__init__.py
@@ -12,3 +12,14 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+
+import locale
+
+import pkg_resources
+
+DOMAIN = "fapolicy_analyzer"
+locale.setlocale(locale.LC_ALL, locale.getlocale())
+locale_path = pkg_resources.resource_filename("fapolicy_analyzer", "locale")
+locale.bindtextdomain(DOMAIN, locale_path)
+locale.textdomain(DOMAIN)

--- a/fapolicy_analyzer/ui/__main__.py
+++ b/fapolicy_analyzer/ui/__main__.py
@@ -22,9 +22,9 @@ import gi
 from fapolicy_analyzer import __version__ as app_version
 from fapolicy_analyzer.util.xdg_utils import xdg_state_dir_prefix
 
-from .session_manager import sessionManager
-from .splash_screen import SplashScreen
-from .store import init_store
+from fapolicy_analyzer.ui.session_manager import sessionManager
+from fapolicy_analyzer.ui.splash_screen import SplashScreen
+from fapolicy_analyzer.ui.store import init_store
 
 gi.require_version("Gtk", "3.0")
 gi.require_version("GtkSource", "3.0")

--- a/fapolicy_analyzer/ui/acl_list.py
+++ b/fapolicy_analyzer/ui/acl_list.py
@@ -15,7 +15,7 @@
 
 import gi
 
-from .searchable_list import SearchableList
+from fapolicy_analyzer.ui.searchable_list import SearchableList
 
 gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk  # isort: skip

--- a/fapolicy_analyzer/ui/add_file_button.py
+++ b/fapolicy_analyzer/ui/add_file_button.py
@@ -21,7 +21,7 @@ gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk
 from events import Events
 from os import path
-from .ui_widget import UIBuilderWidget
+from fapolicy_analyzer.ui.ui_widget import UIBuilderWidget
 
 
 class AddFileButton(UIBuilderWidget, Events):

--- a/fapolicy_analyzer/ui/analyzer_selection_dialog.py
+++ b/fapolicy_analyzer/ui/analyzer_selection_dialog.py
@@ -18,8 +18,8 @@ from os import path
 
 import gi
 
-from .strings import OPEN_FILE_LABEL
-from .ui_widget import UIBuilderWidget
+from fapolicy_analyzer.ui.strings import OPEN_FILE_LABEL
+from fapolicy_analyzer.ui.ui_widget import UIBuilderWidget
 
 gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk  # isort: skip

--- a/fapolicy_analyzer/ui/ancillary_trust_database_admin.py
+++ b/fapolicy_analyzer/ui/ancillary_trust_database_admin.py
@@ -23,17 +23,17 @@ from fapolicy_analyzer.util import fs  # noqa: F401
 from fapolicy_analyzer.util.format import f
 from gi.repository import Gtk
 
-from .actions import (
+from fapolicy_analyzer.ui.actions import (
     NotificationType,
     add_notification,
     apply_changesets,
     request_ancillary_trust,
 )
-from .ancillary_trust_file_list import AncillaryTrustFileList
-from .remove_deleted_dialog import RemoveDeletedDialog
-from .store import dispatch, get_system_feature
-from .trust_file_details import TrustFileDetails
-from .ui_widget import UIConnectedWidget
+from fapolicy_analyzer.ui.ancillary_trust_file_list import AncillaryTrustFileList
+from fapolicy_analyzer.ui.remove_deleted_dialog import RemoveDeletedDialog
+from fapolicy_analyzer.ui.store import dispatch, get_system_feature
+from fapolicy_analyzer.ui.trust_file_details import TrustFileDetails
+from fapolicy_analyzer.ui.ui_widget import UIConnectedWidget
 
 
 class AncillaryTrustDatabaseAdmin(UIConnectedWidget):

--- a/fapolicy_analyzer/ui/ancillary_trust_file_list.py
+++ b/fapolicy_analyzer/ui/ancillary_trust_file_list.py
@@ -20,9 +20,9 @@ from types import SimpleNamespace
 import fapolicy_analyzer.ui.strings as strings
 import gi
 
-from .add_file_button import AddFileButton
-from .configs import Colors
-from .trust_file_list import TrustFileList, epoch_to_string
+from fapolicy_analyzer.ui.add_file_button import AddFileButton
+from fapolicy_analyzer.ui.configs import Colors
+from fapolicy_analyzer.ui.trust_file_list import TrustFileList, epoch_to_string
 
 gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk  # isort: skip

--- a/fapolicy_analyzer/ui/confirm_info_dialog.py
+++ b/fapolicy_analyzer/ui/confirm_info_dialog.py
@@ -18,8 +18,8 @@ import gi
 gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk
 
-from .configs import Colors
-from .strings import (
+from fapolicy_analyzer.ui.configs import Colors
+from fapolicy_analyzer.ui.strings import (
     CHANGESET_ACTION_ADD,
     CHANGESET_ACTION_DEL,
     DEPLOY_ANCILLARY_CONFIRM_DIALOG_TEXT,

--- a/fapolicy_analyzer/ui/database_admin_page.py
+++ b/fapolicy_analyzer/ui/database_admin_page.py
@@ -20,9 +20,11 @@ from fapolicy_analyzer.ui.ui_page import UIPage
 gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk
 
-from .ancillary_trust_database_admin import AncillaryTrustDatabaseAdmin
-from .system_trust_database_admin import SystemTrustDatabaseAdmin
-from .ui_widget import UIWidget
+from fapolicy_analyzer.ui.ancillary_trust_database_admin import (
+    AncillaryTrustDatabaseAdmin,
+)
+from fapolicy_analyzer.ui.system_trust_database_admin import SystemTrustDatabaseAdmin
+from fapolicy_analyzer.ui.ui_widget import UIWidget
 
 
 class DatabaseAdminPage(UIWidget, UIPage):

--- a/fapolicy_analyzer/ui/deploy_confirm_dialog.py
+++ b/fapolicy_analyzer/ui/deploy_confirm_dialog.py
@@ -20,7 +20,7 @@ from gi.repository import Gtk, GLib
 from threading import Thread
 from time import sleep
 from locale import gettext as _
-from .ui_widget import UIBuilderWidget
+from fapolicy_analyzer.ui.ui_widget import UIBuilderWidget
 from fapolicy_analyzer.util.format import f
 
 

--- a/fapolicy_analyzer/ui/faprofiler.py
+++ b/fapolicy_analyzer/ui/faprofiler.py
@@ -18,9 +18,9 @@ import os
 import pwd
 import subprocess
 import time
-from .actions import NotificationType, add_notification
-from .fapd_manager import FapdMode
-from .store import dispatch
+from fapolicy_analyzer.ui.actions import NotificationType, add_notification
+from fapolicy_analyzer.ui.fapd_manager import FapdMode
+from fapolicy_analyzer.ui.store import dispatch
 from datetime import datetime as DT
 from enum import Enum
 
@@ -47,8 +47,7 @@ class FaProfSession:
             return None
         return {
             k: v.strip('"')
-            for k, v in dict(x.strip().split("=")
-                             for x in string_in.split(",")).items()
+            for k, v in dict(x.strip().split("=") for x in string_in.split(",")).items()
         }
 
     def __init__(self, dictProfTgt, faprofiler=None):
@@ -60,7 +59,9 @@ class FaProfSession:
         self.pwd = dictProfTgt["dirText"]
 
         # Convert comma delimited string of "EnvVar=Value" substrings to dict
-        self.env = FaProfSession._comma_delimited_kv_string_to_dict(dictProfTgt["envText"])
+        self.env = FaProfSession._comma_delimited_kv_string_to_dict(
+            dictProfTgt["envText"]
+        )
 
         self.faprofiler = faprofiler
         self.name = os.path.basename(self.execPath)
@@ -118,10 +119,14 @@ class FaProfSession:
                 logging.debug(f"The uid/gid of the profiling tgt: {uid}/{gid}")
 
                 # Change the ownership of profiling tgt's stdout and stderr
-                logging.debug(f"Changing ownership of fds: {self.fdTgtStdout},{self.fdTgtStderr}")
+                logging.debug(
+                    f"Changing ownership of fds: {self.fdTgtStdout},{self.fdTgtStderr}"
+                )
                 os.fchown(self.fdTgtStdout.fileno(), uid, gid)
                 os.fchown(self.fdTgtStderr.fileno(), uid, gid)
-                logging.debug(f"Changed the profiling tgt stdout/err ownership {uid},{gid}")
+                logging.debug(
+                    f"Changed the profiling tgt stdout/err ownership {uid},{gid}"
+                )
                 u_valid = True
             else:
                 # In production, the following will be the superuser defaults
@@ -148,16 +153,14 @@ class FaProfSession:
         try:
             logging.debug(f"Starting {self.listCmdLine} as {uid}/{gid}")
             logging.debug(f"in {self.pwd} with env: {self.env}")
-            self.procTarget = subprocess.Popen(self.listCmdLine,
-                                               stdout=self.fdTgtStdout,
-                                               stderr=self.fdTgtStderr,
-                                               cwd=working_dir,
-                                               env=self.env,
-                                               preexec_fn=FaProfSession._demote(
-                                                   u_valid,
-                                                   uid,
-                                                   gid)
-                                               )
+            self.procTarget = subprocess.Popen(
+                self.listCmdLine,
+                stdout=self.fdTgtStdout,
+                stderr=self.fdTgtStderr,
+                cwd=working_dir,
+                env=self.env,
+                preexec_fn=FaProfSession._demote(u_valid, uid, gid),
+            )
             logging.debug(self.procTarget.pid)
             self.status = ProfSessionStatus.INPROGRESS
 
@@ -222,7 +225,6 @@ class FaProfSession:
     def clean_all(self):
         logging.debug("FaProfSession::clean_all()")
         # Delete all log file artifacts
-        pass
 
 
 class FaProfiler:

--- a/fapolicy_analyzer/ui/features/__init__.py
+++ b/fapolicy_analyzer/ui/features/__init__.py
@@ -14,8 +14,15 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 from typing import Tuple
-from .notification_feature import NOTIFICATIONS_FEATURE, create_notification_feature
-from .system_feature import SYSTEM_FEATURE, create_system_feature
+
+from fapolicy_analyzer.ui.features.notification_feature import (
+    NOTIFICATIONS_FEATURE,
+    create_notification_feature,
+)
+from fapolicy_analyzer.ui.features.system_feature import (
+    SYSTEM_FEATURE,
+    create_system_feature,
+)
 
 __all__: Tuple[str, ...] = (
     "NOTIFICATIONS_FEATURE",

--- a/fapolicy_analyzer/ui/loader.py
+++ b/fapolicy_analyzer/ui/loader.py
@@ -20,8 +20,8 @@ try:
 except ImportError:
     import importlib_resources as resources
 
-from .strings import LOADER_MESSAGE
-from .ui_widget import UIBuilderWidget
+from fapolicy_analyzer.ui.strings import LOADER_MESSAGE
+from fapolicy_analyzer.ui.ui_widget import UIBuilderWidget
 
 gi.require_version("GtkSource", "3.0")
 from gi.repository import GdkPixbuf  # isort: skip

--- a/fapolicy_analyzer/ui/main_window.py
+++ b/fapolicy_analyzer/ui/main_window.py
@@ -23,26 +23,24 @@ from typing import Any
 import fapolicy_analyzer.ui.strings as strings
 import gi
 from fapolicy_analyzer import __version__ as app_version
-from fapolicy_analyzer.ui.ui_page import UIAction, UIPage
-from fapolicy_analyzer.util.format import f
-from fapolicy_analyzer.ui.profile_dialog import ProfileDialog
-
 from fapolicy_analyzer.ui.action_toolbar import ActionToolbar
 from fapolicy_analyzer.ui.actions import NotificationType, add_notification
 from fapolicy_analyzer.ui.analyzer_selection_dialog import ANALYZER_SELECTION
 from fapolicy_analyzer.ui.configs import Sizing
 from fapolicy_analyzer.ui.database_admin_page import DatabaseAdminPage
-
-from fapolicy_analyzer.ui.faprofiler import FaProfiler
 from fapolicy_analyzer.ui.fapd_manager import FapdManager, ServiceStatus
+from fapolicy_analyzer.ui.faprofiler import FaProfiler
 from fapolicy_analyzer.ui.notification import Notification
 from fapolicy_analyzer.ui.operations import DeployChangesetsOp
 from fapolicy_analyzer.ui.policy_rules_admin_page import PolicyRulesAdminPage
+from fapolicy_analyzer.ui.profile_dialog import ProfileDialog
 from fapolicy_analyzer.ui.rules import RulesAdminPage
 from fapolicy_analyzer.ui.session_manager import sessionManager
 from fapolicy_analyzer.ui.store import dispatch, get_system_feature
+from fapolicy_analyzer.ui.ui_page import UIAction, UIPage
 from fapolicy_analyzer.ui.ui_widget import UIConnectedWidget
 from fapolicy_analyzer.ui.unapplied_changes_dialog import UnappliedChangesDialog
+from fapolicy_analyzer.util.format import f
 
 gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk, GLib  # isort: skip

--- a/fapolicy_analyzer/ui/main_window.py
+++ b/fapolicy_analyzer/ui/main_window.py
@@ -25,24 +25,24 @@ import gi
 from fapolicy_analyzer import __version__ as app_version
 from fapolicy_analyzer.ui.ui_page import UIAction, UIPage
 from fapolicy_analyzer.util.format import f
-from .profile_dialog import ProfileDialog
+from fapolicy_analyzer.ui.profile_dialog import ProfileDialog
 
-from .action_toolbar import ActionToolbar
-from .actions import NotificationType, add_notification
-from .analyzer_selection_dialog import ANALYZER_SELECTION
-from .configs import Sizing
-from .database_admin_page import DatabaseAdminPage
+from fapolicy_analyzer.ui.action_toolbar import ActionToolbar
+from fapolicy_analyzer.ui.actions import NotificationType, add_notification
+from fapolicy_analyzer.ui.analyzer_selection_dialog import ANALYZER_SELECTION
+from fapolicy_analyzer.ui.configs import Sizing
+from fapolicy_analyzer.ui.database_admin_page import DatabaseAdminPage
 
-from .faprofiler import FaProfiler
-from .fapd_manager import FapdManager, ServiceStatus
-from .notification import Notification
-from .operations import DeployChangesetsOp
-from .policy_rules_admin_page import PolicyRulesAdminPage
-from .rules import RulesAdminPage
-from .session_manager import sessionManager
-from .store import dispatch, get_system_feature
-from .ui_widget import UIConnectedWidget
-from .unapplied_changes_dialog import UnappliedChangesDialog
+from fapolicy_analyzer.ui.faprofiler import FaProfiler
+from fapolicy_analyzer.ui.fapd_manager import FapdManager, ServiceStatus
+from fapolicy_analyzer.ui.notification import Notification
+from fapolicy_analyzer.ui.operations import DeployChangesetsOp
+from fapolicy_analyzer.ui.policy_rules_admin_page import PolicyRulesAdminPage
+from fapolicy_analyzer.ui.rules import RulesAdminPage
+from fapolicy_analyzer.ui.session_manager import sessionManager
+from fapolicy_analyzer.ui.store import dispatch, get_system_feature
+from fapolicy_analyzer.ui.ui_widget import UIConnectedWidget
+from fapolicy_analyzer.ui.unapplied_changes_dialog import UnappliedChangesDialog
 
 gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk, GLib  # isort: skip
@@ -332,7 +332,9 @@ class MainWindow(UIConnectedWidget):
     def on_syslogMenu_activate(self, *args):
         page = router(ANALYZER_SELECTION.ANALYZE_SYSLOG)
         height = self.get_object("mainWindow").get_size()[1]
-        page.get_object("botBox").set_property("height_request", int(height * Sizing.POLICY_BOTTOM_BOX))
+        page.get_object("botBox").set_property(
+            "height_request", int(height * Sizing.POLICY_BOTTOM_BOX)
+        )
         self.__pack_main_content(page)
         self.__set_trustDbMenu_sensitive(True)
 
@@ -355,7 +357,9 @@ class MainWindow(UIConnectedWidget):
             page = router(ANALYZER_SELECTION.ANALYZE_FROM_AUDIT, file)
             page.object_list.rule_view_activate += self.on_rulesAdminMenu_activate
             height = self.get_object("mainWindow").get_size()[1]
-            page.get_object("botBox").set_property("height_request", int(height * Sizing.POLICY_BOTTOM_BOX))
+            page.get_object("botBox").set_property(
+                "height_request", int(height * Sizing.POLICY_BOTTOM_BOX)
+            )
             self.__pack_main_content(page)
             self.__set_trustDbMenu_sensitive(True)
         fcd.destroy()
@@ -405,12 +409,12 @@ class MainWindow(UIConnectedWidget):
     # ###################### fapolicyd interfacing ##########################
     def on_fapdStartMenu_activate(self, menuitem, data=None):
         logging.debug("on_fapdStartMenu_activate() invoked.")
-        if (self._fapd_status != ServiceStatus.UNKNOWN):
+        if self._fapd_status != ServiceStatus.UNKNOWN:
             self._fapd_mgr.start()
 
     def on_fapdStopMenu_activate(self, menuitem, data=None):
         logging.debug("on_fapdStopMenu_activate() invoked.")
-        if (self._fapd_status != ServiceStatus.UNKNOWN):
+        if self._fapd_status != ServiceStatus.UNKNOWN:
             self._fapd_mgr.stop()
 
     def _enable_fapd_menu_items(self, status: ServiceStatus):

--- a/fapolicy_analyzer/ui/notification.py
+++ b/fapolicy_analyzer/ui/notification.py
@@ -22,9 +22,9 @@ try:
 except ImportError:
     import importlib_resources as resources
 
-from .actions import NotificationType, remove_notification
-from .store import dispatch, get_notifications_feature
-from .ui_widget import UIConnectedWidget
+from fapolicy_analyzer.ui.actions import NotificationType, remove_notification
+from fapolicy_analyzer.ui.store import dispatch, get_notifications_feature
+from fapolicy_analyzer.ui.ui_widget import UIConnectedWidget
 
 gi.require_version("GtkSource", "3.0")
 from gi.repository import Gio, Gtk  # isort: skip

--- a/fapolicy_analyzer/ui/object_list.py
+++ b/fapolicy_analyzer/ui/object_list.py
@@ -16,11 +16,12 @@
 import fapolicy_analyzer.ui.strings as strings
 import gi
 from events import Events
+
 gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk
 
-from .configs import Colors
-from .subject_list import SubjectList
+from fapolicy_analyzer.ui.configs import Colors
+from fapolicy_analyzer.ui.subject_list import SubjectList
 
 
 class ObjectList(SubjectList, Events):
@@ -46,6 +47,7 @@ class ObjectList(SubjectList, Events):
     def __markup(self, value, options, seperator=" / ", multiValue=False):
         def wrap(x):
             return f"<u><b>{x}</b></u>"
+
         valueSet = set(value.upper()) if multiValue else {value.upper()}
         matches = set(options).intersection(valueSet)
         return seperator.join([wrap(o) if o in matches else o for o in options])

--- a/fapolicy_analyzer/ui/operations/__init__.py
+++ b/fapolicy_analyzer/ui/operations/__init__.py
@@ -15,7 +15,7 @@
 
 from typing import Tuple
 
-from .deploy_changesets_op import DeployChangesetsOp
-from .ui_operation import UIOperation
+from fapolicy_analyzer.ui.operations.deploy_changesets_op import DeployChangesetsOp
+from fapolicy_analyzer.ui.operations.ui_operation import UIOperation
 
 __all__: Tuple[str, ...] = ("DeployChangesetsOp", "UIOperation")

--- a/fapolicy_analyzer/ui/operations/deploy_changesets_op.py
+++ b/fapolicy_analyzer/ui/operations/deploy_changesets_op.py
@@ -29,6 +29,7 @@ from fapolicy_analyzer.ui.actions import (
 )
 from fapolicy_analyzer.ui.confirm_info_dialog import ConfirmInfoDialog
 from fapolicy_analyzer.ui.deploy_confirm_dialog import DeployConfirmDialog
+from fapolicy_analyzer.ui.operations.ui_operation import UIOperation
 from fapolicy_analyzer.ui.store import dispatch, get_system_feature
 from fapolicy_analyzer.ui.strings import (
     ANY_FILES_FILTER_LABEL,
@@ -38,8 +39,6 @@ from fapolicy_analyzer.ui.strings import (
     SAVE_AS_FILE_LABEL,
 )
 from fapolicy_analyzer.util.fapd_dbase import fapd_dbase_snapshot
-
-from .ui_operation import UIOperation
 
 gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk  # isort: skip

--- a/fapolicy_analyzer/ui/policy_rules_admin_page.py
+++ b/fapolicy_analyzer/ui/policy_rules_admin_page.py
@@ -21,8 +21,8 @@ from events import Events
 from fapolicy_analyzer import EventLog, Group, Trust, User
 from fapolicy_analyzer.util import acl, fs
 
-from .acl_list import ACLList
-from .actions import (
+from fapolicy_analyzer.ui.acl_list import ACLList
+from fapolicy_analyzer.ui.actions import (
     NotificationType,
     add_notification,
     request_ancillary_trust,
@@ -31,9 +31,9 @@ from .actions import (
     request_system_trust,
     request_users,
 )
-from .object_list import ObjectList
-from .store import dispatch, get_system_feature
-from .strings import (
+from fapolicy_analyzer.ui.object_list import ObjectList
+from fapolicy_analyzer.ui.store import dispatch, get_system_feature
+from fapolicy_analyzer.ui.strings import (
     GET_GROUPS_LOG_ERROR_MSG,
     GET_USERS_ERROR_MSG,
     GROUP_LABEL,
@@ -42,9 +42,9 @@ from .strings import (
     USER_LABEL,
     USERS_LABEL,
 )
-from .subject_list import SubjectList
-from .ui_page import UIAction, UIPage
-from .ui_widget import UIConnectedWidget
+from fapolicy_analyzer.ui.subject_list import SubjectList
+from fapolicy_analyzer.ui.ui_page import UIAction, UIPage
+from fapolicy_analyzer.ui.ui_widget import UIConnectedWidget
 
 gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk  # isort: skip

--- a/fapolicy_analyzer/ui/reducers/__init__.py
+++ b/fapolicy_analyzer/ui/reducers/__init__.py
@@ -14,7 +14,8 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 from typing import Tuple
-from .notification_reducer import notification_reducer
-from .system_reducer import system_reducer
+
+from fapolicy_analyzer.ui.reducers.notification_reducer import notification_reducer
+from fapolicy_analyzer.ui.reducers.system_reducer import system_reducer
 
 __all__: Tuple[str, ...] = ("notification_reducer", "system_reducer")

--- a/fapolicy_analyzer/ui/reducers/system_reducer.py
+++ b/fapolicy_analyzer/ui/reducers/system_reducer.py
@@ -14,16 +14,17 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 from fapolicy_analyzer.ui.actions import ERROR_SYSTEM_INITIALIZATION, SYSTEM_INITIALIZED
+from fapolicy_analyzer.ui.reducers.ancillary_trust_reducer import (
+    ancillary_trust_reducer,
+)
+from fapolicy_analyzer.ui.reducers.changeset_reducer import changeset_reducer
+from fapolicy_analyzer.ui.reducers.event_reducer import event_reducer
+from fapolicy_analyzer.ui.reducers.group_reducer import group_reducer
+from fapolicy_analyzer.ui.reducers.rule_reducer import rule_reducer
+from fapolicy_analyzer.ui.reducers.rules_text_reducer import rules_text_reducer
+from fapolicy_analyzer.ui.reducers.system_trust_reducer import system_trust_reducer
+from fapolicy_analyzer.ui.reducers.user_reducer import user_reducer
 from redux import Reducer, combine_reducers, handle_actions
-
-from .ancillary_trust_reducer import ancillary_trust_reducer
-from .changeset_reducer import changeset_reducer
-from .event_reducer import event_reducer
-from .group_reducer import group_reducer
-from .rule_reducer import rule_reducer
-from .rules_text_reducer import rules_text_reducer
-from .system_trust_reducer import system_trust_reducer
-from .user_reducer import user_reducer
 
 system_initialized_reducer: Reducer = handle_actions(
     {SYSTEM_INITIALIZED: lambda *_: True}, False

--- a/fapolicy_analyzer/ui/rules/__init__.py
+++ b/fapolicy_analyzer/ui/rules/__init__.py
@@ -15,6 +15,6 @@
 
 from typing import Tuple
 
-from .rules_admin_page import RulesAdminPage
+from fapolicy_analyzer.ui.rules.rules_admin_page import RulesAdminPage
 
 __all__: Tuple[str, ...] = ("RulesAdminPage",)

--- a/fapolicy_analyzer/ui/searchable_list.py
+++ b/fapolicy_analyzer/ui/searchable_list.py
@@ -21,8 +21,8 @@ gi.require_version("Gtk", "3.0")
 from events import Events
 from gi.repository import Gtk
 
-from .loader import Loader
-from .ui_widget import UIBuilderWidget
+from fapolicy_analyzer.ui.loader import Loader
+from fapolicy_analyzer.ui.ui_widget import UIBuilderWidget
 
 
 class SearchableList(UIBuilderWidget, Events):
@@ -139,7 +139,9 @@ class SearchableList(UIBuilderWidget, Events):
             return selected is not None
 
         selected = None
-        self.treeView.get_model().foreach(search) if self.treeView.get_model() is not None else None
+        self.treeView.get_model().foreach(
+            search
+        ) if self.treeView.get_model() is not None else None
         return selected
 
     def on_view_selection_changed(self, selection):

--- a/fapolicy_analyzer/ui/session_manager.py
+++ b/fapolicy_analyzer/ui/session_manager.py
@@ -24,13 +24,13 @@ from fapolicy_analyzer import Changeset
 from fapolicy_analyzer.util.format import f
 from locale import gettext as _
 from sys import stderr
-from .actions import (
+from fapolicy_analyzer.ui.actions import (
     NotificationType,
     apply_changesets,
     add_notification,
     restore_system_checkpoint,
 )
-from .store import dispatch, get_system_feature
+from fapolicy_analyzer.ui.store import dispatch, get_system_feature
 
 
 class SessionManager:

--- a/fapolicy_analyzer/ui/splash_screen.py
+++ b/fapolicy_analyzer/ui/splash_screen.py
@@ -19,9 +19,9 @@ import sys
 gi.require_version("Gtk", "3.0")
 from gi.repository import GLib, Gtk
 import fapolicy_analyzer.ui.strings as strings
-from .main_window import MainWindow
-from .store import get_system_feature
-from .ui_widget import UIConnectedWidget
+from fapolicy_analyzer.ui.main_window import MainWindow
+from fapolicy_analyzer.ui.store import get_system_feature
+from fapolicy_analyzer.ui.ui_widget import UIConnectedWidget
 
 
 def trust_db_access_failure_dlg():

--- a/fapolicy_analyzer/ui/store.py
+++ b/fapolicy_analyzer/ui/store.py
@@ -18,7 +18,7 @@ from redux import Action, create_store
 from redux import select_feature
 from rx import operators
 from rx.core.typing import Observable
-from .features import (
+from fapolicy_analyzer.ui.features import (
     NOTIFICATIONS_FEATURE,
     SYSTEM_FEATURE,
     create_notification_feature,

--- a/fapolicy_analyzer/ui/subject_list.py
+++ b/fapolicy_analyzer/ui/subject_list.py
@@ -18,14 +18,14 @@ import gi
 from fapolicy_analyzer import Changeset
 from more_itertools import first_true
 
-from .actions import apply_changesets
-from .add_file_button import AddFileButton
-from .configs import Colors
-from .confirm_change_dialog import ConfirmChangeDialog
-from .searchable_list import SearchableList
-from .store import dispatch
-from .strings import FILE_LABEL, FILES_LABEL
-from .trust_reconciliation_dialog import TrustReconciliationDialog
+from fapolicy_analyzer.ui.actions import apply_changesets
+from fapolicy_analyzer.ui.add_file_button import AddFileButton
+from fapolicy_analyzer.ui.configs import Colors
+from fapolicy_analyzer.ui.confirm_change_dialog import ConfirmChangeDialog
+from fapolicy_analyzer.ui.searchable_list import SearchableList
+from fapolicy_analyzer.ui.store import dispatch
+from fapolicy_analyzer.ui.strings import FILE_LABEL, FILES_LABEL
+from fapolicy_analyzer.ui.trust_reconciliation_dialog import TrustReconciliationDialog
 
 gi.require_version("Gtk", "3.0")
 from gi.repository import Gdk, Gtk  # isort: skip
@@ -268,9 +268,7 @@ class SubjectList(SearchableList):
                     untrustable += 1
 
             self.fileChangeContextMenu.remove(self.fileChangeContextMenu.trustItem)
-            self.fileChangeContextMenu.remove(
-                self.fileChangeContextMenu.untrustItem
-            )
+            self.fileChangeContextMenu.remove(self.fileChangeContextMenu.untrustItem)
             self.fileChangeContextMenu.trustItem.selection_data = None
             self.fileChangeContextMenu.untrustItem.selection_data = None
 
@@ -283,9 +281,7 @@ class SubjectList(SearchableList):
                     changeset,
                 )
             elif trustable and not untrustable:
-                self.fileChangeContextMenu.append(
-                    self.fileChangeContextMenu.trustItem
-                )
+                self.fileChangeContextMenu.append(self.fileChangeContextMenu.trustItem)
                 self.fileChangeContextMenu.trustItem.selection_data = (
                     len(subjects),
                     changeset,

--- a/fapolicy_analyzer/ui/system_trust_database_admin.py
+++ b/fapolicy_analyzer/ui/system_trust_database_admin.py
@@ -21,12 +21,16 @@ from events import Events
 from fapolicy_analyzer.util import fs  # noqa: F401
 from fapolicy_analyzer.util.format import f
 
-from .actions import NotificationType, add_notification, request_system_trust
-from .configs import Colors
-from .store import dispatch, get_system_feature
-from .trust_file_details import TrustFileDetails
-from .trust_file_list import TrustFileList
-from .ui_widget import UIConnectedWidget
+from fapolicy_analyzer.ui.actions import (
+    NotificationType,
+    add_notification,
+    request_system_trust,
+)
+from fapolicy_analyzer.ui.configs import Colors
+from fapolicy_analyzer.ui.store import dispatch, get_system_feature
+from fapolicy_analyzer.ui.trust_file_details import TrustFileDetails
+from fapolicy_analyzer.ui.trust_file_list import TrustFileList
+from fapolicy_analyzer.ui.ui_widget import UIConnectedWidget
 
 
 class SystemTrustDatabaseAdmin(UIConnectedWidget, Events):

--- a/fapolicy_analyzer/ui/trust_file_details.py
+++ b/fapolicy_analyzer/ui/trust_file_details.py
@@ -13,7 +13,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-from .ui_widget import UIBuilderWidget
+from fapolicy_analyzer.ui.ui_widget import UIBuilderWidget
 
 
 class TrustFileDetails(UIBuilderWidget):

--- a/fapolicy_analyzer/ui/trust_file_list.py
+++ b/fapolicy_analyzer/ui/trust_file_list.py
@@ -19,9 +19,9 @@ from time import localtime, mktime, strftime, strptime
 import fapolicy_analyzer.ui.strings as strings
 import gi
 
-from .configs import Colors
-from .searchable_list import SearchableList
-from .strings import FILE_LABEL, FILES_LABEL
+from fapolicy_analyzer.ui.configs import Colors
+from fapolicy_analyzer.ui.searchable_list import SearchableList
+from fapolicy_analyzer.ui.strings import FILE_LABEL, FILES_LABEL
 
 gi.require_version("Gtk", "3.0")
 from gi.repository import GLib, Gtk  # isort: skip

--- a/fapolicy_analyzer/ui/ui_widget.py
+++ b/fapolicy_analyzer/ui/ui_widget.py
@@ -13,32 +13,23 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import locale
 import logging
 from abc import ABC, ABCMeta
 from dataclasses import dataclass
 from typing import Callable
 
 import gi
-import pkg_resources
+from fapolicy_analyzer.ui import DOMAIN
+from fapolicy_analyzer.util.format import snake_to_camelcase
+from rx.core.typing import Observable
 
 try:
     from importlib import resources
 except ImportError:
     import importlib_resources as resources
 
-from fapolicy_analyzer.util.format import snake_to_camelcase
-from rx.core.typing import Observable
-
 gi.require_version("GtkSource", "3.0")
 from gi.repository import Gtk  # isort: skip
-
-
-DOMAIN = "fapolicy_analyzer"
-locale.setlocale(locale.LC_ALL, locale.getlocale())
-locale_path = pkg_resources.resource_filename("fapolicy_analyzer", "locale")
-locale.bindtextdomain(DOMAIN, locale_path)
-locale.textdomain(DOMAIN)
 
 
 class _PostInitCaller(type):

--- a/fapolicy_analyzer/ui/unapplied_changes_dialog.py
+++ b/fapolicy_analyzer/ui/unapplied_changes_dialog.py
@@ -13,7 +13,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-from .ui_widget import UIBuilderWidget
+from fapolicy_analyzer.ui.ui_widget import UIBuilderWidget
 
 
 class UnappliedChangesDialog(UIBuilderWidget):


### PR DESCRIPTION
I switched all relative imports over to absolute imports across the entire UI code base. Long term I think this is our best move as relative imports caused issues when we started creating submodules under the `ui` module. It also is part of the fix to get our text coverage close to matching up with what I'm seeing locally. Right now CI is at 95.43% and locally I'm getting 95.73%.  A couple of caveats:

1. I had to skip the test for internationalization. I can't seem to get that working out in CI. I'm guessing its an difference between RHEL and Ubuntu OS's.
2. @jw3 I'm no longer using the binding wheel file we build in CI for the tests. I'm not sure if we want to keep building that as part of the CI or not. I feel like there is value in doing the build as part of the CI.