### PR TITLE
Multiple gid in analysis

### DIFF
--- a/crates/pyo3/src/analysis.rs
+++ b/crates/pyo3/src/analysis.rs
@@ -47,7 +47,7 @@ pub(crate) fn expand_on_gid(rs: &Analysis) -> Vec<PyEvent> {
             },
         })
     }
-    dbg!(&r);
+    //dbg!(&r);
     r
 }
 
@@ -208,7 +208,7 @@ impl PyEventLog {
     fn by_user(&self, uid: i32) -> Vec<PyEvent> {
         analyze(&self.rs, Perspective::User(uid), &self.rs_trust)
             .iter()
-            .flat_map(|e| expand_on_gid(e))
+            .flat_map(|e| expand_on_gid(e).into_iter().filter(|e| e.uid() == uid))
             .collect()
     }
 
@@ -216,7 +216,7 @@ impl PyEventLog {
     fn by_group(&self, gid: i32) -> Vec<PyEvent> {
         analyze(&self.rs, Perspective::Group(gid), &self.rs_trust)
             .iter()
-            .flat_map(|e| expand_on_gid(e))
+            .flat_map(|e| expand_on_gid(e).into_iter().filter(|e| e.gid() == gid))
             .collect()
     }
 }

--- a/crates/pyo3/src/analysis.rs
+++ b/crates/pyo3/src/analysis.rs
@@ -12,7 +12,7 @@ use pyo3::prelude::*;
 
 use fapolicy_analyzer::events::analysis::{analyze, Analysis, ObjAnalysis, SubjAnalysis};
 use fapolicy_analyzer::events::db::DB as EventDB;
-use fapolicy_analyzer::events::event::Perspective;
+use fapolicy_analyzer::events::event::{Event, Perspective};
 use fapolicy_trust::db::DB as TrustDB;
 
 /// An Event parsed from a fapolicyd log
@@ -30,6 +30,24 @@ impl From<PyEvent> for Analysis {
     fn from(py: PyEvent) -> Self {
         py.rs
     }
+}
+
+pub(crate) fn expand_on_gid(rs: &Analysis) -> Vec<PyEvent> {
+    let mut r = vec![];
+    for gid in &rs.event.gid {
+        let e = rs.clone().event;
+        r.push(PyEvent {
+            rs: Analysis {
+                event: Event {
+                    gid: vec![*gid],
+                    ..e
+                },
+                subject: rs.subject.clone(),
+                object: rs.object.clone(),
+            },
+        })
+    }
+    r
 }
 
 #[pymethods]
@@ -181,7 +199,7 @@ impl PyEventLog {
     fn by_subject(&self, path: String) -> Vec<PyEvent> {
         analyze(&self.rs, Perspective::Subject(path), &self.rs_trust)
             .iter()
-            .map(|e| PyEvent::from(e.clone()))
+            .flat_map(|e| expand_on_gid(e))
             .collect()
     }
 
@@ -189,7 +207,7 @@ impl PyEventLog {
     fn by_user(&self, uid: i32) -> Vec<PyEvent> {
         analyze(&self.rs, Perspective::User(uid), &self.rs_trust)
             .iter()
-            .map(|e| PyEvent::from(e.clone()))
+            .flat_map(|e| expand_on_gid(e))
             .collect()
     }
 
@@ -197,7 +215,7 @@ impl PyEventLog {
     fn by_group(&self, gid: i32) -> Vec<PyEvent> {
         analyze(&self.rs, Perspective::Group(gid), &self.rs_trust)
             .iter()
-            .map(|e| PyEvent::from(e.clone()))
+            .flat_map(|e| expand_on_gid(e))
             .collect()
     }
 }

--- a/crates/pyo3/src/analysis.rs
+++ b/crates/pyo3/src/analysis.rs
@@ -47,7 +47,6 @@ pub(crate) fn expand_on_gid(rs: &Analysis) -> Vec<PyEvent> {
             },
         })
     }
-    //dbg!(&r);
     r
 }
 

--- a/crates/pyo3/src/analysis.rs
+++ b/crates/pyo3/src/analysis.rs
@@ -17,7 +17,7 @@ use fapolicy_trust::db::DB as TrustDB;
 
 /// An Event parsed from a fapolicyd log
 #[pyclass(module = "log", name = "Event")]
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct PyEvent {
     rs: Analysis,
 }
@@ -47,6 +47,7 @@ pub(crate) fn expand_on_gid(rs: &Analysis) -> Vec<PyEvent> {
             },
         })
     }
+    dbg!(&r);
     r
 }
 

--- a/examples/analyze_log.py
+++ b/examples/analyze_log.py
@@ -14,6 +14,7 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 from fapolicy_analyzer import *
+import argparse
 
 
 def show_event(e):
@@ -22,8 +23,13 @@ def show_event(e):
     print(f'{e.uid}:{e.gid} {s.file} => {o.file}')
 
 
+parser = argparse.ArgumentParser()
+parser.add_argument("path", type=str, help="Event log to analyzer")
+args = parser.parse_args()
+
+
 s = System()
-log = s.events('tests/data/events1.log')
+log = s.load_debuglog(args.path)
 
 print(f"Subjects in log: {len(log.subjects())}\n")
 
@@ -32,16 +38,18 @@ for e in log.by_subject('/bin/bash'):
     show_event(e)
 print()
 
-print('# User events - 1')
-for e in log.by_user(1):
-    show_event(e)
-print()
+for u in s.users():
+    ulog = log.by_user(u.id)
+    if ulog:
+        print(f"# User events - {u.id}")
+        for e in ulog:
+            show_event(e)
+        print()
 
-print('Group events- 555')
-for e in log.by_group(555):
-    show_event(e)
-print()
-
-print('Group events - 888')
-for e in log.by_group(888):
-    show_event(e)
+for g in s.groups():
+    glog = log.by_group(g.id)
+    if glog:
+        print(f"# Group events - {g.id}")
+        for e in glog:
+            show_event(e)
+        print()

--- a/examples/analyze_log.py
+++ b/examples/analyze_log.py
@@ -33,15 +33,18 @@ log = s.load_debuglog(args.path)
 
 print(f"Subjects in log: {len(log.subjects())}\n")
 
-print('# Subject events')
-for e in log.by_subject('/bin/bash'):
-    show_event(e)
-print()
+for sub in log.subjects():
+    slog = log.by_subject(sub)
+    if slog:
+        print(f"# Subject {sub} events")
+        for e in slog:
+            show_event(e)
+        print()
 
 for u in s.users():
     ulog = log.by_user(u.id)
     if ulog:
-        print(f"# User events - {u.id}")
+        print(f"# User {u.id} events")
         for e in ulog:
             show_event(e)
         print()

--- a/tests/data/events2.log
+++ b/tests/data/events2.log
@@ -1,1 +1,2 @@
 rule=1 dec=allow perm=any uid=0 gid=990,999 pid=111 exe=/usr/bin/bash : path=/usr/bin/foo
+rule=1 dec=allow perm=any uid=0 gid=999 pid=111 exe=/usr/bin/bash : path=/usr/bin/bar

--- a/tests/data/events2.log
+++ b/tests/data/events2.log
@@ -1,0 +1,1 @@
+rule=1 dec=allow perm=any uid=0 gid=990,999 pid=111 exe=/usr/bin/bash : path=/usr/bin/foo


### PR DESCRIPTION
Ensure gid lists in analysis logs make it to the UI.

## Testing

Given the log

```
rule=1 dec=allow perm=any uid=0 gid=990,999 pid=111 exe=/usr/bin/bash : path=/usr/bin/foo
rule=1 dec=allow perm=any uid=0 gid=999     pid=111 exe=/usr/bin/bash : path=/usr/bin/bar
```

```
Subjects in log: 1

# Subject events

# User events - 0
0:990 /usr/bin/bash => /usr/bin/foo
0:999 /usr/bin/bash => /usr/bin/foo
0:999 /usr/bin/bash => /usr/bin/bar

# Group events - 999
0:999 /usr/bin/bash => /usr/bin/foo
0:999 /usr/bin/bash => /usr/bin/bar

# Group events - 990
0:990 /usr/bin/bash => /usr/bin/foo
```

`python3 examples/analyze_log.py tests/data/events2.log`

Closes #267
