### PR TITLE
Profiler backend

### DIFF
--- a/.github/workflows/tools.yml
+++ b/.github/workflows/tools.yml
@@ -52,8 +52,11 @@ jobs:
       - name: Export files
         run: |
           mkdir /tmp/tools
-          mv target/release/tdb /tmp/tools/tdb-${{ steps.tag_name.outputs.VERSION }}
-          mv target/release/rulec /tmp/tools/rulec-${{ steps.tag_name.outputs.VERSION }}
+          mv target/release/tdb /tmp/tools/tdb-${APP_VERSION}
+          mv target/release/rulec /tmp/tools/rulec-${APP_VERSION}
+          mv target/release/faprofiler /tmp/tools/faprofiler-${APP_VERSION}
+        env:
+          APP_VERSION: ${{ steps.tag_name.outputs.VERSION }}
 
       - name: Archive Tools
         uses: actions/upload-artifact@v2

--- a/.github/workflows/tools.yml
+++ b/.github/workflows/tools.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Install build deps
         run: |
           dnf groupinstall -y "Development Tools"
-          dnf install -y git dbus-devel
+          dnf install -y dbus-devel
 
       - name: Install toolchain
         uses: actions-rs/toolchain@v1
@@ -31,7 +31,7 @@ jobs:
 
       - uses: actions/checkout@v2
         with:
-          ref: ${{ github.head_ref }}
+          ref: ${{ github.ref }}
           fetch-depth: 0
 
       - name: Build tools

--- a/.github/workflows/tools.yml
+++ b/.github/workflows/tools.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Install build deps
         run: |
           dnf groupinstall -y "Development Tools"
-          dnf install -y dbus-devel
+          dnf install -y git dbus-devel
 
       - name: Install toolchain
         uses: actions-rs/toolchain@v1
@@ -31,12 +31,8 @@ jobs:
 
       - uses: actions/checkout@v2
         with:
-          ref: ${{ github.ref }}
+          ref: ${{ github.head_ref }}
           fetch-depth: 0
-
-      - name: Generate package version
-        id: package_version
-        run: echo ::set-output name=TAG::$(./version.py)
 
       - name: Build tools
         uses: actions-rs/cargo@v1
@@ -44,19 +40,12 @@ jobs:
           command: build
           args: --release
 
-      - name: Strip ref to tag
-        id: tag_name
-        if: startsWith(github.ref, 'refs/tags/v')
-        run: echo ::set-output name=VERSION::$(echo $GITHUB_REF | cut -d/ -f3)
-
       - name: Export files
         run: |
           mkdir /tmp/tools
-          mv target/release/tdb /tmp/tools/tdb-${APP_VERSION}
-          mv target/release/rulec /tmp/tools/rulec-${APP_VERSION}
-          mv target/release/faprofiler /tmp/tools/faprofiler-${APP_VERSION}
-        env:
-          APP_VERSION: ${{ steps.tag_name.outputs.VERSION }}
+          mv target/release/tdb /tmp/tools/tdb
+          mv target/release/rulec /tmp/tools/rulec
+          mv target/release/faprofiler /tmp/tools/faprofiler
 
       - name: Archive Tools
         uses: actions/upload-artifact@v2

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -255,7 +255,7 @@ dependencies = [
 
 [[package]]
 name = "fapolicy-daemon"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "dbus",
  "fapolicy-rules",
@@ -280,7 +280,7 @@ dependencies = [
 
 [[package]]
 name = "fapolicy-rules"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "nom",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -258,6 +258,7 @@ name = "fapolicy-daemon"
 version = "0.4.0"
 dependencies = [
  "dbus",
+ "fapolicy-rules",
  "fapolicy-trust",
  "nom",
  "thiserror",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -261,6 +261,7 @@ dependencies = [
  "fapolicy-rules",
  "fapolicy-trust",
  "nom",
+ "tempfile",
  "thiserror",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,10 @@ path = "crates/tools/trust_db_util.rs"
 name = "rulec"
 path = "crates/tools/rule_check.rs"
 
+[[bin]]
+name = "faprofiler"
+path = "crates/tools/fapolicy_profiler.rs"
+
 [[test]]
 name = "integration"
 path = "tests/tests.rs"

--- a/crates/daemon/Cargo.toml
+++ b/crates/daemon/Cargo.toml
@@ -2,7 +2,7 @@
 name = "fapolicy-daemon"
 description = "Bindings to fapolicyd"
 license = "MPL-2.0"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2018"
 
 [dependencies]

--- a/crates/daemon/Cargo.toml
+++ b/crates/daemon/Cargo.toml
@@ -9,4 +9,5 @@ edition = "2018"
 nom = "6.1.0"
 thiserror = "1.0"
 fapolicy-trust = { version = "*", path = "../trust" }
+fapolicy-rules = { version = "*", path = "../rules" }
 dbus = "0.9"

--- a/crates/daemon/Cargo.toml
+++ b/crates/daemon/Cargo.toml
@@ -11,3 +11,4 @@ thiserror = "1.0"
 fapolicy-trust = { version = "*", path = "../trust" }
 fapolicy-rules = { version = "*", path = "../rules" }
 dbus = "0.9"
+tempfile = "3.3"

--- a/crates/daemon/src/error.rs
+++ b/crates/daemon/src/error.rs
@@ -6,6 +6,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
+use std::io;
 use thiserror::Error;
 
 // errors that can occur in this crate
@@ -22,4 +23,10 @@ pub enum Error {
 
     #[error("{0}")]
     ServiceCheckFailure(String),
+
+    #[error("Daemon is unresponsive")]
+    Unresponsive,
+
+    #[error("FileIO error: {0}")]
+    IOError(#[from] io::Error),
 }

--- a/crates/daemon/src/fapolicyd.rs
+++ b/crates/daemon/src/fapolicyd.rs
@@ -12,6 +12,7 @@ pub const TRUST_DB_PATH: &str = "/var/lib/fapolicyd";
 pub const TRUST_DB_NAME: &str = "trust.db";
 pub const TRUST_FILE_PATH: &str = "/etc/fapolicyd/fapolicyd.trust";
 pub const RULES_FILE_PATH: &str = "/etc/fapolicyd/rules.d";
+pub const COMPILED_RULES_PATH: &str = "/etc/fapolicyd/compiled.rules";
 pub const RPM_DB_PATH: &str = "/var/lib/rpm";
 pub const FIFO_PIPE: &str = "/run/fapolicyd/fapolicyd.fifo";
 

--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -12,4 +12,5 @@ pub mod fapolicyd;
 pub mod rpm;
 pub use rpm::fapolicyd_version as version;
 
+pub mod profiler;
 pub mod svc;

--- a/crates/daemon/src/profiler.rs
+++ b/crates/daemon/src/profiler.rs
@@ -1,3 +1,11 @@
+/*
+ * Copyright Concurrent Technologies Corporation 2021
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
 use std::fs;
 use std::fs::File;
 use std::io::Write;
@@ -20,10 +28,9 @@ DefaultDependencies=no
 After=local-fs.target systemd-tmpfiles-setup.service
 
 [Service]
-#Type=forking
+Type=simple
 PIDFile=/run/fapolicyp.pid
-#ExecStart=/usr/sbin/fapolicyd --debug --permissive --no-details
-ExecStart=sleepy
+ExecStart=/usr/sbin/fapolicyd --debug --permissive --no-details
 StandardOutput=file:/tmp/fapolicyp.stdout.log
 StandardError=file:/tmp/fapolicyp.stderr.log
 

--- a/crates/daemon/src/profiler.rs
+++ b/crates/daemon/src/profiler.rs
@@ -34,9 +34,8 @@ WantedBy=multi-user.target
 Type=simple
 PIDFile=/run/fapolicyp.pid
 ExecStart=/usr/sbin/fapolicyd --debug --permissive --no-details
-StandardOutput=file:/tmp/fapolicyp.stdout.log
-StandardError=file:/tmp/fapolicyp.stderr.log
-
+# it appears that a bug pre v240 forces append here systemd#10944
+StandardOutput=append:/tmp/fapolicyp.stdout.log
 "#;
 
 pub struct Profiler {

--- a/crates/daemon/src/profiler.rs
+++ b/crates/daemon/src/profiler.rs
@@ -18,6 +18,8 @@ After=local-fs.target systemd-tmpfiles-setup.service
 PIDFile=/run/fapolicyp.pid
 #ExecStart=/usr/sbin/fapolicyd --debug --permissive --no-details
 ExecStart=sleepy
+StandardOutput=file:/tmp/fapolicyp.stdout.log
+StandardError=file:/tmp/fapolicyp.stderr.log
 
 [Install]
 WantedBy=multi-user.target

--- a/crates/daemon/src/profiler.rs
+++ b/crates/daemon/src/profiler.rs
@@ -106,7 +106,7 @@ impl Profiler {
         }
         // clear the prev state
         self.prev_state = None;
-        delete_drop_in()?;
+        delete_service()?;
         daemon.state()
     }
 
@@ -115,12 +115,12 @@ impl Profiler {
     }
 }
 
-fn path_to_drop_in() -> String {
+fn service_path() -> String {
     format!("/usr/lib/systemd/system/{}.service", PROFILER_UNIT_NAME)
 }
 
 fn write_drop_in(stdout: Option<&PathBuf>) -> Result<(), Error> {
-    let mut unit_file = File::create(path_to_drop_in())?;
+    let mut unit_file = File::create(service_path())?;
     let mut service_def = include_str!("profiler.service").to_string();
     if let Some(stdout_path) = stdout {
         // append? it appears that a bug pre v240 forces append here - systemd#10944
@@ -134,7 +134,7 @@ fn write_drop_in(stdout: Option<&PathBuf>) -> Result<(), Error> {
     Ok(())
 }
 
-fn delete_drop_in() -> Result<(), Error> {
-    fs::remove_file(PathBuf::from(path_to_drop_in()))?;
+fn delete_service() -> Result<(), Error> {
+    fs::remove_file(PathBuf::from(service_path()))?;
     Ok(())
 }

--- a/crates/daemon/src/profiler.rs
+++ b/crates/daemon/src/profiler.rs
@@ -1,0 +1,106 @@
+use crate::error::Error;
+use crate::svc::{wait_for_daemon, Handle, State};
+use std::fs;
+use std::fs::File;
+use std::io::Write;
+use std::path::PathBuf;
+use std::process::Command;
+
+const PROFILER_UNIT_NAME: &str = "fapolicyp";
+const PROFILER_UNIT: &str = r#"
+[Unit]
+Description=File Access Profiling Daemon
+DefaultDependencies=no
+After=local-fs.target systemd-tmpfiles-setup.service
+
+[Service]
+#Type=forking
+PIDFile=/run/fapolicyp.pid
+#ExecStart=/usr/sbin/fapolicyd --debug --permissive --no-details
+ExecStart=sleepy
+
+[Install]
+WantedBy=multi-user.target
+"#;
+
+pub struct Profiler {
+    name: String,
+    prev: Option<State>,
+}
+
+impl Default for Profiler {
+    fn default() -> Self {
+        Profiler {
+            name: PROFILER_UNIT_NAME.to_string(),
+            prev: None,
+        }
+    }
+}
+
+impl Profiler {
+    pub fn new() -> Self {
+        Default::default()
+    }
+
+    fn handle(&self) -> Handle {
+        Handle::new(&self.name)
+    }
+
+    pub fn is_active(&self) -> Result<bool, Error> {
+        self.handle().active()
+    }
+
+    pub fn activate(&mut self) -> Result<State, Error> {
+        let daemon = Handle::default();
+        if !self.is_active()? {
+            // 1. preserve daemon state
+            self.prev = Some(daemon.state()?);
+            // 2. stop daemon if running
+            match &self.prev {
+                Some(State::Active) => daemon.stop()?,
+                _ => {}
+            }
+            // 3. write the profiler unit file
+            write_drop_in()?;
+            // 4. start the profiler
+            self.handle().start()?;
+            // 5. wait for the profiler to become active
+            wait_for_daemon(&self.handle(), State::Active, 10)?;
+        }
+        daemon.state()
+    }
+
+    pub fn deactivate(&mut self) -> Result<State, Error> {
+        let daemon = Handle::default();
+        if self.is_active()? {
+            self.handle().stop()?;
+            wait_for_daemon(&self.handle(), State::Inactive, 10)?;
+            match &self.prev {
+                Some(State::Active) => daemon.start()?,
+                _ => {}
+            }
+        }
+        self.prev = None;
+        delete_drop_in()?;
+        daemon.state()
+    }
+
+    pub fn rollback(&mut self) -> Result<State, Error> {
+        self.deactivate()
+    }
+}
+
+fn path_to_drop_in() -> String {
+    format!("/usr/lib/systemd/system/{}.service", PROFILER_UNIT_NAME)
+}
+
+fn write_drop_in() -> Result<(), Error> {
+    let mut unit_file = File::create(path_to_drop_in())?;
+    unit_file.write_all(PROFILER_UNIT.as_bytes())?;
+    Ok(())
+}
+
+fn delete_drop_in() -> Result<(), Error> {
+    fs::remove_file(PathBuf::from(path_to_drop_in()))?;
+    Ok(())
+}

--- a/crates/daemon/src/profiler.rs
+++ b/crates/daemon/src/profiler.rs
@@ -27,6 +27,9 @@ Description=File Access Profiling Daemon
 DefaultDependencies=no
 After=local-fs.target systemd-tmpfiles-setup.service
 
+[Install]
+WantedBy=multi-user.target
+
 [Service]
 Type=simple
 PIDFile=/run/fapolicyp.pid
@@ -34,8 +37,6 @@ ExecStart=/usr/sbin/fapolicyd --debug --permissive --no-details
 StandardOutput=file:/tmp/fapolicyp.stdout.log
 StandardError=file:/tmp/fapolicyp.stderr.log
 
-[Install]
-WantedBy=multi-user.target
 "#;
 
 pub struct Profiler {

--- a/crates/daemon/src/profiler.service
+++ b/crates/daemon/src/profiler.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=File Access Profiling Daemon
+DefaultDependencies=no
+After=local-fs.target systemd-tmpfiles-setup.service
+
+[Install]
+WantedBy=multi-user.target
+
+[Service]
+Type=simple
+PIDFile=/run/fapolicyp.pid
+ExecStart=/usr/sbin/fapolicyd --debug --permissive --no-details

--- a/crates/daemon/src/svc.rs
+++ b/crates/daemon/src/svc.rs
@@ -160,7 +160,7 @@ pub(crate) fn wait_for_daemon(
     let actual_state = handle.state()?;
     eprintln!("done waiting, daemon is {target_state:?}");
 
-    if target_state.can_be(actual_state.clone()) {
+    if target_state.can_be(actual_state) {
         Ok(())
     } else {
         Err(Unresponsive)

--- a/crates/daemon/src/svc.rs
+++ b/crates/daemon/src/svc.rs
@@ -139,11 +139,7 @@ impl Handle {
     }
 }
 
-pub(crate) fn wait_for_daemon(
-    handle: &Handle,
-    target_state: State,
-    seconds: usize,
-) -> Result<(), Error> {
+pub fn wait_for_daemon(handle: &Handle, target_state: State, seconds: usize) -> Result<(), Error> {
     for _ in 0..seconds {
         eprintln!("waiting on daemon to be {target_state:?}...");
         sleep(Duration::from_secs(1));

--- a/crates/pyo3/src/lib.rs
+++ b/crates/pyo3/src/lib.rs
@@ -11,6 +11,7 @@ use pyo3::prelude::*;
 pub mod acl;
 pub mod analysis;
 pub mod daemon;
+pub mod profiler;
 pub mod rules;
 pub mod system;
 pub mod trust;

--- a/crates/pyo3/src/lib.rs
+++ b/crates/pyo3/src/lib.rs
@@ -21,6 +21,7 @@ fn rust(_py: Python, m: &PyModule) -> PyResult<()> {
     acl::init_module(_py, m)?;
     analysis::init_module(_py, m)?;
     daemon::init_module(_py, m)?;
+    profiler::init_module(_py, m)?;
     rules::init_module(_py, m)?;
     system::init_module(_py, m)?;
     trust::init_module(_py, m)?;

--- a/crates/pyo3/src/profiler.rs
+++ b/crates/pyo3/src/profiler.rs
@@ -35,14 +35,18 @@ impl PyProfiler {
         }
     }
 
-    fn activate(&self) -> PyResult<()> {
-        self.activate()
-            .map_err(|e| exceptions::PyRuntimeError::new_err(format!("{:?}", e)))
+    fn activate(&mut self) -> PyResult<()> {
+        self.rs
+            .activate()
+            .map_err(|e| exceptions::PyRuntimeError::new_err(format!("{:?}", e)))?;
+        Ok(())
     }
 
-    fn deactivate(&self) -> PyResult<()> {
-        self.deactivate()
-            .map_err(|e| exceptions::PyRuntimeError::new_err(format!("{:?}", e)))
+    fn deactivate(&mut self) -> PyResult<()> {
+        self.rs
+            .deactivate()
+            .map_err(|e| exceptions::PyRuntimeError::new_err(format!("{:?}", e)))?;
+        Ok(())
     }
 }
 

--- a/crates/pyo3/src/profiler.rs
+++ b/crates/pyo3/src/profiler.rs
@@ -1,0 +1,52 @@
+/*
+ * Copyright Concurrent Technologies Corporation 2021
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+use pyo3::prelude::*;
+use pyo3::{exceptions, PyResult, Python};
+
+use fapolicy_daemon::profiler::Profiler;
+
+#[pyclass(module = "daemon", name = "Profiler")]
+pub struct PyProfiler {
+    rs: Profiler,
+}
+impl From<Profiler> for PyProfiler {
+    fn from(rs: Profiler) -> Self {
+        Self { rs }
+    }
+}
+impl From<PyProfiler> for Profiler {
+    fn from(py: PyProfiler) -> Self {
+        py.rs
+    }
+}
+
+#[pymethods]
+impl PyProfiler {
+    #[new]
+    fn new() -> Self {
+        Self {
+            rs: Profiler::new(),
+        }
+    }
+
+    fn activate(&self) -> PyResult<()> {
+        self.activate()
+            .map_err(|e| exceptions::PyRuntimeError::new_err(format!("{:?}", e)))
+    }
+
+    fn deactivate(&self) -> PyResult<()> {
+        self.deactivate()
+            .map_err(|e| exceptions::PyRuntimeError::new_err(format!("{:?}", e)))
+    }
+}
+
+pub fn init_module(_py: Python, m: &PyModule) -> PyResult<()> {
+    m.add_class::<PyProfiler>()?;
+    Ok(())
+}

--- a/crates/rules/Cargo.toml
+++ b/crates/rules/Cargo.toml
@@ -2,7 +2,7 @@
 name = "fapolicy-rules"
 description = "Rule support for fapolicyd"
 license = "MPL-2.0"
-version = "0.4.2"
+version = "0.4.3"
 edition = "2018"
 
 [lib]

--- a/crates/rules/src/write.rs
+++ b/crates/rules/src/write.rs
@@ -7,6 +7,7 @@
  */
 
 use crate::db::DB;
+use crate::write;
 use std::collections::HashMap;
 use std::fs::File;
 use std::io::Write;
@@ -49,7 +50,15 @@ fn rules_dir(db: &DB, dir: &Path, compiled: &Path) -> Result<(), io::Error> {
 
     // write compiled.rules
     // todo;; get this from config or constants
-    let mut rf = File::create(compiled)?;
+    compiled_rules(&db, compiled)?;
+
+    Ok(())
+}
+
+pub fn compiled_rules(db: &DB, path: &Path) -> Result<(), io::Error> {
+    // write compiled.rules
+    // todo;; get this from config or constants
+    let mut rf = File::create(path)?;
     for (_, (_, e)) in db.iter() {
         rf.write_all(format!("{}\n", e).as_bytes())?;
     }

--- a/crates/rules/src/write.rs
+++ b/crates/rules/src/write.rs
@@ -7,7 +7,6 @@
  */
 
 use crate::db::DB;
-use crate::write;
 use std::collections::HashMap;
 use std::fs::File;
 use std::io::Write;
@@ -50,7 +49,7 @@ fn rules_dir(db: &DB, dir: &Path, compiled: &Path) -> Result<(), io::Error> {
 
     // write compiled.rules
     // todo;; get this from config or constants
-    compiled_rules(&db, compiled)?;
+    compiled_rules(db, compiled)?;
 
     Ok(())
 }

--- a/crates/tools/fapolicy_profiler.rs
+++ b/crates/tools/fapolicy_profiler.rs
@@ -17,10 +17,7 @@ use clap::Clap;
 use fapolicy_daemon::profiler::Profiler;
 use fapolicy_rules::read::load_rules_db;
 use std::error::Error;
-use std::path::PathBuf;
 use std::process::Command;
-use std::thread::sleep;
-use std::time::Duration;
 
 #[derive(Clap)]
 #[clap(name = "File Access Policy Profiler", version = "v0.0.0")]

--- a/crates/tools/fapolicy_profiler.rs
+++ b/crates/tools/fapolicy_profiler.rs
@@ -16,6 +16,7 @@
 use clap::Clap;
 use fapolicy_daemon::profiler::Profiler;
 use fapolicy_rules::read::load_rules_db;
+use nom::combinator::opt;
 use std::error::Error;
 use std::process::Command;
 
@@ -23,22 +24,28 @@ use std::process::Command;
 #[clap(name = "File Access Policy Profiler", version = "v0.0.0")]
 struct Opts {
     /// path to *.rules or rules.d
-    rules_path: Option<String>,
+    #[clap(short, long)]
+    rules: Option<String>,
+
+    #[clap(allow_hyphen_values = true)]
+    target: Vec<String>,
 }
 
 fn main() -> Result<(), Box<dyn Error>> {
     let opts: Opts = Opts::parse();
+    eprintln!("profiling: {:?}", opts.target);
+    let target = opts.target.first().expect("target not specified");
+    let args: Vec<&String> = opts.target.iter().skip(1).collect();
+
     let mut profiler = Profiler::new();
-    let db = if let Some(rules_path) = opts.rules_path {
+    let db = if let Some(rules_path) = opts.rules {
         Some(load_rules_db(&rules_path)?)
     } else {
         None
     };
 
     profiler.activate_with_rules(db.as_ref())?;
-    let out = Command::new("cat")
-        .arg("/etc/fapolicyd/compiled.rules")
-        .output()?;
+    let out = Command::new(target).args(args).output()?;
     println!("{}", String::from_utf8(out.stdout)?);
     profiler.deactivate()?;
 

--- a/crates/tools/fapolicy_profiler.rs
+++ b/crates/tools/fapolicy_profiler.rs
@@ -15,13 +15,15 @@
 
 use fapolicy_daemon::profiler::Profiler;
 use std::error::Error;
+use std::process::Command;
 use std::thread::sleep;
 use std::time::Duration;
 
 fn main() -> Result<(), Box<dyn Error>> {
     let mut profiler = Profiler::new();
     profiler.activate()?;
-    sleep(Duration::from_secs(10));
+    let out = Command::new("ls").arg("/tmp").output()?;
+    println!("{}", String::from_utf8(out.stdout)?);
     profiler.deactivate()?;
 
     Ok(())

--- a/crates/tools/fapolicy_profiler.rs
+++ b/crates/tools/fapolicy_profiler.rs
@@ -1,0 +1,28 @@
+// Copyright Concurrent Technologies Corporation 2021
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+use fapolicy_daemon::profiler::Profiler;
+use std::error::Error;
+use std::thread::sleep;
+use std::time::Duration;
+
+fn main() -> Result<(), Box<dyn Error>> {
+    let mut profiler = Profiler::new();
+    profiler.activate()?;
+    sleep(Duration::from_secs(10));
+    profiler.deactivate()?;
+
+    Ok(())
+}

--- a/crates/tools/fapolicy_profiler.rs
+++ b/crates/tools/fapolicy_profiler.rs
@@ -33,7 +33,7 @@ struct Opts {
 
     /// the literal target to run, prefix by double hyphens
     /// faprofiler -- ls -al /tmp
-    #[clap(allow_hyphen_values = true)]
+    #[clap(required = true, allow_hyphen_values = true)]
     target: Vec<String>,
 }
 
@@ -48,15 +48,15 @@ fn main() -> Result<(), Box<dyn Error>> {
         .rules
         .map(|p| load_rules_db(&p).expect("failed to load rules"));
 
-    if let Some(stdout_path) = opts.stdout.map(PathBuf::from) {
-        if stdout_path.exists() {
+    if let Some(path) = opts.stdout.map(PathBuf::from) {
+        if path.exists() {
             eprintln!(
                 "warning: deleting existing log file from {}",
-                stdout_path.display()
+                path.display()
             );
-            std::fs::remove_file(&stdout_path)?;
+            std::fs::remove_file(&path)?;
         }
-        profiler.stdout_log = Some(stdout_path);
+        profiler.stdout_log = Some(path);
     }
 
     profiler.activate_with_rules(db.as_ref())?;

--- a/crates/tools/fapolicy_profiler.rs
+++ b/crates/tools/fapolicy_profiler.rs
@@ -27,9 +27,12 @@ struct Opts {
     #[clap(short, long)]
     rules: Option<String>,
 
+    /// out path for daemon stdout log
     #[clap(long)]
     stdout: Option<String>,
 
+    /// the literal target to run, prefix by double hyphens
+    /// faprofiler -- ls -al /tmp
     #[clap(allow_hyphen_values = true)]
     target: Vec<String>,
 }

--- a/crates/tools/rule_check.rs
+++ b/crates/tools/rule_check.rs
@@ -1,10 +1,17 @@
-/*
- * Copyright Concurrent Technologies Corporation 2021
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at https://mozilla.org/MPL/2.0/.
- */
+// Copyright Concurrent Technologies Corporation 2021
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 use std::error::Error;
 use std::ops::Range;

--- a/crates/tools/trust_db_util.rs
+++ b/crates/tools/trust_db_util.rs
@@ -1,10 +1,17 @@
-/*
- * Copyright Concurrent Technologies Corporation 2021
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at https://mozilla.org/MPL/2.0/.
- */
+// Copyright Concurrent Technologies Corporation 2021
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 use std::fs::File;
 use std::io;

--- a/examples/policy_profiler.py
+++ b/examples/policy_profiler.py
@@ -1,0 +1,20 @@
+# Copyright Concurrent Technologies Corporation 2021
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+from fapolicy_analyzer import *
+
+profiler = Profiler()
+profiler.activate()
+profiler.deactivate()

--- a/examples/policy_profiler.py
+++ b/examples/policy_profiler.py
@@ -14,7 +14,10 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 from fapolicy_analyzer import *
+from time import sleep
+import subprocess
 
 profiler = Profiler()
 profiler.activate()
+subprocess.getoutput(f"cat /etc/fapolicyd/compiled.rules")
 profiler.deactivate()


### PR DESCRIPTION
## Experimental profiler backend

This is a first pass at backend functionality with initial bindings.  Future PR(s) will expand the bindings and integrate with the Python `faprofiler`.

### todo
- [x] does the profiler live in its own crate?
- [x] review the `wait_for_daemon` functions in daemon and pyo3 crates and eliminate one if possible
- [x] add remaining clap arguments 

### Goals
1. Provide Rust backend that matches the profiling APIs defined by `fapd_manager.py` and `faprofiler.py`
2. Shift the profiling flow control backwards into Rust.
3. Provide a standalone executable that can profile without the GUI
4. Move  the profiler control into systemd
5. Stateless lock-free control
6. Provide bindings that allow the UI to be unchanged 
7. Allow non-deployed rules to be profiled

### Accomplished
1. > Provide Rust backend that matches the profiling APIs defined by `fapd_manager.py` and `faprofiler.py`
    - Rust backend :heavy_check_mark: 
    - Matching APIs - Follow up PRs
2. > Shift the profiling flow control backwards into Rust.
    - `daemon::Profiler` :heavy_check_mark: 
3. > Provide a standalone executable that can profile without the GUI
    - Added `faprofiler` as a CLI tool :heavy_check_mark: 
4. > Move  the profiler control into systemd
    - :heavy_check_mark: 
6. > Stateless lock-free control
    - Stateless: there is state to maintain when supporting optional features
    - lock-free: client concern
8. > Provide bindings that allow the UI to be unchanged
    - Follow up PRs
9. > Allow non-deployed rules to be profiled
    - CLI :heavy_check_mark:
    - GUI: will need some additional support


### Impacts
- #508 
- #531


### todo
- Determine if the target should be a systemd unit