### PR TITLE
Include spec in artifacts

### DIFF
--- a/.github/workflows/rpm.yml
+++ b/.github/workflows/rpm.yml
@@ -100,12 +100,15 @@ jobs:
         run: |
           mv $HOME/rpmbuild/RPMS/*/*.rpm /tmp
           mv $HOME/rpmbuild/SRPMS/*.rpm  /tmp
+          mv $HOME/rpmbuild/SPECS/fapolicy-analyzer.spec /tmp/fapolicy-analyzer.${{ matrix.triple.name }}.spec
 
       - name: Archive RPMs
         uses: actions/upload-artifact@v2
         with:
           name: fapolicy-analyzer-rpms
-          path: /tmp/*.rpm
+          path: |
+            /tmp/*.rpm
+            /tmp/*.spec
 
       - name: Release artifacts
         uses: softprops/action-gh-release@v1
@@ -114,4 +117,6 @@ jobs:
           tag_name: ${{ steps.tag_name.outputs.VERSION }}
           prerelease: ${{ startsWith(github.ref, 'refs/tags/v0') || contains(github.ref, 'rc') }}
           draft: true
-          files: /tmp/*.rpm
+          files: |
+            /tmp/*.rpm
+            /tmp/*.spec


### PR DESCRIPTION
The spec that created the rpm is included in the src rpm, also including it in the release artifacts for convenience.

Closes #581 