### PR TITLE
Active checks with dbus

### DIFF
--- a/crates/daemon/src/error.rs
+++ b/crates/daemon/src/error.rs
@@ -23,7 +23,4 @@ pub enum Error {
 
     #[error("{0}")]
     ServiceCheckFailure(String),
-
-    #[error("Failed to parse systemctl output")]
-    ServiceCheckParseFailure(#[from] FromUtf8Error),
 }

--- a/crates/daemon/src/error.rs
+++ b/crates/daemon/src/error.rs
@@ -6,7 +6,6 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use std::string::FromUtf8Error;
 use thiserror::Error;
 
 // errors that can occur in this crate

--- a/crates/daemon/src/fapolicyd.rs
+++ b/crates/daemon/src/fapolicyd.rs
@@ -8,13 +8,6 @@
 
 // todo;; tracking the fapolicyd specific bits in here to determine if bindings are worthwhile
 
-use std::thread::sleep;
-use std::time::Duration;
-
-use crate::error::Error;
-use crate::error::Error::FapolicydReloadFail;
-use crate::svc::Handle;
-
 pub const TRUST_DB_PATH: &str = "/var/lib/fapolicyd";
 pub const TRUST_DB_NAME: &str = "trust.db";
 pub const TRUST_FILE_PATH: &str = "/etc/fapolicyd/fapolicyd.trust";
@@ -31,28 +24,6 @@ const USR_SHARE_ALLOWED_EXTS: [&str; 15] = [
 pub enum Version {
     Unknown,
     Release { major: u8, minor: u8, patch: u8 },
-}
-
-const RETRIES: u8 = 15;
-pub fn reload() -> Result<(), Error> {
-    let fapolicyd = Handle::default();
-    fapolicyd.stop()?;
-    for _ in 0..RETRIES {
-        sleep(Duration::from_secs(1));
-        if !fapolicyd.active()? {
-            fapolicyd.start()?;
-            break;
-        }
-    }
-    for _ in 0..RETRIES {
-        sleep(Duration::from_secs(1));
-        if fapolicyd.active()? {
-            return Ok(());
-        }
-    }
-    Err(FapolicydReloadFail(
-        "Could not reload after 10 tries".to_string(),
-    ))
 }
 
 /// filtering logic as implemented by fapolicyd rpm backend

--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -8,7 +8,6 @@
 
 pub mod error;
 pub mod fapolicyd;
-pub use fapolicyd::reload;
 
 pub mod rpm;
 pub use rpm::fapolicyd_version as version;

--- a/crates/daemon/src/svc.rs
+++ b/crates/daemon/src/svc.rs
@@ -8,7 +8,6 @@
 
 use dbus::arg::messageitem::MessageItem;
 use std::fmt;
-use std::process::Command;
 use std::time::Duration;
 
 use dbus::blocking::{BlockingSender, Connection};

--- a/crates/daemon/src/svc.rs
+++ b/crates/daemon/src/svc.rs
@@ -61,7 +61,7 @@ impl Default for Handle {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub enum State {
     Active,
     Inactive,

--- a/crates/daemon/src/svc.rs
+++ b/crates/daemon/src/svc.rs
@@ -69,6 +69,17 @@ pub enum State {
     Other(String),
 }
 
+impl State {
+    pub fn can_be(&self, other: State) -> bool {
+        use State::*;
+
+        match self {
+            Inactive if other == Failed => true,
+            _ => *self == other,
+        }
+    }
+}
+
 impl Handle {
     pub fn new(name: &str) -> Handle {
         Handle {
@@ -124,5 +135,18 @@ impl Handle {
                 "DBUS unit active check failed".to_string(),
             ))
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::svc::State::*;
+
+    #[test]
+    fn state_can_be() {
+        // Failed is Inactive
+        assert!(Inactive.can_be(Failed));
+        // Inactive is not Failed
+        assert!(!Failed.can_be(Inactive));
     }
 }

--- a/crates/daemon/src/svc.rs
+++ b/crates/daemon/src/svc.rs
@@ -148,5 +148,7 @@ mod tests {
         assert!(Inactive.can_be(Failed));
         // Inactive is not Failed
         assert!(!Failed.can_be(Inactive));
+        // Identity
+        assert!(Active.can_be(Active))
     }
 }

--- a/crates/daemon/src/svc.rs
+++ b/crates/daemon/src/svc.rs
@@ -93,6 +93,7 @@ impl Handle {
         let p = Props::new(
             &c,
             "org.freedesktop.systemd1",
+            // todo;; the path name may need to be fetched dynamically via a Message
             format!("/org/freedesktop/systemd1/unit/{}_2eservice", self.name),
             "org.freedesktop.systemd1.Unit",
             5000,

--- a/crates/pyo3/src/daemon.rs
+++ b/crates/pyo3/src/daemon.rs
@@ -137,10 +137,10 @@ fn wait_for_daemon(target_state: State) -> PyResult<()> {
         sleep(Duration::from_secs(1));
         if Handle::default()
             .state()
-            .map(|state| state == target_state)
+            .map(|state| target_state.can_be(state))
             .unwrap_or(false)
         {
-            eprintln!("daemon is now {target_state:?}");
+            eprintln!("done waiting, daemon is {target_state:?}");
             return Ok(());
         }
     }

--- a/crates/pyo3/src/daemon.rs
+++ b/crates/pyo3/src/daemon.rs
@@ -131,6 +131,7 @@ fn is_fapolicyd_active() -> PyResult<bool> {
         .map_err(|e| PyRuntimeError::new_err(format!("{:?}", e)))
 }
 
+#[derive(Debug)]
 enum State {
     Up,
     Down,
@@ -139,11 +140,14 @@ enum State {
 fn wait_for_daemon(state: State) -> PyResult<()> {
     let dir: bool = matches!(state, State::Up);
     for _ in 0..10 {
+        println!("waiting on daemon {dir}...");
         sleep(Duration::from_secs(1));
         if dir == Handle::default().active().unwrap_or(!dir) {
+            println!("daemon is {state:?}...");
             return Ok(());
         }
     }
+    println!("daemon is unresponsive...");
     Err(PyRuntimeError::new_err("Daemon unresponsive"))
 }
 

--- a/crates/pyo3/src/daemon.rs
+++ b/crates/pyo3/src/daemon.rs
@@ -121,6 +121,11 @@ pub(crate) fn deploy(system: &PySystem) -> PyResult<()> {
 }
 
 #[pyfunction]
+fn rollback_fapolicyd(to: PySystem) -> PyResult<()> {
+    deploy(&to)
+}
+
+#[pyfunction]
 fn is_fapolicyd_active() -> PyResult<bool> {
     Handle::default()
         .active()
@@ -148,6 +153,7 @@ pub fn init_module(_py: Python, m: &PyModule) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(fapolicyd_version, m)?)?;
     m.add_function(wrap_pyfunction!(start_fapolicyd, m)?)?;
     m.add_function(wrap_pyfunction!(stop_fapolicyd, m)?)?;
+    m.add_function(wrap_pyfunction!(rollback_fapolicyd, m)?)?;
     m.add_function(wrap_pyfunction!(is_fapolicyd_active, m)?)?;
     Ok(())
 }

--- a/crates/pyo3/src/daemon.rs
+++ b/crates/pyo3/src/daemon.rs
@@ -116,8 +116,7 @@ pub(crate) fn deploy(system: &PySystem) -> PyResult<()> {
         .and_then(|_| wait_for_daemon(State::Down))
         .and_then(|_| system.deploy_only())
         .and_then(|_| start_fapolicyd())
-        // wait but dont throw
-        .and_then(|_| wait_for_daemon(State::Up).or(Ok(())))
+        .and_then(|_| wait_for_daemon(State::Up))
 }
 
 #[pyfunction]

--- a/crates/pyo3/src/system.rs
+++ b/crates/pyo3/src/system.rs
@@ -19,9 +19,9 @@ use fapolicy_app::sys::deploy_app_state;
 use super::trust::PyTrust;
 use crate::acl::{PyGroup, PyUser};
 use crate::analysis::PyEventLog;
-use crate::rules;
 use crate::rules::PyRule;
 use crate::trust;
+use crate::{daemon, rules};
 
 #[pyclass(module = "app", name = "System")]
 #[derive(Clone)]
@@ -99,10 +99,7 @@ impl PySystem {
 
     /// Update the host system with this state of this System and signal fapolicyd to reload trust
     pub fn deploy(&self) -> PyResult<()> {
-        self.deploy_only().and_then(|_| {
-            fapolicy_daemon::reload()
-                .map_err(|e| exceptions::PyRuntimeError::new_err(format!("{:?}", e)))
-        })
+        daemon::deploy(&self).map_err(|e| exceptions::PyRuntimeError::new_err(format!("{:?}", e)))
     }
 
     /// Update the host system with this state of this System

--- a/crates/pyo3/src/system.rs
+++ b/crates/pyo3/src/system.rs
@@ -99,7 +99,7 @@ impl PySystem {
 
     /// Update the host system with this state of this System and signal fapolicyd to reload trust
     pub fn deploy(&self) -> PyResult<()> {
-        daemon::deploy(&self).map_err(|e| exceptions::PyRuntimeError::new_err(format!("{:?}", e)))
+        daemon::deploy(self).map_err(|e| exceptions::PyRuntimeError::new_err(format!("{:?}", e)))
     }
 
     /// Update the host system with this state of this System


### PR DESCRIPTION
Eliminate the calls to systemctl for service status checks, use dbus instead.  This removes potential pinch point where deployed rules can limit the call to systemctl.

Also updates to align both stages of deployment.  Those stages, deployment and rollback, used to be different in that deployment only was a pipe write, while deployment was a full daemon reload.  Then the pipe write went away, but there were some straggling issues that were left.  This should resolve.

This also fixes the monitoring while fapolicyd is deployed with deny any all all rules.

Closes #565