### PR TITLE
Disable Profiler menu item for non-root users

### DIFF
--- a/fapolicy_analyzer/tests/test_main_window.py
+++ b/fapolicy_analyzer/tests/test_main_window.py
@@ -103,6 +103,17 @@ def es_locale():
     reload(fapolicy_analyzer.ui)
 
 
+@pytest.fixture
+def profiler_envvar_override(monkeypatch):
+    monkeypatch.setenv("PROF_UI_ENABLE", "TRUE")
+
+
+@pytest.fixture
+def profiler_file_override(mocker):
+    mocker.patch("fapolicy_analyzer.ui.main_window.path.exists",
+                 return_value=True)
+
+
 def test_displays_window(mainWindow):
     window = mainWindow.get_ref()
     assert type(window) is Gtk.Window
@@ -608,6 +619,21 @@ def test_update_fapd_status(mainWindow, mocker):
     mainWindow._update_fapd_status(ServiceStatus.UNKNOWN)
     tupleIdSize = mainWindow.get_object("fapdStatusLight").get_icon_name()
     assert tupleIdSize == ("edit-delete", 4)
+
+
+def test_profiler_ui_envvar_override(profiler_envvar_override, mainWindow):
+    menu_item = mainWindow.get_object("profileExecMenu")
+    assert menu_item.get_sensitive()
+
+
+def test_profiler_ui_default(mainWindow):
+    menu_item = mainWindow.get_object("profileExecMenu")
+    assert not menu_item.get_sensitive()
+
+
+def test_profiler_ui_file_override(profiler_file_override, mainWindow):
+    menu_item = mainWindow.get_object("profileExecMenu")
+    assert menu_item.get_sensitive()
 
 
 def test_added_page_specific_toolbar_buttons(mainWindow):

--- a/fapolicy_analyzer/ui/main_window.py
+++ b/fapolicy_analyzer/ui/main_window.py
@@ -89,9 +89,10 @@ class MainWindow(UIConnectedWidget):
         # Set fapd status UI element to default 'No' = Red button
         self.fapdStatusLight.set_from_icon_name("process-stop", size=4)
 
-        # Set initial fapd menu item state
+        # Set initial fapd menu items state
         self._fapdStartMenuItem.set_sensitive(False)
         self._fapdStopMenuItem.set_sensitive(False)
+        self.get_object("profileExecMenu").set_sensitive(self._fapdControlPermitted)
 
         self.__add_toolbar()
         self.window.show_all()

--- a/fapolicy_analyzer/ui/main_window.py
+++ b/fapolicy_analyzer/ui/main_window.py
@@ -92,7 +92,12 @@ class MainWindow(UIConnectedWidget):
         # Set initial fapd menu items state
         self._fapdStartMenuItem.set_sensitive(False)
         self._fapdStopMenuItem.set_sensitive(False)
-        self.get_object("profileExecMenu").set_sensitive(self._fapdControlPermitted)
+
+        # Enable profiler tool menu item if root user, env var, or magic file
+        prof_ui_enable = (self._fapdControlPermitted  # EUID == 0
+                          or getenv("PROF_UI_ENABLE", "false").lower() != "false"
+                          or path.exists("/tmp/prof_ui_enable"))
+        self.get_object("profileExecMenu").set_sensitive(prof_ui_enable)
 
         self.__add_toolbar()
         self.window.show_all()


### PR DESCRIPTION
Add development overrides via `PROF_UI_ENABLE` env var and/or the existence of the magic file, `/tmp/prof_ui_enable`.