### PR TITLE
Preserve comments

### DIFF
--- a/crates/pyo3/src/rules.rs
+++ b/crates/pyo3/src/rules.rs
@@ -226,7 +226,7 @@ fn text_for_entry(e: &Entry) -> String {
         ValidSet(s) => s.to_string(),
         RuleWithWarning(r, _) => r.to_string(),
         SetWithWarning(r, _) => r.to_string(),
-        Comment(t) => t.clone(),
+        Comment(text) => format!("#{}", text),
     }
 }
 

--- a/crates/pyo3/src/rules.rs
+++ b/crates/pyo3/src/rules.rs
@@ -10,7 +10,7 @@ use pyo3::prelude::*;
 use pyo3::{exceptions, PyObjectProtocol};
 
 use fapolicy_rules::db::Entry::*;
-use fapolicy_rules::db::DB;
+use fapolicy_rules::db::{Entry, DB};
 use fapolicy_rules::error::Error::MalformedFileMarker;
 use fapolicy_rules::ops::Changeset;
 use fapolicy_rules::parser::parse::StrTrace;
@@ -142,7 +142,7 @@ impl PyChangeset {
     }
 
     pub fn rules(&self) -> Vec<PyRule> {
-        rules_to_vec(self.rs.get())
+        to_vec(self.rs.get())
     }
 
     pub fn set(&mut self, text: &str) -> bool {
@@ -172,7 +172,7 @@ fn rule_text_error_check(txt: &str) -> Option<String> {
     }
 }
 
-pub(crate) fn rules_to_vec(db: &DB) -> Vec<PyRule> {
+pub(crate) fn to_vec(db: &DB) -> Vec<PyRule> {
     db.rules()
         .iter()
         .map(|e| {
@@ -196,24 +196,38 @@ pub(crate) fn rules_to_vec(db: &DB) -> Vec<PyRule> {
         .collect()
 }
 
-pub(crate) fn entries_to_vec(db: &DB) -> Vec<PyRule> {
+pub(crate) fn to_text(db: &DB) -> String {
     db.iter()
-        .map(|(id, (origin, e))| {
-            let (valid, text, info) = match e {
-                Invalid { text, error } => {
-                    (false, text.clone(), vec![("e".to_string(), error.clone())])
-                }
-                InvalidSet { text, error } => {
-                    (false, text.clone(), vec![("e".to_string(), error.clone())])
-                }
-                ValidRule(r) => (true, r.to_string(), vec![]),
-                ValidSet(s) => (true, s.to_string(), vec![]),
-                RuleWithWarning(r, w) => (true, r.to_string(), vec![("w".to_string(), w.clone())]),
-                SetWithWarning(r, w) => (true, r.to_string(), vec![("w".to_string(), w.clone())]),
-            };
-            PyRule::new(*id, text, origin.to_string(), info, valid)
+        .fold((None, String::new()), |x, (id, (origin, e))| match x {
+            // no origin established yet
+            (None, _) => (
+                Some(origin.clone()),
+                format!("[{}]\n{}", origin, text_for_entry(e)),
+            ),
+            // same origin as previous
+            (Some(last_origin), acc_text) if last_origin == *origin => (
+                Some(last_origin),
+                format!("{}\n{}", acc_text, text_for_entry(e)),
+            ),
+            // origin has changed
+            (Some(_), acc_text) => (
+                Some(origin.clone()),
+                format!("{}\n\n[{}]\n{}", acc_text, origin, text_for_entry(e)),
+            ),
         })
-        .collect()
+        .1
+}
+
+fn text_for_entry(e: &Entry) -> String {
+    match e {
+        Invalid { text, error } => text.clone(),
+        InvalidSet { text, error } => text.clone(),
+        ValidRule(r) => r.to_string(),
+        ValidSet(s) => s.to_string(),
+        RuleWithWarning(r, _) => r.to_string(),
+        SetWithWarning(r, _) => r.to_string(),
+        Comment(t) => t.clone(),
+    }
 }
 
 // #[pyfunction]

--- a/crates/pyo3/src/rules.rs
+++ b/crates/pyo3/src/rules.rs
@@ -198,7 +198,7 @@ pub(crate) fn to_vec(db: &DB) -> Vec<PyRule> {
 
 pub(crate) fn to_text(db: &DB) -> String {
     db.iter()
-        .fold((None, String::new()), |x, (id, (origin, e))| match x {
+        .fold((None, String::new()), |x, (_, (origin, e))| match x {
             // no origin established yet
             (None, _) => (
                 Some(origin.clone()),
@@ -220,8 +220,8 @@ pub(crate) fn to_text(db: &DB) -> String {
 
 fn text_for_entry(e: &Entry) -> String {
     match e {
-        Invalid { text, error } => text.clone(),
-        InvalidSet { text, error } => text.clone(),
+        Invalid { text, .. } => text.clone(),
+        InvalidSet { text, .. } => text.clone(),
         ValidRule(r) => r.to_string(),
         ValidSet(s) => s.to_string(),
         RuleWithWarning(r, _) => r.to_string(),

--- a/crates/pyo3/src/rules.rs
+++ b/crates/pyo3/src/rules.rs
@@ -226,7 +226,7 @@ fn text_for_entry(e: &Entry) -> String {
         ValidSet(s) => s.to_string(),
         RuleWithWarning(r, _) => r.to_string(),
         SetWithWarning(r, _) => r.to_string(),
-        Comment(text) => text.clone(),
+        e @ Comment(_) => e.to_string(),
     }
 }
 
@@ -239,4 +239,17 @@ pub fn init_module(_py: Python, m: &PyModule) -> PyResult<()> {
     m.add_class::<PyChangeset>()?;
     m.add_function(wrap_pyfunction!(rule_text_error_check, m)?)?;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::rules::text_for_entry;
+    use fapolicy_rules::db::Entry::Comment;
+
+    #[test]
+    fn test_comment_prefix() {
+        let text = text_for_entry(&Comment("foo".to_string()));
+        assert!(text.starts_with('#'));
+        assert!(text.ends_with("foo"));
+    }
 }

--- a/crates/pyo3/src/rules.rs
+++ b/crates/pyo3/src/rules.rs
@@ -226,7 +226,7 @@ fn text_for_entry(e: &Entry) -> String {
         ValidSet(s) => s.to_string(),
         RuleWithWarning(r, _) => r.to_string(),
         SetWithWarning(r, _) => r.to_string(),
-        Comment(text) => format!("#{}", text),
+        Comment(text) => text.clone(),
     }
 }
 

--- a/crates/pyo3/src/system.rs
+++ b/crates/pyo3/src/system.rs
@@ -145,29 +145,11 @@ impl PySystem {
     }
 
     fn rules(&self) -> Vec<PyRule> {
-        rules::rules_to_vec(&self.rs.rules_db)
+        rules::to_vec(&self.rs.rules_db)
     }
 
     fn rules_text(&self) -> String {
-        rules::entries_to_vec(&self.rs.rules_db)
-            .into_iter()
-            .fold((None, String::new()), |x, r| match x {
-                // no origin established yet
-                (None, _) => (
-                    Some(r.origin.clone()),
-                    format!("[{}]\n{}", r.origin, r.text),
-                ),
-                // same origin as previous
-                (Some(last_origin), acc_text) if last_origin == r.origin => {
-                    (Some(last_origin), format!("{}\n{}", acc_text, r.text))
-                }
-                // origin has changed
-                (Some(_), acc_text) => (
-                    Some(r.origin.clone()),
-                    format!("{}\n\n[{}]\n{}", acc_text, r.origin, r.text),
-                ),
-            })
-            .1
+        rules::to_text(&self.rs.rules_db)
     }
 }
 

--- a/crates/rules/src/db.rs
+++ b/crates/rules/src/db.rs
@@ -34,6 +34,11 @@ pub struct SetEntry {
     _fk: usize,
 }
 
+#[derive(Clone, Debug)]
+struct CommentEntry {
+    text: String,
+}
+
 /// Rule Definition
 /// Can be valid or invalid
 /// When invalid it provides the text definition
@@ -46,6 +51,7 @@ pub enum Entry {
     SetWithWarning(Set, String),
     Invalid { text: String, error: String },
     InvalidSet { text: String, error: String },
+    Comment(String),
 }
 
 impl Display for Entry {
@@ -55,6 +61,7 @@ impl Display for Entry {
             ValidSet(r) | SetWithWarning(r, _) => r.to_string(),
             Invalid { text, .. } => text.clone(),
             InvalidSet { text, .. } => text.clone(),
+            Comment(text) => text.clone(),
         };
         f.write_fmt(format_args!("{}", txt))
     }
@@ -88,6 +95,7 @@ pub struct DB {
     model: BTreeMap<usize, DbEntry>,
     rules: BTreeMap<usize, RuleEntry>,
     sets: BTreeMap<usize, SetEntry>,
+    comments: BTreeMap<usize, CommentEntry>,
 }
 
 impl From<Vec<(Origin, Entry)>> for DB {
@@ -141,7 +149,14 @@ impl DB {
             })
             .collect();
 
-        Self { model, rules, sets }
+        let comments = BTreeMap::new();
+
+        Self {
+            model,
+            rules,
+            sets,
+            comments,
+        }
     }
 
     /// Get the number of RuleDefs

--- a/crates/rules/src/db.rs
+++ b/crates/rules/src/db.rs
@@ -68,7 +68,7 @@ impl Display for Entry {
             ValidSet(r) | SetWithWarning(r, _) => r.to_string(),
             Invalid { text, .. } => text.clone(),
             InvalidSet { text, .. } => text.clone(),
-            Comment(text) => text.clone(),
+            Comment(text) => format!("#{}", text),
         };
         f.write_fmt(format_args!("{}", txt))
     }
@@ -333,5 +333,10 @@ mod tests {
         for s in subjs.iter().enumerate() {
             assert_eq!(db.entry(s.0).unwrap().unwrap().subj.exe().unwrap(), *s.1);
         }
+    }
+
+    #[test]
+    fn test_prefixed_comment() {
+        assert!(Comment("sometext".to_string()).to_string().starts_with('#'))
     }
 }

--- a/crates/rules/src/db.rs
+++ b/crates/rules/src/db.rs
@@ -45,12 +45,17 @@ struct CommentEntry {
 /// When valid the text definition can be rendered from the ADTs
 #[derive(Clone, Debug)]
 pub enum Entry {
+    // rules
     ValidRule(Rule),
-    ValidSet(Set),
     RuleWithWarning(Rule, String),
-    SetWithWarning(Set, String),
     Invalid { text: String, error: String },
+
+    // sets
+    ValidSet(Set),
+    SetWithWarning(Set, String),
     InvalidSet { text: String, error: String },
+
+    // other
     Comment(String),
 }
 
@@ -82,7 +87,15 @@ fn is_valid(def: &Entry) -> bool {
 }
 
 fn is_rule(def: &Entry) -> bool {
-    !matches!(def, ValidSet(_) | SetWithWarning(..) | InvalidSet { .. })
+    matches!(def, ValidRule(_) | RuleWithWarning(..) | Invalid { .. })
+}
+
+fn is_set(def: &Entry) -> bool {
+    matches!(def, ValidSet(_) | SetWithWarning(..) | InvalidSet { .. })
+}
+
+fn is_comment(def: &Entry) -> bool {
+    matches!(def, Comment(_))
 }
 
 type Origin = String;

--- a/crates/rules/src/parser/comment.rs
+++ b/crates/rules/src/parser/comment.rs
@@ -6,14 +6,15 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use nom::bytes::complete::{is_not, tag};
+use nom::bytes::complete::tag;
+use nom::character::complete::not_line_ending;
 
 use nom::sequence::preceded;
 
 use crate::parser::parse::{StrTrace, TraceResult};
 
 pub fn parse(i: StrTrace) -> TraceResult<String> {
-    match nom::combinator::complete(preceded(tag("#"), is_not("\n")))(i) {
+    match nom::combinator::complete(preceded(tag("#"), not_line_ending))(i) {
         Ok((remaining, c)) => Ok((remaining, c.current.to_string())),
         Err(e) => Err(e),
     }
@@ -33,5 +34,15 @@ mod tests {
                 .unwrap()
                 .1
         );
+    }
+
+    #[test]
+    fn empty_line() {
+        assert_eq!("", parse("#".into()).ok().unwrap().1);
+    }
+
+    #[test]
+    fn empty_with_newline() {
+        assert_eq!("", parse("#\n".into()).ok().unwrap().1);
     }
 }

--- a/crates/rules/src/read.rs
+++ b/crates/rules/src/read.rs
@@ -106,6 +106,7 @@ fn read_rules_db(xs: Vec<RuleSource>) -> Result<DB, Error> {
             SetDef(s) => Some((source, Entry::ValidSet(s))),
             Malformed(text, error) => Some((source, Entry::Invalid { text, error })),
             MalformedSet(text, error) => Some((source, Entry::InvalidSet { text, error })),
+            Comment(text) => Some((source, Entry::Comment(text))),
             _ => None,
         })
         .collect();


### PR DESCRIPTION
Preserve comments during the parse so that they can be written out to disk.

Closes #543 