### PR TITLE
Add rules validation to rule text edit

### DIFF
--- a/fapolicy_analyzer/locale/fapolicy_analyzer.pot
+++ b/fapolicy_analyzer/locale/fapolicy_analyzer.pot
@@ -7,9 +7,9 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: fapolicy-analyzer 0.3.1+101.ga756fb6.dirty\n"
+"Project-Id-Version: fapolicy-analyzer 0.3.1+104.g7857488.dirty\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2022-07-28 09:31-0400\n"
+"POT-Creation-Date: 2022-07-28 14:29-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -104,8 +104,8 @@ msgstr ""
 
 #: fapolicy_analyzer/ui/strings.py:27
 msgid ""
-"Save failed. The current rule text is not valid. See Status Information "
-"for details."
+"The current rule text is not valid and cannot be saved. See Status "
+"Information for details."
 msgstr ""
 
 #: fapolicy_analyzer/ui/strings.py:30
@@ -537,11 +537,11 @@ msgid "Remove Deleted Files"
 msgstr ""
 
 #: fapolicy_analyzer/glade/rules_admin_page.glade:50
-msgid "Guided Editor"
+msgid "Rules Editor"
 msgstr ""
 
 #: fapolicy_analyzer/glade/rules_admin_page.glade:73
-msgid "Text Editor"
+msgid "Rules View"
 msgstr ""
 
 #: fapolicy_analyzer/glade/rules_status_info.glade:55

--- a/fapolicy_analyzer/locale/fapolicy_analyzer.pot
+++ b/fapolicy_analyzer/locale/fapolicy_analyzer.pot
@@ -7,9 +7,9 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: fapolicy-analyzer 0.3.1+99.ga13cd40.dirty\n"
+"Project-Id-Version: fapolicy-analyzer 0.3.1+101.ga756fb6.dirty\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2022-07-27 10:10-0400\n"
+"POT-Creation-Date: 2022-07-28 09:31-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -103,7 +103,9 @@ msgid "Error reading the Rules file"
 msgstr ""
 
 #: fapolicy_analyzer/ui/strings.py:27
-msgid "The current rule text is not valid. See Status Information for details."
+msgid ""
+"Save failed. The current rule text is not valid. See Status Information "
+"for details."
 msgstr ""
 
 #: fapolicy_analyzer/ui/strings.py:30

--- a/fapolicy_analyzer/locale/fapolicy_analyzer.pot
+++ b/fapolicy_analyzer/locale/fapolicy_analyzer.pot
@@ -7,9 +7,9 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: fapolicy-analyzer 0.3.1+100.gf93af5f\n"
+"Project-Id-Version: fapolicy-analyzer 0.3.1+99.ga13cd40.dirty\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2022-07-26 11:10-0400\n"
+"POT-Creation-Date: 2022-07-27 10:10-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -103,156 +103,164 @@ msgid "Error reading the Rules file"
 msgstr ""
 
 #: fapolicy_analyzer/ui/strings.py:27
-msgid "Rule"
+msgid "The current rule text is not valid. See Status Information for details."
 msgstr ""
 
-#: fapolicy_analyzer/ui/strings.py:28
-msgid "Rules"
-msgstr ""
-
-#: fapolicy_analyzer/ui/strings.py:29
-msgid "Error initializing communications with daemon"
-msgstr ""
-
-#: fapolicy_analyzer/ui/strings.py:32
-msgid "Action"
+#: fapolicy_analyzer/ui/strings.py:30
+msgid "The current rule text has warnings. See Status Information for details."
 msgstr ""
 
 #: fapolicy_analyzer/ui/strings.py:33
-msgid "Change"
+msgid "Rule"
 msgstr ""
 
 #: fapolicy_analyzer/ui/strings.py:34
-msgid "Changes successfully deployed."
+msgid "Rules"
 msgstr ""
 
 #: fapolicy_analyzer/ui/strings.py:35
-msgid "An error occurred trying to deploy the changes. Please try again."
+msgid "Error initializing communications with daemon"
+msgstr ""
+
+#: fapolicy_analyzer/ui/strings.py:38
+msgid "Action"
 msgstr ""
 
 #: fapolicy_analyzer/ui/strings.py:39
-msgid "This file is trusted in the System Trust Database."
+msgid "Change"
 msgstr ""
 
 #: fapolicy_analyzer/ui/strings.py:40
+msgid "Changes successfully deployed."
+msgstr ""
+
+#: fapolicy_analyzer/ui/strings.py:41
+msgid "An error occurred trying to deploy the changes. Please try again."
+msgstr ""
+
+#: fapolicy_analyzer/ui/strings.py:45
+msgid "This file is trusted in the System Trust Database."
+msgstr ""
+
+#: fapolicy_analyzer/ui/strings.py:46
 msgid "There is a discrepancy between this file and the System Trust Database."
 msgstr ""
 
-#: fapolicy_analyzer/ui/strings.py:43
+#: fapolicy_analyzer/ui/strings.py:49
 msgid "The trust status of this file is unknown in the System Trust Database."
 msgstr ""
 
-#: fapolicy_analyzer/ui/strings.py:47
+#: fapolicy_analyzer/ui/strings.py:53
 msgid "This file is trusted in the Ancillary Trust Database."
 msgstr ""
 
-#: fapolicy_analyzer/ui/strings.py:50
+#: fapolicy_analyzer/ui/strings.py:56
 msgid "There is a discrepancy between this file and the Ancillary Trust Database."
 msgstr ""
 
-#: fapolicy_analyzer/ui/strings.py:53
+#: fapolicy_analyzer/ui/strings.py:59
 msgid "The trust status of this file is unknown in the Ancillary Trust Database."
 msgstr ""
 
-#: fapolicy_analyzer/ui/strings.py:57
+#: fapolicy_analyzer/ui/strings.py:63
 msgid "The trust status of this file is unknown"
 msgstr ""
 
-#: fapolicy_analyzer/ui/strings.py:59
+#: fapolicy_analyzer/ui/strings.py:65
 msgid "System Trust Database"
 msgstr ""
 
-#: fapolicy_analyzer/ui/strings.py:60
+#: fapolicy_analyzer/ui/strings.py:66
 msgid "Ancillary Trust Database"
 msgstr ""
 
 #: fapolicy_analyzer/glade/ancillary_trust_database_admin.glade:60
 #: fapolicy_analyzer/glade/trust_reconciliation_dialog.glade:41
-#: fapolicy_analyzer/ui/strings.py:62
+#: fapolicy_analyzer/ui/strings.py:68
 msgid "Trust"
 msgstr ""
 
-#: fapolicy_analyzer/ui/strings.py:63
+#: fapolicy_analyzer/ui/strings.py:69
 msgid "File"
 msgstr ""
 
-#: fapolicy_analyzer/ui/strings.py:64
+#: fapolicy_analyzer/ui/strings.py:70
 msgid "MTime"
 msgstr ""
 
-#: fapolicy_analyzer/ui/strings.py:65
+#: fapolicy_analyzer/ui/strings.py:71
 msgid "Changes"
 msgstr ""
 
-#: fapolicy_analyzer/ui/strings.py:66
+#: fapolicy_analyzer/ui/strings.py:72
 msgid "Mode"
 msgstr ""
 
-#: fapolicy_analyzer/ui/strings.py:67
+#: fapolicy_analyzer/ui/strings.py:73
 msgid "Access"
 msgstr ""
 
-#: fapolicy_analyzer/ui/strings.py:69
+#: fapolicy_analyzer/ui/strings.py:75
 msgid "Add"
 msgstr ""
 
-#: fapolicy_analyzer/ui/strings.py:70
+#: fapolicy_analyzer/ui/strings.py:76
 msgid "Delete"
 msgstr ""
 
-#: fapolicy_analyzer/ui/strings.py:71
+#: fapolicy_analyzer/ui/strings.py:77
 msgid "Add Trust"
 msgstr ""
 
-#: fapolicy_analyzer/ui/strings.py:72
+#: fapolicy_analyzer/ui/strings.py:78
 msgid "Delete Trust"
 msgstr ""
 
-#: fapolicy_analyzer/ui/strings.py:73
+#: fapolicy_analyzer/ui/strings.py:79
 msgid "Edit Rules"
 msgstr ""
 
-#: fapolicy_analyzer/ui/strings.py:75
+#: fapolicy_analyzer/ui/strings.py:81
 msgid "Add File"
 msgstr ""
 
-#: fapolicy_analyzer/ui/strings.py:76
+#: fapolicy_analyzer/ui/strings.py:82
 msgid "Open File"
 msgstr ""
 
-#: fapolicy_analyzer/ui/strings.py:77
+#: fapolicy_analyzer/ui/strings.py:83
 msgid "Save As..."
 msgstr ""
 
-#: fapolicy_analyzer/ui/strings.py:78
+#: fapolicy_analyzer/ui/strings.py:84
 msgid "FA Session files"
 msgstr ""
 
-#: fapolicy_analyzer/ui/strings.py:79
+#: fapolicy_analyzer/ui/strings.py:85
 msgid "fapolicyd archive files"
 msgstr ""
 
-#: fapolicy_analyzer/ui/strings.py:80
+#: fapolicy_analyzer/ui/strings.py:86
 msgid "Any files"
 msgstr ""
 
-#: fapolicy_analyzer/ui/strings.py:82
+#: fapolicy_analyzer/ui/strings.py:88
 msgid "Profiling target file chown failure"
 msgstr ""
 
-#: fapolicy_analyzer/ui/strings.py:83
+#: fapolicy_analyzer/ui/strings.py:89
 msgid "Profiling target Popen failure"
 msgstr ""
 
-#: fapolicy_analyzer/ui/strings.py:84
+#: fapolicy_analyzer/ui/strings.py:90
 msgid "Profiling target redirection failure"
 msgstr ""
 
-#: fapolicy_analyzer/ui/strings.py:86
+#: fapolicy_analyzer/ui/strings.py:92
 msgid "File path(s) contains embedded whitespace."
 msgstr ""
 
-#: fapolicy_analyzer/ui/strings.py:87
+#: fapolicy_analyzer/ui/strings.py:93
 msgid ""
 "fapolicyd currently does not support paths containing spaces. The "
 "following paths will not be added to the Trusted Files List.\n"
@@ -260,7 +268,7 @@ msgid ""
 "\n"
 msgstr ""
 
-#: fapolicy_analyzer/ui/strings.py:92
+#: fapolicy_analyzer/ui/strings.py:98
 msgid ""
 "\n"
 "        Restore your prior session now?\n"
@@ -277,57 +285,57 @@ msgid ""
 "        "
 msgstr ""
 
-#: fapolicy_analyzer/ui/strings.py:108
+#: fapolicy_analyzer/ui/strings.py:114
 msgid "An error occurred trying to restore a prior autosaved edit session"
 msgstr ""
 
-#: fapolicy_analyzer/glade/loader.glade:45 fapolicy_analyzer/ui/strings.py:112
+#: fapolicy_analyzer/glade/loader.glade:45 fapolicy_analyzer/ui/strings.py:118
 msgid "Loading..."
 msgstr ""
 
-#: fapolicy_analyzer/ui/strings.py:114
+#: fapolicy_analyzer/ui/strings.py:120
 msgid "file"
 msgstr ""
 
-#: fapolicy_analyzer/ui/strings.py:115
+#: fapolicy_analyzer/ui/strings.py:121
 msgid "files"
 msgstr ""
 
-#: fapolicy_analyzer/ui/strings.py:116
+#: fapolicy_analyzer/ui/strings.py:122
 msgid "user"
 msgstr ""
 
-#: fapolicy_analyzer/ui/strings.py:117
+#: fapolicy_analyzer/ui/strings.py:123
 msgid "users"
 msgstr ""
 
-#: fapolicy_analyzer/ui/strings.py:118
+#: fapolicy_analyzer/ui/strings.py:124
 msgid "group"
 msgstr ""
 
-#: fapolicy_analyzer/ui/strings.py:119
+#: fapolicy_analyzer/ui/strings.py:125
 msgid "groups"
 msgstr ""
 
-#: fapolicy_analyzer/ui/strings.py:120
+#: fapolicy_analyzer/ui/strings.py:126
 msgid ""
 "An error occurred trying to parse the event log file. Please try again or"
 " select a different file."
 msgstr ""
 
-#: fapolicy_analyzer/ui/strings.py:123
+#: fapolicy_analyzer/ui/strings.py:129
 msgid "An error occurred trying to retrieve the user list. Please try again."
 msgstr ""
 
-#: fapolicy_analyzer/ui/strings.py:126
+#: fapolicy_analyzer/ui/strings.py:132
 msgid "An error occurred trying to retrieve the group list. Please try again."
 msgstr ""
 
-#: fapolicy_analyzer/ui/strings.py:130
+#: fapolicy_analyzer/ui/strings.py:136
 msgid "Trust Database"
 msgstr ""
 
-#: fapolicy_analyzer/ui/strings.py:131
+#: fapolicy_analyzer/ui/strings.py:137
 msgid ""
 "\n"
 "The fapolicyd trusted resources database\n"
@@ -352,7 +360,7 @@ msgid ""
 "    "
 msgstr ""
 
-#: fapolicy_analyzer/ui/strings.py:155
+#: fapolicy_analyzer/ui/strings.py:161
 msgid "Error applying changes"
 msgstr ""
 
@@ -412,17 +420,17 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: fapolicy_analyzer/glade/confirm_deployment_dialog.glade:7
+#: fapolicy_analyzer/glade/confirm_deployment_dialog.glade:23
 msgid "Deploy Changesets?"
 msgstr ""
 
-#: fapolicy_analyzer/glade/confirm_deployment_dialog.glade:71
+#: fapolicy_analyzer/glade/confirm_deployment_dialog.glade:87
 msgid ""
 "Are you sure you wish to deploy your changes to the fapolicyd?\n"
 "This will update fapolicyd and restart the service."
 msgstr ""
 
-#: fapolicy_analyzer/glade/confirm_deployment_dialog.glade:111
+#: fapolicy_analyzer/glade/confirm_deployment_dialog.glade:127
 msgid ""
 "\"Save As...\" fapolicyd data and configuration to archive prior to "
 "deployment."

--- a/fapolicy_analyzer/tests/rules/test_rules_admin_page.py
+++ b/fapolicy_analyzer/tests/rules/test_rules_admin_page.py
@@ -185,7 +185,7 @@ def test_handles_rule_text_change(widget, mock_dispatch):
 
 
 def test_save_click(widget, mock_dispatch):
-    widget._text_view.rules_changed("modified rules")
+    widget._text_view.rules_changed("allow perm=any all : all")
     widget.on_save_clicked()
     mock_dispatch.assert_called_with(InstanceOf(Action) & Attrs(type=APPLY_CHANGESETS))
 

--- a/fapolicy_analyzer/tests/test_changeset_wrapper.py
+++ b/fapolicy_analyzer/tests/test_changeset_wrapper.py
@@ -58,6 +58,15 @@ def test_RuleChangeset_set(mocker):
     mock().set.assert_called_with("foo")
 
 
+def test_RuleChangeset_rules(mocker):
+    mock = mocker.patch(
+        "fapolicy_analyzer.ui.changeset_wrapper.fapolicy_analyzer.RuleChangeset"
+    )
+    sut = RuleChangeset()
+    sut.rules()
+    mock().rules.assert_called()
+
+
 def test_RuleChangeset_serialize():
     sut = RuleChangeset()
     sut.set("foo")

--- a/fapolicy_analyzer/ui/changeset_wrapper.py
+++ b/fapolicy_analyzer/ui/changeset_wrapper.py
@@ -56,6 +56,9 @@ class RuleChangeset(Changeset[str]):
     def set(self, change: str):
         self.__wrapped.set(change)
 
+    def rules(self):
+        return self.__wrapped.rules()
+
     def apply_to_system(self, system: System) -> System:
         return system.apply_rule_changes(self.__wrapped)
 

--- a/fapolicy_analyzer/ui/confirm_deployment_dialog.py
+++ b/fapolicy_analyzer/ui/confirm_deployment_dialog.py
@@ -78,23 +78,12 @@ class ConfirmDeploymentDialog(UIBuilderWidget):
             diffs = rules_difference(previous_system, current_system).split("\n")
             adds = len([d for d in diffs if d.startswith("+")])
             dels = len([d for d in diffs if d.startswith("-")])
-            message = (
-                " and ".join(
-                    (
-                        m
-                        for m in [
-                            f"{adds} addition{'s' if adds > 1 else ''}"
-                            if adds
-                            else None,
-                            f"{dels} removal{'s' if dels > 1 else ''}"
-                            if dels
-                            else None,
-                        ]
-                        if m
-                    )
-                )
-                + " made"
-            )
+            if (adds + dels) == 0:
+                return []
+
+            add_text = f"{adds} addition{'s' if adds > 1 else ''}" if adds else None
+            del_text = f"{dels} removal{'s' if dels > 1 else ''}" if dels else None
+            message = " and ".join((m for m in [add_text, del_text] if m)) + " made"
             return [(_(message), "Rules")]
 
         def trust_changes():

--- a/fapolicy_analyzer/ui/rules/rules_admin_page.py
+++ b/fapolicy_analyzer/ui/rules/rules_admin_page.py
@@ -109,6 +109,8 @@ class RulesAdminPage(UIConnectedWidget, UIPage):
 
     def __valid_changes(self, changeset: RuleChangeset) -> bool:
         rules = changeset.rules()
+        for r in rules:
+            print(r, [(i.category, i.message) for i in r.info])
         if not all([r.is_valid for r in rules]):
             dispatch(
                 add_notification(

--- a/fapolicy_analyzer/ui/rules/rules_admin_page.py
+++ b/fapolicy_analyzer/ui/rules/rules_admin_page.py
@@ -109,8 +109,7 @@ class RulesAdminPage(UIConnectedWidget, UIPage):
 
     def __valid_changes(self, changeset: RuleChangeset) -> bool:
         rules = changeset.rules()
-        for r in rules:
-            print(r, [(i.category, i.message) for i in r.info])
+
         if not all([r.is_valid for r in rules]):
             dispatch(
                 add_notification(

--- a/fapolicy_analyzer/ui/strings.py
+++ b/fapolicy_analyzer/ui/strings.py
@@ -25,7 +25,7 @@ RULES_LOAD_ERROR = _("Error loading Rules")
 RULES_TEXT_LOAD_ERROR = _("Error loading Rules text")
 RULES_FILE_READ_ERROR = _("Error reading the Rules file")
 RULES_VALIDATION_ERROR = _(
-    "The current rule text is not valid. See Status Information for details."
+    "Save failed. The current rule text is not valid. See Status Information for details."
 )
 RULES_VALIDATION_WARNING = _(
     "The current rule text has warnings. See Status Information for details."

--- a/fapolicy_analyzer/ui/strings.py
+++ b/fapolicy_analyzer/ui/strings.py
@@ -24,6 +24,12 @@ SYSTEM_TRUST_LOAD_ERROR = _("Error loading System Trust")
 RULES_LOAD_ERROR = _("Error loading Rules")
 RULES_TEXT_LOAD_ERROR = _("Error loading Rules text")
 RULES_FILE_READ_ERROR = _("Error reading the Rules file")
+RULES_VALIDATION_ERROR = _(
+    "The current rule text is not valid. See Status Information for details."
+)
+RULES_VALIDATION_WARNING = _(
+    "The current rule text has warnings. See Status Information for details."
+)
 RULE_LABEL = _("Rule")
 RULES_LABEL = _("Rules")
 DAEMON_INITIALIZATION_ERROR = _("Error initializing communications with daemon")

--- a/fapolicy_analyzer/ui/strings.py
+++ b/fapolicy_analyzer/ui/strings.py
@@ -25,7 +25,7 @@ RULES_LOAD_ERROR = _("Error loading Rules")
 RULES_TEXT_LOAD_ERROR = _("Error loading Rules text")
 RULES_FILE_READ_ERROR = _("Error reading the Rules file")
 RULES_VALIDATION_ERROR = _(
-    "Save failed. The current rule text is not valid. See Status Information for details."
+    "The current rule text is not valid and cannot be saved. See Status Information for details."
 )
 RULES_VALIDATION_WARNING = _(
     "The current rule text has warnings. See Status Information for details."


### PR DESCRIPTION
Adds a new validate button to the toolbar to validate rule changes prior to saving. If there are errors or warnings a toaster message is show and the Status Information section is updated. The Save button was also update to not allow saving if there are invalid rules in the text.

closes #559 