### PR TITLE
Ignore part ordering in dupe detection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -278,7 +278,7 @@ dependencies = [
 
 [[package]]
 name = "fapolicy-rules"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "nom",
  "serde",

--- a/crates/rules/Cargo.toml
+++ b/crates/rules/Cargo.toml
@@ -2,7 +2,7 @@
 name = "fapolicy-rules"
 description = "Rule support for fapolicyd"
 license = "MPL-2.0"
-version = "0.4.1"
+version = "0.4.2"
 edition = "2018"
 
 [lib]

--- a/crates/rules/src/file_type.rs
+++ b/crates/rules/src/file_type.rs
@@ -10,7 +10,7 @@ use std::fmt::{Display, Formatter};
 
 use crate::set::Set;
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq, Hash)]
 pub enum Rvalue {
     Any,
     Literal(String),

--- a/crates/rules/src/lib.rs
+++ b/crates/rules/src/lib.rs
@@ -15,6 +15,8 @@ pub use self::rule::Rule;
 pub use self::set::Set;
 pub use self::subject::Part as SubjPart;
 pub use self::subject::Subject;
+use std::collections::HashMap;
+use std::hash::Hash;
 
 pub mod ops;
 pub mod parser;
@@ -42,4 +44,15 @@ pub(crate) fn bool_to_c(b: bool) -> char {
     } else {
         '0'
     }
+}
+
+pub(crate) fn hasher<T>(items: &[T]) -> HashMap<&T, usize>
+where
+    T: Eq + Hash,
+{
+    let mut map = HashMap::new();
+    for i in items {
+        *map.entry(i).or_insert(0) += 1
+    }
+    map
 }

--- a/crates/rules/src/linter/findings.rs
+++ b/crates/rules/src/linter/findings.rs
@@ -140,6 +140,40 @@ mod tests {
     }
 
     #[test]
+    fn lint_duplicate_subject_ordering() -> Result<(), Box<dyn Error>> {
+        let db = deserialize_rules_db(
+            r#"
+        [foo.bar]
+        deny perm=any gid=1 uid=1 : all
+        deny perm=any uid=1 gid=1 : all
+        "#,
+        )?;
+        let r = db.rule(1).unwrap();
+
+        assert!(r.msg.is_some());
+        assert!(r.msg.as_ref().unwrap().starts_with(L004_MESSAGE));
+        assert!(r.msg.as_ref().unwrap().ends_with(&2.to_string()));
+        Ok(())
+    }
+
+    #[test]
+    fn lint_duplicate_object_ordering() -> Result<(), Box<dyn Error>> {
+        let db = deserialize_rules_db(
+            r#"
+        [foo.bar]
+        deny perm=any all : dir=/tmp/ trust=1
+        deny perm=any all : trust=1 dir=/tmp/
+        "#,
+        )?;
+        let r = db.rule(1).unwrap();
+
+        assert!(r.msg.is_some());
+        assert!(r.msg.as_ref().unwrap().starts_with(L004_MESSAGE));
+        assert!(r.msg.as_ref().unwrap().ends_with(&2.to_string()));
+        Ok(())
+    }
+
+    #[test]
     fn lint_missing_dir() -> Result<(), Box<dyn Error>> {
         let db = deserialize_rules_db("allow perm=any all : dir=/foo")?;
         let r = db.rule(1).unwrap();

--- a/crates/rules/src/object.rs
+++ b/crates/rules/src/object.rs
@@ -111,10 +111,6 @@ impl PartialEq for Object {
         use crate::hasher;
         hasher(&self.parts) == hasher(&other.parts)
     }
-
-    fn ne(&self, other: &Self) -> bool {
-        !self.eq(other)
-    }
 }
 
 #[cfg(test)]

--- a/crates/rules/src/object.rs
+++ b/crates/rules/src/object.rs
@@ -14,7 +14,7 @@ use crate::{bool_to_c, ObjPart, Rvalue};
 /// The object is the file that the subject is interacting with.
 /// The fields in the rule that describe the object are written in a `name=value` format.
 /// There can be one or more object fields. Each field is and'ed with others to decide if a rule triggers.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug)]
 pub struct Object {
     pub parts: Vec<Part>,
 }
@@ -52,7 +52,7 @@ impl Object {
 ///     - The hash in the rules should be all lowercase letters and do NOT start with 0x.
 ///     - Lowercase is the default output of sha256sum.
 ///
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq, Hash)]
 pub enum Part {
     /// This matches against any subject. When used, this must be the only subject in the rule.
     All,
@@ -103,6 +103,17 @@ impl Display for Part {
             Part::Path(p) => f.write_fmt(format_args!("path={}", p)),
             Part::Trust(b) => f.write_fmt(format_args!("trust={}", bool_to_c(*b))),
         }
+    }
+}
+
+impl PartialEq for Object {
+    fn eq(&self, other: &Self) -> bool {
+        use crate::hasher;
+        hasher(&self.parts) == hasher(&other.parts)
+    }
+
+    fn ne(&self, other: &Self) -> bool {
+        !self.eq(other)
     }
 }
 

--- a/crates/rules/src/set.rs
+++ b/crates/rules/src/set.rs
@@ -21,7 +21,7 @@ use std::fmt::{Display, Formatter};
 /// - It is also possible to use a plain list as an attribute value without previous definition.
 /// - The assigned set has to match the attribute type. It is not possible set groups for `TRUST` and `PATTERN` attributes.
 ///
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq, Hash)]
 pub struct Set {
     pub name: String,
     pub values: Vec<String>,

--- a/crates/rules/src/subject.rs
+++ b/crates/rules/src/subject.rs
@@ -136,10 +136,6 @@ impl PartialEq for Subject {
         use crate::hasher;
         hasher(&self.parts) == hasher(&other.parts)
     }
-
-    fn ne(&self, other: &Self) -> bool {
-        !self.eq(other)
-    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Implement partialeq to check subject and object parts without concern of ordering.

This should probably be benched in some way.

Closes #620 