### PR TITLE
Add blocking fapd Handle.wait_until_active/inactive() calls

### DIFF
--- a/fapolicy_analyzer/ui/fapd_manager.py
+++ b/fapolicy_analyzer/ui/fapd_manager.py
@@ -142,6 +142,7 @@ class FapdManager():
                 try:
                     with self._fapd_lock:
                         self._fapd_ref.start()
+                        self._fapd_ref.wait_until_active(10)
                         self.mode = FapdMode.ONLINE
 
                 except Exception:
@@ -205,6 +206,7 @@ class FapdManager():
                 try:
                     with self._fapd_lock:
                         self._fapd_ref.stop()
+                        self._fapd_ref.wait_until_inactive(10)
 
                 except Exception:
                     logging.error(FAPD_DBUS_STOP_ERROR_MSG)


### PR DESCRIPTION
Phasing in explicit daemon query/waits to replace magic hard coded delays to wait for the on-line fapolicyd instance to come up or shut down when transitioning between on-line active service and FA profiling in permissive mode.

Need to create something functionally equivalent for the subprocess.Popen() fapolicyd profiling instance monitoring until it is migrated to a systemd service.