### PR TITLE
Change post deployment revert so changes are kept in the UI

### DIFF
--- a/fapolicy_analyzer/tests/features/test_system_feature.py
+++ b/fapolicy_analyzer/tests/features/test_system_feature.py
@@ -20,12 +20,13 @@ import fapolicy_analyzer.ui.store as store
 import pytest
 from callee import InstanceOf
 from callee.attributes import Attrs
+from fapolicy_analyzer.redux import Action, ReduxFeatureModule, create_store
 from fapolicy_analyzer.ui.actions import (
     ERROR_SYSTEM_INITIALIZATION,
     SYSTEM_CHECKPOINT_SET,
     SYSTEM_RECEIVED,
     apply_changesets,
-    deploy_ancillary_trust,
+    deploy_system,
     error_ancillary_trust,
     error_events,
     error_groups,
@@ -52,7 +53,6 @@ from fapolicy_analyzer.ui.changeset_wrapper import TrustChangeset
 from fapolicy_analyzer.ui.features.system_feature import create_system_feature
 from fapolicy_analyzer.ui.store import dispatch, init_store
 from fapolicy_analyzer.ui.strings import SYSTEM_INITIALIZATION_ERROR
-from fapolicy_analyzer.redux import Action, ReduxFeatureModule, create_store
 
 
 @pytest.fixture
@@ -237,37 +237,37 @@ def test_request_events_epic_bad_request(mocker):
     mock_received_action.assert_called_with([])
 
 
-def test_deploy_ancillary_trust_epic(mocker):
+def test_deploy_system_epic(mocker):
     mock_system = MagicMock()
     mock_received_action = mocker.patch(
-        "fapolicy_analyzer.ui.features.system_feature.ancillary_trust_deployed"
+        "fapolicy_analyzer.ui.features.system_feature.system_deployed"
     )
     init_store(mock_system)
-    dispatch(deploy_ancillary_trust())
+    dispatch(deploy_system())
     mock_system.deploy.assert_called()
     mock_received_action.assert_called_with()
 
 
-def test_deploy_ancillary_trust_epic_error(mocker):
+def test_deploy_system_epic_error(mocker):
     mock_system = MagicMock(
-        deploy=MagicMock(side_effect=Exception("deploy trust error"))
+        deploy=MagicMock(side_effect=Exception("deploy system error"))
     )
     mock_error_action = mocker.patch(
-        "fapolicy_analyzer.ui.features.system_feature.error_deploying_ancillary_trust"
+        "fapolicy_analyzer.ui.features.system_feature.error_deploying_system"
     )
     init_store(mock_system)
-    dispatch(deploy_ancillary_trust())
-    mock_error_action.assert_called_with("deploy trust error")
+    dispatch(deploy_system())
+    mock_error_action.assert_called_with("deploy system error")
 
 
-def test_deploy_ancillary_trust_epic_snapshot_error(mocker):
+def test_deploy_system_epic_snapshot_error(mocker):
     mocker.patch(
         "fapolicy_analyzer.ui.features.system_feature.fapd_dbase_snapshot",
         return_value=False,
     )
     mock_logger = mocker.patch("fapolicy_analyzer.ui.features.system_feature.logging")
     init_store(MagicMock())
-    dispatch(deploy_ancillary_trust())
+    dispatch(deploy_system())
     mock_logger.warning.assert_called_with(
         "Fapolicyd pre-deploy backup failed, continuing with deployment."
     )

--- a/fapolicy_analyzer/tests/operations/test_deploy_changesets_op.py
+++ b/fapolicy_analyzer/tests/operations/test_deploy_changesets_op.py
@@ -20,10 +20,11 @@ import gi
 import pytest
 from callee import InstanceOf
 from callee.attributes import Attrs
+from fapolicy_analyzer.redux import Action
 from fapolicy_analyzer.ui.actions import (
     ADD_NOTIFICATION,
     CLEAR_CHANGESETS,
-    DEPLOY_ANCILLARY_TRUST,
+    DEPLOY_SYSTEM,
     RESTORE_SYSTEM_CHECKPOINT,
     SET_SYSTEM_CHECKPOINT,
     NotificationType,
@@ -31,11 +32,10 @@ from fapolicy_analyzer.ui.actions import (
 from fapolicy_analyzer.ui.operations.deploy_changesets_op import DeployChangesetsOp
 from fapolicy_analyzer.ui.store import init_store
 from fapolicy_analyzer.ui.strings import (
-    DEPLOY_ANCILLARY_ERROR_MSG,
-    DEPLOY_ANCILLARY_SUCCESSFUL_MSG,
+    DEPLOY_SYSTEM_ERROR_MSG,
+    DEPLOY_SYSTEM_SUCCESSFUL_MSG,
 )
-from mocks import mock_System, mock_trust
-from fapolicy_analyzer.redux import Action
+from mocks import mock_System
 from rx.subject import Subject
 
 gi.require_version("Gtk", "3.0")
@@ -87,9 +87,7 @@ def revert_dialog(revert_resp, mocker):
 @pytest.mark.usefixtures("revert_dialog")
 def test_on_confirm_deployment(operation, confirm_dialog, mock_dispatch):
     operation.run([], None, None)
-    mock_dispatch.assert_called_with(
-        InstanceOf(Action) & Attrs(type=DEPLOY_ANCILLARY_TRUST)
-    )
+    mock_dispatch.assert_called_with(InstanceOf(Action) & Attrs(type=DEPLOY_SYSTEM))
     confirm_dialog.run.assert_called()
     confirm_dialog.hide.assert_called()
 
@@ -107,20 +105,18 @@ def test_deploy_w_exception(mock_dispatch, mocker):
         system_features_mock.on_next(
             {
                 "changesets": [],
-                "ancillary_trust": MagicMock(
-                    trust=[mock_trust()], error=None, loading=False
-                ),
+                "system": MagicMock(error=None, loading=False),
             }
         )
         operation.run([], None, None)
         system_features_mock.on_next(
-            {"changesets": [], "ancillary_trust": MagicMock(error="foo")}
+            {"changesets": [], "system": MagicMock(error="foo")}
         )
     mock_dispatch.assert_any_call(
         InstanceOf(Action)
         & Attrs(
             type=ADD_NOTIFICATION,
-            payload=Attrs(type=NotificationType.ERROR, text=DEPLOY_ANCILLARY_ERROR_MSG),
+            payload=Attrs(type=NotificationType.ERROR, text=DEPLOY_SYSTEM_ERROR_MSG),
         )
     )
 
@@ -137,15 +133,13 @@ def test_on_neg_confirm_deployment(confirm_dialog, mock_dispatch, mocker):
         system_features_mock.on_next(
             {
                 "changesets": [],
-                "ancillary_trust": MagicMock(trust=[mock_trust()], error=None),
+                "system": MagicMock(error=None),
             }
         )
         operation.run([], None, None)
     confirm_dialog.run.assert_called()
     confirm_dialog.hide.assert_called()
-    mock_dispatch.assert_not_any_call(
-        InstanceOf(Action) & Attrs(type=DEPLOY_ANCILLARY_TRUST)
-    )
+    mock_dispatch.assert_not_any_call(InstanceOf(Action) & Attrs(type=DEPLOY_SYSTEM))
 
 
 @pytest.mark.parametrize("confirm_resp", [Gtk.ResponseType.YES])
@@ -162,14 +156,14 @@ def test_on_revert_deployment(mock_dispatch, mocker):
         system_features_mock.on_next(
             {
                 "changesets": [],
-                "ancillary_trust": MagicMock(trust=[mock_trust()], error=None),
+                "system": MagicMock(error=None),
             }
         )
         operation.run([], None, None)
         system_features_mock.on_next(
             {
                 "changesets": [],
-                "ancillary_trust": MagicMock(trust=[mock_trust()], error=None),
+                "system": MagicMock(error=None),
             }
         )
     mock_dispatch.assert_any_call(
@@ -177,7 +171,7 @@ def test_on_revert_deployment(mock_dispatch, mocker):
         & Attrs(
             type=ADD_NOTIFICATION,
             payload=Attrs(
-                type=NotificationType.SUCCESS, text=DEPLOY_ANCILLARY_SUCCESSFUL_MSG
+                type=NotificationType.SUCCESS, text=DEPLOY_SYSTEM_SUCCESSFUL_MSG
             ),
         )
     )
@@ -204,14 +198,14 @@ def test_on_neg_revert_deployment(mock_dispatch, mocker):
         system_features_mock.on_next(
             {
                 "changesets": [],
-                "ancillary_trust": MagicMock(trust=[mock_trust()], error=None),
+                "system": MagicMock(error=None),
             }
         )
         operation.run([], None, None)
         system_features_mock.on_next(
             {
                 "changesets": [],
-                "ancillary_trust": MagicMock(trust=[mock_trust()], error=None),
+                "system": MagicMock(error=None),
             }
         )
     mock_dispatch.assert_any_call(
@@ -219,7 +213,7 @@ def test_on_neg_revert_deployment(mock_dispatch, mocker):
         & Attrs(
             type=ADD_NOTIFICATION,
             payload=Attrs(
-                type=NotificationType.SUCCESS, text=DEPLOY_ANCILLARY_SUCCESSFUL_MSG
+                type=NotificationType.SUCCESS, text=DEPLOY_SYSTEM_SUCCESSFUL_MSG
             ),
         )
     )

--- a/fapolicy_analyzer/tests/reducers/test_ancillary_trust_reducer.py
+++ b/fapolicy_analyzer/tests/reducers/test_ancillary_trust_reducer.py
@@ -19,11 +19,7 @@ from unittest.mock import MagicMock
 import pytest
 from fapolicy_analyzer.ui.reducers.ancillary_trust_reducer import (
     TrustState,
-    handle_add_changesets,
-    handle_ancillary_trust_deployed,
-    handle_clear_changesets,
     handle_error_ancillary_trust,
-    handle_error_deploying_ancillary_trust,
     handle_received_ancillary_trust,
     handle_request_ancillary_trust,
 )
@@ -31,43 +27,19 @@ from fapolicy_analyzer.ui.reducers.ancillary_trust_reducer import (
 
 @pytest.fixture()
 def initial_state():
-    return TrustState(error=None, trust=[], deployed=False, loading=False)
+    return TrustState(error=None, trust=[], loading=False)
 
 
 def test_handle_request_ancillary_trust(initial_state):
     result = handle_request_ancillary_trust(initial_state, MagicMock())
-    assert result == TrustState(error=None, trust=[], deployed=False, loading=True)
+    assert result == TrustState(error=None, trust=[], loading=True)
 
 
 def test_handle_received_ancillary_trust(initial_state):
     result = handle_received_ancillary_trust(initial_state, MagicMock(payload=["foo"]))
-    assert result == TrustState(
-        error=None, trust=["foo"], deployed=False, loading=False
-    )
+    assert result == TrustState(error=None, trust=["foo"], loading=False)
 
 
 def test_handle_error_ancillary_trust(initial_state):
     result = handle_error_ancillary_trust(initial_state, MagicMock(payload="foo"))
-    assert result == TrustState(error="foo", trust=[], deployed=False, loading=False)
-
-
-def test_handle_ancillary_trust_deployed(initial_state):
-    result = handle_ancillary_trust_deployed(initial_state, MagicMock())
-    assert result == TrustState(error=None, trust=[], deployed=True, loading=False)
-
-
-def test_handle_error_deploying_ancillary_trust(initial_state):
-    result = handle_error_deploying_ancillary_trust(
-        initial_state, MagicMock(payload="foo")
-    )
-    assert result == TrustState(error="foo", trust=[], deployed=False, loading=False)
-
-
-def test_handle_add_changesets(initial_state):
-    result = handle_add_changesets(initial_state, MagicMock())
-    assert result == TrustState(error=None, trust=[], deployed=False, loading=False)
-
-
-def test_handle_clear_changesets(initial_state):
-    result = handle_clear_changesets(initial_state, MagicMock())
-    assert result == TrustState(error=None, trust=[], deployed=True, loading=False)
+    assert result == TrustState(error="foo", trust=[], loading=False)

--- a/fapolicy_analyzer/tests/reducers/test_system_reducer.py
+++ b/fapolicy_analyzer/tests/reducers/test_system_reducer.py
@@ -1,0 +1,87 @@
+# Copyright Concurrent Technologies Corporation 2022
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import context  # noqa: F401 # isort: skip
+from unittest.mock import MagicMock
+
+import pytest
+from fapolicy_analyzer.ui.reducers.system_reducer import (
+    SystemState,
+    handle_add_changesets,
+    handle_clear_changesets,
+    handle_error_deploying_system,
+    handle_error_system_initialization,
+    handle_system_checkpoint_set,
+    handle_system_deployed,
+    handle_system_received,
+)
+
+
+@pytest.fixture()
+def initial_state():
+    return SystemState(error=None, system=None, checkpoint=None, deployed=False)
+
+
+def test_handle_system_received(initial_state):
+    mock_system = MagicMock()
+    result = handle_system_received(initial_state, MagicMock(payload=mock_system))
+    assert result == SystemState(
+        error=None, system=mock_system, checkpoint=None, deployed=False
+    )
+
+
+def test_handle_error_system_initialization(initial_state):
+    result = handle_error_system_initialization(initial_state, MagicMock(payload="foo"))
+    assert result == SystemState(
+        error="foo", system=None, checkpoint=None, deployed=False
+    )
+
+
+def test_handle_system_checkpoint_set(initial_state):
+    mock_checkpoint = MagicMock()
+    result = handle_system_checkpoint_set(
+        initial_state, MagicMock(payload=mock_checkpoint)
+    )
+    assert result == SystemState(
+        error=None, system=None, checkpoint=mock_checkpoint, deployed=False
+    )
+
+
+def test_handle_system_deployed(initial_state):
+    result = handle_system_deployed(initial_state, MagicMock())
+    assert result == SystemState(
+        error=None, system=None, checkpoint=None, deployed=True
+    )
+
+
+def test_handle_error_deploying_system(initial_state):
+    result = handle_error_deploying_system(initial_state, MagicMock(payload="foo"))
+    assert result == SystemState(
+        error="foo", system=None, checkpoint=None, deployed=False
+    )
+
+
+def test_handle_add_changesets(initial_state):
+    result = handle_add_changesets(initial_state, MagicMock())
+    assert result == SystemState(
+        error=None, system=None, checkpoint=None, deployed=False
+    )
+
+
+def test_handle_clear_changesets(initial_state):
+    result = handle_clear_changesets(initial_state, MagicMock())
+    assert result == SystemState(
+        error=None, system=None, checkpoint=None, deployed=True
+    )

--- a/fapolicy_analyzer/tests/test_actions.py
+++ b/fapolicy_analyzer/tests/test_actions.py
@@ -17,16 +17,16 @@ import context  # noqa: F401 # isort: skip
 from unittest.mock import MagicMock
 
 import pytest
+from fapolicy_analyzer.redux import Action
 from fapolicy_analyzer.ui.actions import (
     ADD_CHANGESETS,
     ADD_NOTIFICATION,
-    ANCILLARY_TRUST_DEPLOYED,
     APPLY_CHANGESETS,
     CLEAR_CHANGESETS,
-    DEPLOY_ANCILLARY_TRUST,
+    DEPLOY_SYSTEM,
     ERROR_ANCILLARY_TRUST,
     ERROR_APPLY_CHANGESETS,
-    ERROR_DEPLOYING_ANCILLARY_TRUST,
+    ERROR_DEPLOYING_SYSTEM,
     ERROR_EVENTS,
     ERROR_GROUPS,
     ERROR_RULES,
@@ -54,18 +54,18 @@ from fapolicy_analyzer.ui.actions import (
     RESTORE_SYSTEM_CHECKPOINT,
     SET_SYSTEM_CHECKPOINT,
     SYSTEM_CHECKPOINT_SET,
+    SYSTEM_DEPLOYED,
     SYSTEM_RECEIVED,
     Notification,
     NotificationType,
     add_changesets,
     add_notification,
-    ancillary_trust_deployed,
     apply_changesets,
     clear_changesets,
-    deploy_ancillary_trust,
+    deploy_system,
     error_ancillary_trust,
     error_apply_changesets,
-    error_deploying_ancillary_trust,
+    error_deploying_system,
     error_events,
     error_groups,
     error_rules,
@@ -92,10 +92,10 @@ from fapolicy_analyzer.ui.actions import (
     restore_system_checkpoint,
     set_system_checkpoint,
     system_checkpoint_set,
+    system_deployed,
     system_initialization_error,
     system_received,
 )
-from fapolicy_analyzer.redux import Action
 
 
 @pytest.mark.parametrize("notification_type", [t for t in list(NotificationType)])
@@ -193,24 +193,24 @@ def test_error_system_trust():
     assert action.payload == "foo"
 
 
-def test_deploy_ancillary_trust():
-    action = deploy_ancillary_trust()
+def test_deploy_system():
+    action = deploy_system()
     assert type(action) is Action
-    assert action.type == DEPLOY_ANCILLARY_TRUST
+    assert action.type == DEPLOY_SYSTEM
     assert not action.payload
 
 
-def test_ancillary_trust_deployed():
-    action = ancillary_trust_deployed()
+def test_system_deployed():
+    action = system_deployed()
     assert type(action) is Action
-    assert action.type == ANCILLARY_TRUST_DEPLOYED
+    assert action.type == SYSTEM_DEPLOYED
     assert not action.payload
 
 
-def test_error_deploying_ancillary_trust():
-    action = error_deploying_ancillary_trust("foo")
+def test_error_deploying_system():
+    action = error_deploying_system("foo")
     assert type(action) is Action
-    assert action.type == ERROR_DEPLOYING_ANCILLARY_TRUST
+    assert action.type == ERROR_DEPLOYING_SYSTEM
     assert action.payload == "foo"
 
 

--- a/fapolicy_analyzer/tests/test_session_manager.py
+++ b/fapolicy_analyzer/tests/test_session_manager.py
@@ -22,14 +22,15 @@ from unittest.mock import MagicMock, call, mock_open
 
 import pytest
 from callee import Attr, EndsWith, InstanceOf, StartsWith
+from fapolicy_analyzer.redux import Action
 from fapolicy_analyzer.ui.actions import (
     ADD_NOTIFICATION,
     APPLY_CHANGESETS,
+    CLEAR_CHANGESETS,
     RESTORE_SYSTEM_CHECKPOINT,
 )
 from fapolicy_analyzer.ui.changeset_wrapper import RuleChangeset, TrustChangeset
 from fapolicy_analyzer.ui.session_manager import SessionManager
-from fapolicy_analyzer.redux import Action
 
 import context  # noqa: F401
 
@@ -107,6 +108,7 @@ def test_open_edit_session(uut, mock_dispatch, mocker):
     mock_dispatch.assert_has_calls(
         [
             call(InstanceOf(Action) & Attr(type=RESTORE_SYSTEM_CHECKPOINT)),
+            call(InstanceOf(Action) & Attr(type=CLEAR_CHANGESETS)),
             call(InstanceOf(Action) & Attr(type=APPLY_CHANGESETS)),
         ]
     )
@@ -114,7 +116,7 @@ def test_open_edit_session(uut, mock_dispatch, mocker):
     # verify changesets
     expected = test_changes
     # parse changesets to json string to compare
-    args, _ = mock_dispatch.call_args_list[1]
+    args, _ = mock_dispatch.call_args_list[2]
     actual = [
         {path: action for path, action in c.serialize().items()}
         if isinstance(c, TrustChangeset)
@@ -277,6 +279,7 @@ def test_restore_previous_session(uut_autosave_enabled, autosaved_files, mock_di
     mock_dispatch.assert_has_calls(
         [
             call(InstanceOf(Action) & Attr(type=RESTORE_SYSTEM_CHECKPOINT)),
+            call(InstanceOf(Action) & Attr(type=CLEAR_CHANGESETS)),
             call(InstanceOf(Action) & Attr(type=APPLY_CHANGESETS)),
         ]
     )
@@ -284,7 +287,7 @@ def test_restore_previous_session(uut_autosave_enabled, autosaved_files, mock_di
     # verify changesets
     expected = test_changes
     # parse changesets to json string to compare
-    args, _ = mock_dispatch.call_args_list[1]
+    args, _ = mock_dispatch.call_args_list[2]
     actual = [
         {path: action for path, action in c.serialize().items()}
         if isinstance(c, TrustChangeset)

--- a/fapolicy_analyzer/ui/actions.py
+++ b/fapolicy_analyzer/ui/actions.py
@@ -44,9 +44,9 @@ REQUEST_SYSTEM_TRUST = "REQUEST_SYSTEM_TRUST"
 RECEIVED_SYSTEM_TRUST = "RECEIVED_SYSTEM_TRUST"
 ERROR_SYSTEM_TRUST = "ERROR_SYSTEM_TRUST"
 
-DEPLOY_ANCILLARY_TRUST = "DEPLOY_ANCILLARY_TRUST"
-ANCILLARY_TRUST_DEPLOYED = "ANCILLARY_TRUST_DEPLOYED"
-ERROR_DEPLOYING_ANCILLARY_TRUST = "ERROR_DEPLOYING_ANCILLARY_TRUST"
+DEPLOY_SYSTEM = "DEPLOY_SYSTEM"
+SYSTEM_DEPLOYED = "SYSTEM_DEPLOYED"
+ERROR_DEPLOYING_SYSTEM = "ERROR_DEPLOYING_SYSTEM"
 
 REQUEST_EVENTS = "REQUEST_EVENTS"
 RECEIVED_EVENTS = "RECEIVED_EVENTS"
@@ -138,16 +138,16 @@ def error_system_trust(error: str) -> Action:
     return _create_action(ERROR_SYSTEM_TRUST, error)
 
 
-def deploy_ancillary_trust() -> Action:
-    return _create_action(DEPLOY_ANCILLARY_TRUST)
+def deploy_system() -> Action:
+    return _create_action(DEPLOY_SYSTEM)
 
 
-def ancillary_trust_deployed() -> Action:
-    return _create_action(ANCILLARY_TRUST_DEPLOYED)
+def system_deployed() -> Action:
+    return _create_action(SYSTEM_DEPLOYED)
 
 
-def error_deploying_ancillary_trust(error: str) -> Action:
-    return _create_action(ERROR_DEPLOYING_ANCILLARY_TRUST, error)
+def error_deploying_system(error: str) -> Action:
+    return _create_action(ERROR_DEPLOYING_SYSTEM, error)
 
 
 def set_system_checkpoint() -> Action:

--- a/fapolicy_analyzer/ui/operations/deploy_changesets_op.py
+++ b/fapolicy_analyzer/ui/operations/deploy_changesets_op.py
@@ -23,7 +23,7 @@ from fapolicy_analyzer.ui.actions import (
     NotificationType,
     add_notification,
     clear_changesets,
-    deploy_ancillary_trust,
+    deploy_system,
     restore_system_checkpoint,
     set_system_checkpoint,
 )
@@ -34,8 +34,8 @@ from fapolicy_analyzer.ui.operations.ui_operation import UIOperation
 from fapolicy_analyzer.ui.store import dispatch, get_system_feature
 from fapolicy_analyzer.ui.strings import (
     ANY_FILES_FILTER_LABEL,
-    DEPLOY_ANCILLARY_ERROR_MSG,
-    DEPLOY_ANCILLARY_SUCCESSFUL_MSG,
+    DEPLOY_SYSTEM_ERROR_MSG,
+    DEPLOY_SYSTEM_SUCCESSFUL_MSG,
     FA_ARCHIVE_FILES_FILTER_LABEL,
     SAVE_AS_FILE_LABEL,
 )
@@ -117,19 +117,17 @@ class DeployChangesetsOp(UIOperation):
             dispatch(restore_system_checkpoint())
 
     def __on_next(self, system: Any):
-        trustState = system.get("ancillary_trust")
+        systemState = system.get("system")
 
-        if trustState.error and self.__deploying:
+        if systemState.error and self.__deploying:
             self.__deploying = False
-            logging.error("%s: %s", DEPLOY_ANCILLARY_ERROR_MSG, trustState.error)
-            dispatch(
-                add_notification(DEPLOY_ANCILLARY_ERROR_MSG, NotificationType.ERROR)
-            )
-        elif self.__deploying and trustState.deployed:
+            logging.error("%s: %s", DEPLOY_SYSTEM_ERROR_MSG, systemState.error)
+            dispatch(add_notification(DEPLOY_SYSTEM_ERROR_MSG, NotificationType.ERROR))
+        elif self.__deploying and systemState.deployed:
             self.__deploying = False
             dispatch(
                 add_notification(
-                    DEPLOY_ANCILLARY_SUCCESSFUL_MSG,
+                    DEPLOY_SYSTEM_SUCCESSFUL_MSG,
                     NotificationType.SUCCESS,
                 )
             )
@@ -169,7 +167,7 @@ class DeployChangesetsOp(UIOperation):
 
             logging.debug("Deploying...")
             self.__deploying = True
-            dispatch((deploy_ancillary_trust()))
+            dispatch((deploy_system()))
 
         dlgDeployList.get_ref().destroy()
 

--- a/fapolicy_analyzer/ui/reducers/ancillary_trust_reducer.py
+++ b/fapolicy_analyzer/ui/reducers/ancillary_trust_reducer.py
@@ -16,23 +16,18 @@
 from typing import Any, NamedTuple, Optional, Sequence, cast
 
 from fapolicy_analyzer import Trust
+from fapolicy_analyzer.redux import Action, Reducer, handle_actions
 from fapolicy_analyzer.ui.actions import (
-    ADD_CHANGESETS,
-    ANCILLARY_TRUST_DEPLOYED,
-    CLEAR_CHANGESETS,
     ERROR_ANCILLARY_TRUST,
-    ERROR_DEPLOYING_ANCILLARY_TRUST,
     RECEIVED_ANCILLARY_TRUST,
     REQUEST_ANCILLARY_TRUST,
 )
-from fapolicy_analyzer.redux import Action, Reducer, handle_actions
 
 
 class TrustState(NamedTuple):
     error: Optional[str]
     loading: bool
     trust: Sequence[Trust]
-    deployed: bool
 
 
 def _create_state(state: TrustState, **kwargs: Optional[Any]) -> TrustState:
@@ -53,34 +48,11 @@ def handle_error_ancillary_trust(state: TrustState, action: Action) -> TrustStat
     return _create_state(state, error=payload, loading=False)
 
 
-def handle_ancillary_trust_deployed(state: TrustState, action: Action) -> TrustState:
-    return _create_state(state, error=None, deployed=True)
-
-
-def handle_error_deploying_ancillary_trust(
-    state: TrustState, action: Action
-) -> TrustState:
-    payload = cast(str, action.payload)
-    return _create_state(state, error=payload)
-
-
-def handle_add_changesets(state: TrustState, action: Action) -> TrustState:
-    return _create_state(state, error=None, deployed=False)
-
-
-def handle_clear_changesets(state: TrustState, action: Action) -> TrustState:
-    return _create_state(state, error=None, deployed=True)
-
-
 ancillary_trust_reducer: Reducer = handle_actions(
     {
         REQUEST_ANCILLARY_TRUST: handle_request_ancillary_trust,
         RECEIVED_ANCILLARY_TRUST: handle_received_ancillary_trust,
         ERROR_ANCILLARY_TRUST: handle_error_ancillary_trust,
-        ANCILLARY_TRUST_DEPLOYED: handle_ancillary_trust_deployed,
-        ERROR_DEPLOYING_ANCILLARY_TRUST: handle_error_deploying_ancillary_trust,
-        ADD_CHANGESETS: handle_add_changesets,
-        CLEAR_CHANGESETS: handle_clear_changesets,
     },
-    TrustState(error=None, trust=[], deployed=True, loading=False),
+    TrustState(error=None, trust=[], loading=False),
 )

--- a/fapolicy_analyzer/ui/session_manager.py
+++ b/fapolicy_analyzer/ui/session_manager.py
@@ -28,6 +28,7 @@ from fapolicy_analyzer.ui.actions import (
     NotificationType,
     add_notification,
     apply_changesets,
+    clear_changesets,
     restore_system_checkpoint,
 )
 from fapolicy_analyzer.ui.changeset_wrapper import Changeset
@@ -147,6 +148,7 @@ class SessionManager:
         if changesets:
             # Deleting current edit session history prior to replacing it.
             dispatch(restore_system_checkpoint())
+            dispatch(clear_changesets())
             dispatch(apply_changesets(*changesets))
         return True
 

--- a/fapolicy_analyzer/ui/strings.py
+++ b/fapolicy_analyzer/ui/strings.py
@@ -37,8 +37,8 @@ DAEMON_INITIALIZATION_ERROR = _("Error initializing communications with daemon")
 
 DEPLOY_ANCILLARY_CONFIRM_DLG_ACTION_COL_HDR = _("Action")
 DEPLOY_ANCILLARY_CONFIRM_DLG_CHANGE_COL_HDR = _("Change")
-DEPLOY_ANCILLARY_SUCCESSFUL_MSG = _("Changes successfully deployed.")
-DEPLOY_ANCILLARY_ERROR_MSG = _(
+DEPLOY_SYSTEM_SUCCESSFUL_MSG = _("Changes successfully deployed.")
+DEPLOY_SYSTEM_ERROR_MSG = _(
     "An error occurred trying to deploy the changes. Please try again."
 )
 


### PR DESCRIPTION
Changed the UI behavior so changes are kept in the UI if the user decides to rollback the deploy when the post-deployment revert dialog. The functionality of loading a saved session file should be the same. When loading the file, current changes are cleared and the set of changes from the session file are loaded.

closes #550 