### PR TITLE
Renamed and reordered tabs in Rules Admin tool

### DIFF
--- a/fapolicy_analyzer/glade/rules_admin_page.glade
+++ b/fapolicy_analyzer/glade/rules_admin_page.glade
@@ -34,7 +34,7 @@
             <property name="visible">True</property>
             <property name="can_focus">True</property>
             <child>
-              <object class="GtkBox" id="guidedEditorContent">
+              <object class="GtkBox" id="editorViewContent">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="orientation">vertical</property>
@@ -44,17 +44,17 @@
               </object>
             </child>
             <child type="tab">
-              <object class="GtkLabel" id="tableView">
+              <object class="GtkLabel" id="editorView">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="label" translatable="yes">Guided Editor</property>
+                <property name="label" translatable="yes">Rules Editor</property>
               </object>
               <packing>
                 <property name="tab_fill">False</property>
               </packing>
             </child>
             <child>
-              <object class="GtkBox" id="textEditorContent">
+              <object class="GtkBox" id="rulesViewContent">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="orientation">vertical</property>
@@ -67,10 +67,10 @@
               </packing>
             </child>
             <child type="tab">
-              <object class="GtkLabel" id="textView">
+              <object class="GtkLabel" id="rulesView">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="label" translatable="yes">Text Editor</property>
+                <property name="label" translatable="yes">Rules View</property>
               </object>
               <packing>
                 <property name="position">1</property>

--- a/fapolicy_analyzer/ui/rules/rules_admin_page.py
+++ b/fapolicy_analyzer/ui/rules/rules_admin_page.py
@@ -73,13 +73,13 @@ class RulesAdminPage(UIConnectedWidget, UIPage):
 
     def __init_child_widgets(self):
         self._text_view: RulesTextView = RulesTextView()
-        self.get_object("textEditorContent").pack_start(
+        self.get_object("editorViewContent").pack_start(
             self._text_view.get_ref(), True, True, 0
         )
         self._text_view.rules_changed += self.on_text_view_rules_changed
 
         self._list_view: RulesListView = RulesListView()
-        self.get_object("guidedEditorContent").pack_start(
+        self.get_object("rulesViewContent").pack_start(
             self._list_view.get_ref(), True, True, 0
         )
 


### PR DESCRIPTION
Reordered the tabs so the rules text editor was first. Also renamed the tabs to "Rules Editor" and "Rules View".