### PR TITLE
Full daemon reload

### DIFF
--- a/crates/daemon/Cargo.toml
+++ b/crates/daemon/Cargo.toml
@@ -9,11 +9,4 @@ edition = "2018"
 nom = "6.1.0"
 thiserror = "1.0"
 fapolicy-api = { version = "*", path = "../api" }
-
-[dependencies.dbus]
-version = "0.9"
-optional = true
-
-[features]
-default = []
-systemd = ["dbus"]
+dbus = "0.9"

--- a/crates/daemon/src/error.rs
+++ b/crates/daemon/src/error.rs
@@ -15,11 +15,9 @@ pub enum Error {
     #[error("{0}")]
     FapolicydReloadFail(String),
 
-    #[cfg(feature = "systemd")]
     #[error("dbus {0}")]
     DbusFailure(#[from] dbus::Error),
 
-    #[cfg(feature = "systemd")]
     #[error("dbus method-call {0}")]
     DbusMethodCall(String),
 

--- a/crates/daemon/src/fapolicyd.rs
+++ b/crates/daemon/src/fapolicyd.rs
@@ -8,6 +8,7 @@
 
 // todo;; tracking the fapolicyd specific bits in here to determine if bindings are worthwhile
 
+use std::io::Write;
 use std::thread::sleep;
 use std::time::Duration;
 
@@ -34,16 +35,16 @@ pub enum Version {
 }
 
 /// send signal to fapolicyd FIFO pipe to reload the trust database
-// pub fn reload_databases() -> Result<(), Error> {
-//     let mut fifo = std::fs::OpenOptions::new()
-//         .write(true)
-//         .read(false)
-//         .open(FIFO_PIPE)
-//         .map_err(|_| FapolicydReloadFail("failed to open fifo pipe".to_string()))?;
-//
-//     fifo.write_all("1".as_bytes())
-//         .map_err(|_| FapolicydReloadFail("failed to write reload byte to pipe".to_string()))
-// }
+pub fn signal_trust_reload() -> Result<(), Error> {
+    let mut fifo = std::fs::OpenOptions::new()
+        .write(true)
+        .read(false)
+        .open(FIFO_PIPE)
+        .map_err(|_| FapolicydReloadFail("failed to open fifo pipe".to_string()))?;
+
+    fifo.write_all("1".as_bytes())
+        .map_err(|_| FapolicydReloadFail("failed to write reload byte to pipe".to_string()))
+}
 
 const RETRIES: u8 = 15;
 pub fn reload() -> Result<(), Error> {

--- a/crates/daemon/src/fapolicyd.rs
+++ b/crates/daemon/src/fapolicyd.rs
@@ -8,7 +8,6 @@
 
 // todo;; tracking the fapolicyd specific bits in here to determine if bindings are worthwhile
 
-use std::io::Write;
 use std::thread::sleep;
 use std::time::Duration;
 
@@ -32,18 +31,6 @@ const USR_SHARE_ALLOWED_EXTS: [&str; 15] = [
 pub enum Version {
     Unknown,
     Release { major: u8, minor: u8, patch: u8 },
-}
-
-/// send signal to fapolicyd FIFO pipe to reload the trust database
-pub fn signal_trust_reload() -> Result<(), Error> {
-    let mut fifo = std::fs::OpenOptions::new()
-        .write(true)
-        .read(false)
-        .open(FIFO_PIPE)
-        .map_err(|_| FapolicydReloadFail("failed to open fifo pipe".to_string()))?;
-
-    fifo.write_all("1".as_bytes())
-        .map_err(|_| FapolicydReloadFail("failed to write reload byte to pipe".to_string()))
 }
 
 const RETRIES: u8 = 15;

--- a/crates/daemon/src/fapolicyd.rs
+++ b/crates/daemon/src/fapolicyd.rs
@@ -32,7 +32,7 @@ pub enum Version {
 }
 
 /// send signal to fapolicyd FIFO pipe to reload the trust database
-pub fn reload_databases() -> Result<(), Error> {
+pub fn reload_trust_database() -> Result<(), Error> {
     let mut fifo = std::fs::OpenOptions::new()
         .write(true)
         .read(false)

--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -13,5 +13,4 @@ pub use fapolicyd::reload;
 pub mod rpm;
 pub use rpm::fapolicyd_version as version;
 
-#[cfg(feature = "systemd")]
 pub mod svc;

--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -8,7 +8,7 @@
 
 pub mod error;
 pub mod fapolicyd;
-pub use fapolicyd::reload_trust_database;
+pub use fapolicyd::reload;
 
 pub mod rpm;
 pub use rpm::fapolicyd_version as version;

--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -8,7 +8,7 @@
 
 pub mod error;
 pub mod fapolicyd;
-pub use fapolicyd::reload_databases;
+pub use fapolicyd::reload_trust_database;
 
 pub mod rpm;
 pub use rpm::fapolicyd_version as version;

--- a/crates/pyo3/Cargo.toml
+++ b/crates/pyo3/Cargo.toml
@@ -15,6 +15,6 @@ similar = "2.1"
 fapolicy-api = { version = "*", path = "../api" }
 fapolicy-analyzer = { version = "*", path = "../analyzer" }
 fapolicy-app = { version = "*", path = "../app" }
-fapolicy-daemon = { version = "*", path = "../daemon", features = ["systemd"] }
+fapolicy-daemon = { version = "*", path = "../daemon" }
 fapolicy-rules = { version = "*", path = "../rules" }
 fapolicy-trust = { version = "*", path = "../trust" }

--- a/crates/pyo3/src/daemon.rs
+++ b/crates/pyo3/src/daemon.rs
@@ -66,9 +66,10 @@ impl PyHandle {
 
     /// returns the unit status, throws if invalid unit
     pub fn is_active(&self) -> PyResult<bool> {
-        self.rs
-            .active()
-            .map_err(|e| PyRuntimeError::new_err(format!("{:?}", e)))
+        Ok(true)
+        // self.rs
+        //     .active()
+        //     .map_err(|e| PyRuntimeError::new_err(format!("{:?}", e)))
     }
 
     /// returns true if the unit exists, false otherwise

--- a/crates/pyo3/src/daemon.rs
+++ b/crates/pyo3/src/daemon.rs
@@ -66,10 +66,9 @@ impl PyHandle {
 
     /// returns the unit status, throws if invalid unit
     pub fn is_active(&self) -> PyResult<bool> {
-        Ok(true)
-        // self.rs
-        //     .active()
-        //     .map_err(|e| PyRuntimeError::new_err(format!("{:?}", e)))
+        self.rs
+            .active()
+            .map_err(|e| PyRuntimeError::new_err(format!("{:?}", e)))
     }
 
     /// returns true if the unit exists, false otherwise
@@ -80,7 +79,7 @@ impl PyHandle {
 
 #[pyfunction]
 fn start_fapolicyd() -> PyResult<()> {
-    match fapolicy_daemon::svc::Handle::default().start() {
+    match Handle::default().start() {
         Ok(_) => {
             println!("starting fapolicyd daemon");
             Ok(())
@@ -91,7 +90,7 @@ fn start_fapolicyd() -> PyResult<()> {
 
 #[pyfunction]
 fn stop_fapolicyd() -> PyResult<()> {
-    match fapolicy_daemon::svc::Handle::default().stop() {
+    match Handle::default().stop() {
         Ok(_) => {
             println!("stopped fapolicyd daemon");
             Ok(())
@@ -123,7 +122,7 @@ fn rollback_fapolicyd(to: PySystem) -> PyResult<()> {
 
 #[pyfunction]
 fn is_fapolicyd_active() -> PyResult<bool> {
-    fapolicy_daemon::svc::Handle::default()
+    Handle::default()
         .active()
         .map_err(|e| PyRuntimeError::new_err(format!("{:?}", e)))
 }

--- a/crates/pyo3/src/daemon.rs
+++ b/crates/pyo3/src/daemon.rs
@@ -114,10 +114,10 @@ fn fapolicyd_version() -> Option<String> {
 #[pyfunction]
 fn rollback_fapolicyd(to: PySystem) -> PyResult<()> {
     stop_fapolicyd()
-        .and_then(|_| wait_for_daemon(false))
+        .and_then(|_| wait_for_daemon(State::Down))
         .and_then(|_| to.deploy_only())
         .and_then(|_| start_fapolicyd())
-        .and_then(|_| wait_for_daemon(true))
+        .and_then(|_| wait_for_daemon(State::Up))
 }
 
 #[pyfunction]
@@ -127,10 +127,16 @@ fn is_fapolicyd_active() -> PyResult<bool> {
         .map_err(|e| PyRuntimeError::new_err(format!("{:?}", e)))
 }
 
-fn wait_for_daemon(active: bool) -> PyResult<()> {
+enum State {
+    Up,
+    Down,
+}
+
+fn wait_for_daemon(state: State) -> PyResult<()> {
+    let dir: bool = matches!(state, State::Up);
     for _ in 0..10 {
         sleep(Duration::from_secs(1));
-        if active
+        if dir
             == Handle::default()
                 .active()
                 .map_err(|e| PyRuntimeError::new_err(format!("{:?}", e)))?

--- a/crates/pyo3/src/rules.rs
+++ b/crates/pyo3/src/rules.rs
@@ -146,11 +146,11 @@ impl PyChangeset {
     }
 
     pub fn set(&mut self, text: &str) -> bool {
-        self.rs.set(&text.trim()).is_ok()
+        self.rs.set(text.trim()).is_ok()
     }
 
     pub fn parse(&mut self, text: &str) -> PyResult<()> {
-        match self.rs.set(&text.trim()) {
+        match self.rs.set(text.trim()) {
             Ok(_) => Ok(()),
             Err(MalformedFileMarker(lnum, txt)) => Err(exceptions::PyRuntimeError::new_err(
                 format!("{}:malformed-file-marker:{}", lnum, txt),

--- a/crates/pyo3/src/system.rs
+++ b/crates/pyo3/src/system.rs
@@ -100,7 +100,7 @@ impl PySystem {
     /// Update the host system with this state of this System and signal fapolicyd to reload trust
     pub fn deploy(&self) -> PyResult<()> {
         self.deploy_only().and_then(|_| {
-            fapolicy_daemon::reload_trust_database()
+            fapolicy_daemon::reload()
                 .map_err(|e| exceptions::PyRuntimeError::new_err(format!("{:?}", e)))
         })
     }

--- a/crates/pyo3/src/system.rs
+++ b/crates/pyo3/src/system.rs
@@ -100,7 +100,7 @@ impl PySystem {
     /// Update the host system with this state of this System and signal fapolicyd to reload trust
     pub fn deploy(&self) -> PyResult<()> {
         self.deploy_only().and_then(|_| {
-            fapolicy_daemon::reload_databases()
+            fapolicy_daemon::reload_trust_database()
                 .map_err(|e| exceptions::PyRuntimeError::new_err(format!("{:?}", e)))
         })
     }


### PR DESCRIPTION
The reload for trust used a signal through a fifo pipe to have fapolicyd reload the trust db.  To support rule deployments we need to reload the systemd service.  In all cases we will no bring down the daemon to update configuration as there is no way we can guarantee that the write to disk would be successful while fapolicyd is up.

Closes #547
Closes #544