### PR TITLE
Prevent empty rules

### DIFF
--- a/crates/pyo3/src/rules.rs
+++ b/crates/pyo3/src/rules.rs
@@ -11,7 +11,7 @@ use pyo3::{exceptions, PyObjectProtocol};
 
 use fapolicy_rules::db::Entry::*;
 use fapolicy_rules::db::{Entry, DB};
-use fapolicy_rules::error::Error::MalformedFileMarker;
+use fapolicy_rules::error::Error::{MalformedFileMarker, ZeroRulesDefined};
 use fapolicy_rules::ops::Changeset;
 use fapolicy_rules::parser::parse::StrTrace;
 use fapolicy_rules::parser::rule::parse_with_error_message;
@@ -151,6 +151,13 @@ impl PyChangeset {
             Err(MalformedFileMarker(lnum, txt)) => Err(exceptions::PyRuntimeError::new_err(
                 format!("{}:malformed-file-marker:{}", lnum, txt),
             )),
+            Err(ZeroRulesDefined) => {
+                println!("throwing parse error no rules defined");
+                Err(exceptions::PyRuntimeError::new_err(format!(
+                    "{:?}",
+                    ZeroRulesDefined
+                )))
+            }
             Err(e) => Err(exceptions::PyRuntimeError::new_err(format!("{:?}", e))),
         }
     }
@@ -162,6 +169,7 @@ impl PyChangeset {
 
 #[pyfunction]
 fn rule_text_error_check(txt: &str) -> Option<String> {
+    println!("error check");
     match parse_with_error_message(StrTrace::new(txt)) {
         Ok(_) => None,
         Err(s) => Some(s),

--- a/crates/pyo3/src/rules.rs
+++ b/crates/pyo3/src/rules.rs
@@ -145,10 +145,6 @@ impl PyChangeset {
         to_vec(self.rs.get())
     }
 
-    pub fn set(&mut self, text: &str) -> bool {
-        self.rs.set(text.trim()).is_ok()
-    }
-
     pub fn parse(&mut self, text: &str) -> PyResult<()> {
         match self.rs.set(text.trim()) {
             Ok(_) => Ok(()),

--- a/crates/pyo3/src/rules.rs
+++ b/crates/pyo3/src/rules.rs
@@ -151,13 +151,10 @@ impl PyChangeset {
             Err(MalformedFileMarker(lnum, txt)) => Err(exceptions::PyRuntimeError::new_err(
                 format!("{}:malformed-file-marker:{}", lnum, txt),
             )),
-            Err(ZeroRulesDefined) => {
-                println!("throwing parse error no rules defined");
-                Err(exceptions::PyRuntimeError::new_err(format!(
-                    "{:?}",
-                    ZeroRulesDefined
-                )))
-            }
+            Err(ZeroRulesDefined) => Err(exceptions::PyRuntimeError::new_err(format!(
+                "{:?}",
+                ZeroRulesDefined
+            ))),
             Err(e) => Err(exceptions::PyRuntimeError::new_err(format!("{:?}", e))),
         }
     }

--- a/crates/rules/src/db.rs
+++ b/crates/rules/src/db.rs
@@ -194,9 +194,14 @@ impl DB {
         self.model.len()
     }
 
-    /// Test if there are any RuleDefs in this DB
+    /// Test if there are any Entries in this DB
     pub fn is_empty(&self) -> bool {
         self.model.is_empty()
+    }
+
+    /// Test if there are any RuleEntry in this DB
+    pub fn is_empty_rules(&self) -> bool {
+        self.rules.is_empty()
     }
 
     /// Get a RuleEntry ref by ID
@@ -224,6 +229,7 @@ impl DB {
         self.comments.values().collect()
     }
 
+    /// Get and entry by id (aka the fk)
     pub fn entry(&self, num: usize) -> Option<&Entry> {
         self.model.get(&num).map(|(_, e)| e)
     }

--- a/crates/rules/src/error.rs
+++ b/crates/rules/src/error.rs
@@ -17,4 +17,7 @@ pub enum Error {
 
     #[error("Malformed marker @ {0}: {1}")]
     MalformedFileMarker(usize, String),
+
+    #[error("No rules are defined")]
+    ZeroRulesDefined,
 }

--- a/crates/rules/src/ops.rs
+++ b/crates/rules/src/ops.rs
@@ -9,6 +9,7 @@
 use crate::db::{RuleEntry, DB};
 
 use crate::error::Error;
+use crate::error::Error::ZeroRulesDefined;
 use crate::read::deserialize_rules_db;
 
 // Mutable
@@ -27,16 +28,9 @@ impl Changeset {
         self.src.as_ref()
     }
 
-    // todo;; how to properly convey lints and errors in the parse fail?
-    //        perhaps just roll it up to a _simple_ Error/Warn/Ok result enum
     pub fn set(&mut self, text: &str) -> Result<&DB, Error> {
-        // todo;; what to do with the source text here?
-        //        writing it out verbatim to the disk at deploy would be ideal
-        //        but it has to be stashed somewhere until writing at deploy time
-        //        Q: use compression?  stash in temp file?  stash in XDG dir?
-        //        there is also the question of preserving the rule editing session
-        //        as was done for trust
         match deserialize_rules_db(text) {
+            Ok(r) if r.is_empty_rules() => Err(ZeroRulesDefined),
             Ok(r) => {
                 self.db = r;
                 self.src = Some(text.to_string());

--- a/fapolicy_analyzer/locale/fapolicy_analyzer.pot
+++ b/fapolicy_analyzer/locale/fapolicy_analyzer.pot
@@ -7,9 +7,9 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: fapolicy-analyzer 0.3.1+124.g36da019.dirty\n"
+"Project-Id-Version: fapolicy-analyzer 0.3.1+131.g64143b4.dirty\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2022-08-19 07:12-0400\n"
+"POT-Creation-Date: 2022-08-22 16:11-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -103,178 +103,182 @@ msgid "Error reading the Rules file"
 msgstr ""
 
 #: fapolicy_analyzer/ui/strings.py:27
+msgid "Error parsing the rules text. See log for more details."
+msgstr ""
+
+#: fapolicy_analyzer/ui/strings.py:30
 msgid ""
 "The current rule text is not valid and cannot be saved. See Status "
 "Information for details."
 msgstr ""
 
-#: fapolicy_analyzer/ui/strings.py:30
+#: fapolicy_analyzer/ui/strings.py:33
 msgid "The current rule text has warnings. See Status Information for details."
 msgstr ""
 
-#: fapolicy_analyzer/ui/strings.py:33
+#: fapolicy_analyzer/ui/strings.py:36
 msgid "Rule"
 msgstr ""
 
-#: fapolicy_analyzer/ui/strings.py:34
+#: fapolicy_analyzer/ui/strings.py:37
 msgid "Rules"
 msgstr ""
 
-#: fapolicy_analyzer/ui/strings.py:35
+#: fapolicy_analyzer/ui/strings.py:38
 msgid "Error initializing communications with daemon"
 msgstr ""
 
-#: fapolicy_analyzer/ui/strings.py:38
+#: fapolicy_analyzer/ui/strings.py:41
 msgid "Action"
 msgstr ""
 
-#: fapolicy_analyzer/ui/strings.py:39
+#: fapolicy_analyzer/ui/strings.py:42
 msgid "Change"
 msgstr ""
 
-#: fapolicy_analyzer/ui/strings.py:40
+#: fapolicy_analyzer/ui/strings.py:43
 msgid "Changes successfully deployed."
 msgstr ""
 
-#: fapolicy_analyzer/ui/strings.py:41
+#: fapolicy_analyzer/ui/strings.py:44
 msgid "An error occurred trying to deploy the changes. Please try again."
 msgstr ""
 
-#: fapolicy_analyzer/ui/strings.py:44
+#: fapolicy_analyzer/ui/strings.py:47
 msgid "Successfully reverted to the previous state."
 msgstr ""
 
-#: fapolicy_analyzer/ui/strings.py:46
+#: fapolicy_analyzer/ui/strings.py:49
 msgid "This file is trusted in the System Trust Database."
 msgstr ""
 
-#: fapolicy_analyzer/ui/strings.py:47
+#: fapolicy_analyzer/ui/strings.py:50
 msgid "There is a discrepancy between this file and the System Trust Database."
 msgstr ""
 
-#: fapolicy_analyzer/ui/strings.py:50
+#: fapolicy_analyzer/ui/strings.py:53
 msgid "The trust status of this file is unknown in the System Trust Database."
 msgstr ""
 
-#: fapolicy_analyzer/ui/strings.py:54
+#: fapolicy_analyzer/ui/strings.py:57
 msgid "This file is trusted in the Ancillary Trust Database."
 msgstr ""
 
-#: fapolicy_analyzer/ui/strings.py:57
+#: fapolicy_analyzer/ui/strings.py:60
 msgid "There is a discrepancy between this file and the Ancillary Trust Database."
 msgstr ""
 
-#: fapolicy_analyzer/ui/strings.py:60
+#: fapolicy_analyzer/ui/strings.py:63
 msgid "The trust status of this file is unknown in the Ancillary Trust Database."
 msgstr ""
 
-#: fapolicy_analyzer/ui/strings.py:64
+#: fapolicy_analyzer/ui/strings.py:67
 msgid "The trust status of this file is unknown"
 msgstr ""
 
-#: fapolicy_analyzer/ui/strings.py:66
+#: fapolicy_analyzer/ui/strings.py:69
 msgid "System Trust Database"
 msgstr ""
 
-#: fapolicy_analyzer/ui/strings.py:67
+#: fapolicy_analyzer/ui/strings.py:70
 msgid "Ancillary Trust Database"
 msgstr ""
 
 #: fapolicy_analyzer/glade/ancillary_trust_database_admin.glade:60
 #: fapolicy_analyzer/glade/trust_reconciliation_dialog.glade:41
-#: fapolicy_analyzer/ui/strings.py:69
+#: fapolicy_analyzer/ui/strings.py:72
 msgid "Trust"
 msgstr ""
 
-#: fapolicy_analyzer/ui/strings.py:70
+#: fapolicy_analyzer/ui/strings.py:73
 msgid "File"
 msgstr ""
 
-#: fapolicy_analyzer/ui/strings.py:71
+#: fapolicy_analyzer/ui/strings.py:74
 msgid "MTime"
 msgstr ""
 
-#: fapolicy_analyzer/ui/strings.py:72
+#: fapolicy_analyzer/ui/strings.py:75
 msgid "Changes"
 msgstr ""
 
-#: fapolicy_analyzer/ui/strings.py:73
+#: fapolicy_analyzer/ui/strings.py:76
 msgid "Mode"
 msgstr ""
 
-#: fapolicy_analyzer/ui/strings.py:74
+#: fapolicy_analyzer/ui/strings.py:77
 msgid "Access"
 msgstr ""
 
-#: fapolicy_analyzer/ui/strings.py:76
+#: fapolicy_analyzer/ui/strings.py:79
 msgid "Add"
 msgstr ""
 
-#: fapolicy_analyzer/ui/strings.py:77
+#: fapolicy_analyzer/ui/strings.py:80
 msgid "Delete"
 msgstr ""
 
-#: fapolicy_analyzer/ui/strings.py:78
+#: fapolicy_analyzer/ui/strings.py:81
 msgid "Add Trust"
 msgstr ""
 
-#: fapolicy_analyzer/ui/strings.py:79
+#: fapolicy_analyzer/ui/strings.py:82
 msgid "Delete Trust"
 msgstr ""
 
-#: fapolicy_analyzer/ui/strings.py:80
+#: fapolicy_analyzer/ui/strings.py:83
 msgid "Edit Rules"
 msgstr ""
 
-#: fapolicy_analyzer/ui/strings.py:82
+#: fapolicy_analyzer/ui/strings.py:85
 msgid "Add File"
 msgstr ""
 
-#: fapolicy_analyzer/ui/strings.py:83
+#: fapolicy_analyzer/ui/strings.py:86
 msgid "Open File"
 msgstr ""
 
-#: fapolicy_analyzer/ui/strings.py:84
+#: fapolicy_analyzer/ui/strings.py:87
 msgid "Save As..."
 msgstr ""
 
-#: fapolicy_analyzer/ui/strings.py:85
+#: fapolicy_analyzer/ui/strings.py:88
 msgid "FA Session files"
 msgstr ""
 
-#: fapolicy_analyzer/ui/strings.py:86
+#: fapolicy_analyzer/ui/strings.py:89
 msgid "fapolicyd archive files"
 msgstr ""
 
-#: fapolicy_analyzer/ui/strings.py:87
+#: fapolicy_analyzer/ui/strings.py:90
 msgid "Any files"
 msgstr ""
 
-#: fapolicy_analyzer/ui/strings.py:89
+#: fapolicy_analyzer/ui/strings.py:92
 msgid "On-line fapolicyd start failed"
 msgstr ""
 
-#: fapolicy_analyzer/ui/strings.py:90
+#: fapolicy_analyzer/ui/strings.py:93
 msgid "On-line fapolicyd stop failed"
 msgstr ""
 
-#: fapolicy_analyzer/ui/strings.py:92
+#: fapolicy_analyzer/ui/strings.py:95
 msgid "Profiling target file chown failure"
 msgstr ""
 
-#: fapolicy_analyzer/ui/strings.py:93
+#: fapolicy_analyzer/ui/strings.py:96
 msgid "Profiling target Popen failure"
 msgstr ""
 
-#: fapolicy_analyzer/ui/strings.py:94
+#: fapolicy_analyzer/ui/strings.py:97
 msgid "Profiling target redirection failure"
 msgstr ""
 
-#: fapolicy_analyzer/ui/strings.py:96
+#: fapolicy_analyzer/ui/strings.py:99
 msgid "File path(s) contains embedded whitespace."
 msgstr ""
 
-#: fapolicy_analyzer/ui/strings.py:97
+#: fapolicy_analyzer/ui/strings.py:100
 msgid ""
 "fapolicyd currently does not support paths containing spaces. The "
 "following paths will not be added to the Trusted Files List.\n"
@@ -282,7 +286,7 @@ msgid ""
 "\n"
 msgstr ""
 
-#: fapolicy_analyzer/ui/strings.py:102
+#: fapolicy_analyzer/ui/strings.py:105
 msgid ""
 "\n"
 "        Restore your prior session now?\n"
@@ -299,57 +303,57 @@ msgid ""
 "        "
 msgstr ""
 
-#: fapolicy_analyzer/ui/strings.py:118
+#: fapolicy_analyzer/ui/strings.py:121
 msgid "An error occurred trying to restore a prior autosaved edit session"
 msgstr ""
 
-#: fapolicy_analyzer/glade/loader.glade:44 fapolicy_analyzer/ui/strings.py:122
+#: fapolicy_analyzer/glade/loader.glade:44 fapolicy_analyzer/ui/strings.py:125
 msgid "Loading..."
 msgstr ""
 
-#: fapolicy_analyzer/ui/strings.py:124
+#: fapolicy_analyzer/ui/strings.py:127
 msgid "file"
 msgstr ""
 
-#: fapolicy_analyzer/ui/strings.py:125
+#: fapolicy_analyzer/ui/strings.py:128
 msgid "files"
 msgstr ""
 
-#: fapolicy_analyzer/ui/strings.py:126
+#: fapolicy_analyzer/ui/strings.py:129
 msgid "user"
 msgstr ""
 
-#: fapolicy_analyzer/ui/strings.py:127
+#: fapolicy_analyzer/ui/strings.py:130
 msgid "users"
 msgstr ""
 
-#: fapolicy_analyzer/ui/strings.py:128
+#: fapolicy_analyzer/ui/strings.py:131
 msgid "group"
 msgstr ""
 
-#: fapolicy_analyzer/ui/strings.py:129
+#: fapolicy_analyzer/ui/strings.py:132
 msgid "groups"
 msgstr ""
 
-#: fapolicy_analyzer/ui/strings.py:130
+#: fapolicy_analyzer/ui/strings.py:133
 msgid ""
 "An error occurred trying to parse the event log file. Please try again or"
 " select a different file."
 msgstr ""
 
-#: fapolicy_analyzer/ui/strings.py:133
+#: fapolicy_analyzer/ui/strings.py:136
 msgid "An error occurred trying to retrieve the user list. Please try again."
 msgstr ""
 
-#: fapolicy_analyzer/ui/strings.py:136
+#: fapolicy_analyzer/ui/strings.py:139
 msgid "An error occurred trying to retrieve the group list. Please try again."
 msgstr ""
 
-#: fapolicy_analyzer/ui/strings.py:140
+#: fapolicy_analyzer/ui/strings.py:143
 msgid "Could not load application resources"
 msgstr ""
 
-#: fapolicy_analyzer/ui/strings.py:141
+#: fapolicy_analyzer/ui/strings.py:144
 msgid ""
 "The required application resource files could not be loaded from disk.\n"
 "The fapolicy analyzer application cannot open.\n"
@@ -361,11 +365,11 @@ msgid ""
 "2. An incorrectly configured fapolicyd rule set."
 msgstr ""
 
-#: fapolicy_analyzer/ui/strings.py:152
+#: fapolicy_analyzer/ui/strings.py:155
 msgid "Trust Database"
 msgstr ""
 
-#: fapolicy_analyzer/ui/strings.py:153
+#: fapolicy_analyzer/ui/strings.py:156
 msgid ""
 "\n"
 "The fapolicyd trusted resources database\n"
@@ -390,7 +394,7 @@ msgid ""
 "    "
 msgstr ""
 
-#: fapolicy_analyzer/ui/strings.py:177
+#: fapolicy_analyzer/ui/strings.py:180
 msgid "Error applying changes"
 msgstr ""
 

--- a/fapolicy_analyzer/tests/test_changeset_wrapper.py
+++ b/fapolicy_analyzer/tests/test_changeset_wrapper.py
@@ -49,13 +49,13 @@ def test_RuleChangeset_apply():
     mock_system_apply.assert_called_with(sut._RuleChangeset__wrapped)
 
 
-def test_RuleChangeset_set(mocker):
+def test_RuleChangeset_parse(mocker):
     mock = mocker.patch(
         "fapolicy_analyzer.ui.changeset_wrapper.fapolicy_analyzer.RuleChangeset"
     )
     sut = RuleChangeset()
-    sut.set("foo")
-    mock().set.assert_called_with("foo")
+    sut.parse("foo")
+    mock().parse.assert_called_with("foo")
 
 
 def test_RuleChangeset_rules(mocker):
@@ -69,7 +69,7 @@ def test_RuleChangeset_rules(mocker):
 
 def test_RuleChangeset_serialize():
     sut = RuleChangeset()
-    sut.set("foo")
+    sut.parse("foo")
     assert sut.serialize() == "foo"
 
 

--- a/fapolicy_analyzer/tests/test_session_manager.py
+++ b/fapolicy_analyzer/tests/test_session_manager.py
@@ -50,7 +50,7 @@ test_json = json.dumps(
 )
 
 test_changesets = [RuleChangeset(), TrustChangeset()]
-test_changesets[0].set("foo rules")
+test_changesets[0].parse("foo rules")
 test_changesets[1].delete("/data_space/this/is/a/longer/path/now_is_the_time.txt")
 test_changesets[1].add("/data_space/Integration.json")
 

--- a/fapolicy_analyzer/ui/changeset_wrapper.py
+++ b/fapolicy_analyzer/ui/changeset_wrapper.py
@@ -43,7 +43,7 @@ class Changeset(ABC, Generic[T]):
             return tcs
         elif isinstance(data, str):
             rcs = RuleChangeset()
-            rcs.set(data)
+            rcs.parse(data)
             return rcs
 
         raise TypeError("Invalid changeset type to deserialize")
@@ -53,7 +53,7 @@ class RuleChangeset(Changeset[str]):
     def __init__(self):
         self.__wrapped = fapolicy_analyzer.RuleChangeset()
 
-    def set(self, change: str):
+    def parse(self, change: str):
         self.__wrapped.parse(change)
 
     def rules(self):

--- a/fapolicy_analyzer/ui/changeset_wrapper.py
+++ b/fapolicy_analyzer/ui/changeset_wrapper.py
@@ -54,7 +54,7 @@ class RuleChangeset(Changeset[str]):
         self.__wrapped = fapolicy_analyzer.RuleChangeset()
 
     def set(self, change: str):
-        self.__wrapped.set(change)
+        self.__wrapped.parse(change)
 
     def rules(self):
         return self.__wrapped.rules()

--- a/fapolicy_analyzer/ui/rules/rules_admin_page.py
+++ b/fapolicy_analyzer/ui/rules/rules_admin_page.py
@@ -144,7 +144,7 @@ class RulesAdminPage(UIConnectedWidget, UIPage):
             changeset.set(self.__modified_rules_text)
         except Exception as e:
             logging.error(
-                "%s", e
+                "save --------------> %s", e
             )
 
         if self.__valid_changes(changeset):
@@ -155,6 +155,13 @@ class RulesAdminPage(UIConnectedWidget, UIPage):
 
     def on_validate_clicked(self, *args):
         changeset = RuleChangeset()
+        try:
+            changeset.set(self.__modified_rules_text)
+        except Exception as e:
+            logging.error(
+                "validate --------> %s", e
+            )
+
         changeset.set(self.__modified_rules_text)
         self.__valid_changes(changeset)
         self.__status_info.render_rule_status(changeset.rules())

--- a/fapolicy_analyzer/ui/rules/rules_admin_page.py
+++ b/fapolicy_analyzer/ui/rules/rules_admin_page.py
@@ -140,7 +140,13 @@ class RulesAdminPage(UIConnectedWidget, UIPage):
 
     def on_save_clicked(self, *args):
         changeset = RuleChangeset()
-        changeset.set(self.__modified_rules_text)
+        try:
+            changeset.set(self.__modified_rules_text)
+        except Exception as e:
+            logging.error(
+                "%s", e
+            )
+
         if self.__valid_changes(changeset):
             self.__saving = True
             dispatch(apply_changesets(changeset))

--- a/fapolicy_analyzer/ui/rules/rules_admin_page.py
+++ b/fapolicy_analyzer/ui/rules/rules_admin_page.py
@@ -14,7 +14,7 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import logging
-from typing import Any, Optional, Sequence
+from typing import Any, Optional, Sequence, Tuple
 
 from fapolicy_analyzer import Rule, System
 from fapolicy_analyzer.ui.actions import (
@@ -32,6 +32,7 @@ from fapolicy_analyzer.ui.rules.rules_text_view import RulesTextView
 from fapolicy_analyzer.ui.store import dispatch, get_system_feature
 from fapolicy_analyzer.ui.strings import (
     APPLY_CHANGESETS_ERROR_MESSAGE,
+    RULES_CHANGESET_PARSE_ERROR,
     RULES_LOAD_ERROR,
     RULES_TEXT_LOAD_ERROR,
     RULES_VALIDATION_ERROR,
@@ -108,16 +109,31 @@ class RulesAdminPage(UIConnectedWidget, UIPage):
             and self.__modified_rules_text != self.__rules_text
         )
 
-    def __valid_changes(self, changeset: RuleChangeset) -> bool:
-        rules = changeset.rules()
-
-        # update the rules list view with changes
+    def __update_list_view(self, changeset: RuleChangeset):
         if self.__system:
             try:
                 tmp_system = changeset.apply_to_system(self.__system)
                 self._list_view.render_rules(tmp_system.rules())
             except Exception:
                 logging.warning("Failed to parse validating changeset")
+
+    def __build_and_validate_changeset(self) -> Tuple[RuleChangeset, bool]:
+        changeset = RuleChangeset()
+        valid = True
+
+        try:
+            changeset.parse(self.__modified_rules_text)
+        except Exception as e:
+            logging.error("Error setting changeset rules: %s", e)
+            dispatch(
+                add_notification(
+                    RULES_CHANGESET_PARSE_ERROR,
+                    NotificationType.ERROR,
+                )
+            )
+            return changeset, False
+
+        rules = changeset.rules()
 
         if not all([r.is_valid for r in rules]):
             dispatch(
@@ -126,7 +142,7 @@ class RulesAdminPage(UIConnectedWidget, UIPage):
                     NotificationType.ERROR,
                 )
             )
-            return False
+            valid = False
 
         if any([True for r in rules for i in r.info if i.category.lower() == "w"]):
             dispatch(
@@ -135,35 +151,20 @@ class RulesAdminPage(UIConnectedWidget, UIPage):
                     NotificationType.WARN,
                 )
             )
-
-        return True
+        return changeset, valid
 
     def on_save_clicked(self, *args):
-        changeset = RuleChangeset()
-        try:
-            changeset.set(self.__modified_rules_text)
-        except Exception as e:
-            logging.error(
-                "save --------------> %s", e
-            )
-
-        if self.__valid_changes(changeset):
+        changeset, valid = self.__build_and_validate_changeset()
+        self.__update_list_view(changeset)
+        if valid:
             self.__saving = True
             dispatch(apply_changesets(changeset))
         else:
             self.__status_info.render_rule_status(changeset.rules())
 
     def on_validate_clicked(self, *args):
-        changeset = RuleChangeset()
-        try:
-            changeset.set(self.__modified_rules_text)
-        except Exception as e:
-            logging.error(
-                "validate --------> %s", e
-            )
-
-        changeset.set(self.__modified_rules_text)
-        self.__valid_changes(changeset)
+        changeset, _ = self.__build_and_validate_changeset()
+        self.__update_list_view(changeset)
         self.__status_info.render_rule_status(changeset.rules())
 
     def on_text_view_rules_changed(self, rules: str):

--- a/fapolicy_analyzer/ui/strings.py
+++ b/fapolicy_analyzer/ui/strings.py
@@ -24,6 +24,9 @@ SYSTEM_TRUST_LOAD_ERROR = _("Error loading System Trust")
 RULES_LOAD_ERROR = _("Error loading Rules")
 RULES_TEXT_LOAD_ERROR = _("Error loading Rules text")
 RULES_FILE_READ_ERROR = _("Error reading the Rules file")
+RULES_CHANGESET_PARSE_ERROR = _(
+    "Error parsing the rules text. See log for more details."
+)
 RULES_VALIDATION_ERROR = _(
     "The current rule text is not valid and cannot be saved. See Status Information for details."
 )


### PR DESCRIPTION
Detect empty rules and throw a parse error to prevent the system from deploying and ultimately blowing up the fapolicyd reload.

Classifying the empty-rule failure in same bucket as a malformed-marker parse, doing that stops the changeset from being populated which seems to be the right spot in the flow to put a halt to things.

This impacts the bindings by dropping the `set` call which never throws, and forcing the use of the `parse` call that may throw.  Forcing the client to be aware of the potential parse error here is important.

Closes #604 