### PR TITLE
Temporal filtering of events

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -286,6 +286,7 @@ dependencies = [
 name = "fapolicy-pyo3"
 version = "0.4.0"
 dependencies = [
+ "chrono",
  "fapolicy-analyzer",
  "fapolicy-app",
  "fapolicy-daemon",

--- a/crates/analyzer/src/events/db.rs
+++ b/crates/analyzer/src/events/db.rs
@@ -19,6 +19,10 @@ impl DB {
         DB { events: es }
     }
 
+    pub fn len(&self) -> usize {
+        self.events.len()
+    }
+
     /// Get an iterator to the underlying events
     pub fn iter(&self) -> Iter<'_, Event> {
         self.events.iter()

--- a/crates/pyo3/Cargo.toml
+++ b/crates/pyo3/Cargo.toml
@@ -11,6 +11,7 @@ crate-type = ["cdylib"]
 [dependencies]
 pyo3 = { version="0.15", features = ["abi3-py36"] }
 similar = "2.1"
+chrono = "0.4.22"
 
 fapolicy-analyzer = { version = "*", path = "../analyzer" }
 fapolicy-app = { version = "*", path = "../app" }

--- a/crates/pyo3/src/analysis.rs
+++ b/crates/pyo3/src/analysis.rs
@@ -208,23 +208,17 @@ impl PyEventLog {
         m.into_iter().collect()
     }
 
-    fn within(&self, start: usize, stop: usize) -> PyEventLog {
-        let mut other = self.clone();
-        other.start = Some(start);
-        other.stop = Some(stop);
-        other
+    fn begin(&mut self, start: usize) {
+        self.start = Some(start);
     }
 
-    fn from(&self, start: usize) -> PyEventLog {
-        let mut other = self.clone();
-        other.start = Some(start);
-        other
+    fn until(&mut self, stop: usize) {
+        self.stop = Some(stop);
     }
 
-    fn until(&self, stop: usize) -> PyEventLog {
-        let mut other = self.clone();
-        other.stop = Some(stop);
-        other
+    fn unbounded(&mut self) {
+        self.start = None;
+        self.stop = None;
     }
 
     /// Get events that fit the given subject perspective perspective

--- a/crates/pyo3/src/analysis.rs
+++ b/crates/pyo3/src/analysis.rs
@@ -215,13 +215,13 @@ impl PyEventLog {
         other
     }
 
-    fn starting(&self, start: usize) -> PyEventLog {
+    fn from(&self, start: usize) -> PyEventLog {
         let mut other = self.clone();
         other.start = Some(start);
         other
     }
 
-    fn ending(&self, stop: usize) -> PyEventLog {
+    fn until(&self, stop: usize) -> PyEventLog {
         let mut other = self.clone();
         other.stop = Some(stop);
         other

--- a/crates/pyo3/src/analysis.rs
+++ b/crates/pyo3/src/analysis.rs
@@ -185,6 +185,19 @@ impl PyObject {
 pub struct PyEventLog {
     pub(crate) rs: EventDB,
     pub(crate) rs_trust: TrustDB,
+    start: Option<usize>,
+    stop: Option<usize>,
+}
+
+impl PyEventLog {
+    pub(crate) fn new(rs: EventDB, trust: TrustDB) -> Self {
+        Self {
+            rs,
+            rs_trust: trust,
+            start: None,
+            stop: None,
+        }
+    }
 }
 
 #[pymethods]
@@ -193,6 +206,25 @@ impl PyEventLog {
     fn subjects(&self) -> Vec<String> {
         let m: HashSet<String> = self.rs.iter().filter_map(|e| e.subj.exe()).collect();
         m.into_iter().collect()
+    }
+
+    fn within(&self, start: usize, stop: usize) -> PyEventLog {
+        let mut other = self.clone();
+        other.start = Some(start);
+        other.stop = Some(stop);
+        other
+    }
+
+    fn starting(&self, start: usize) -> PyEventLog {
+        let mut other = self.clone();
+        other.start = Some(start);
+        other
+    }
+
+    fn ending(&self, stop: usize) -> PyEventLog {
+        let mut other = self.clone();
+        other.stop = Some(stop);
+        other
     }
 
     /// Get events that fit the given subject perspective perspective

--- a/crates/pyo3/src/analysis.rs
+++ b/crates/pyo3/src/analysis.rs
@@ -185,8 +185,8 @@ impl PyObject {
 pub struct PyEventLog {
     pub(crate) rs: EventDB,
     pub(crate) rs_trust: TrustDB,
-    start: Option<usize>,
-    stop: Option<usize>,
+    start: Option<i64>,
+    stop: Option<i64>,
 }
 
 impl PyEventLog {
@@ -196,6 +196,15 @@ impl PyEventLog {
             rs_trust: trust,
             start: None,
             stop: None,
+        }
+    }
+
+    fn temporal_filter(&self, e: &PyEvent) -> bool {
+        match (e.rs.event.when, self.start, self.stop) {
+            (None, _, _) | (_, None, None) => true,
+            (Some(t), Some(begin), None) => t.timestamp() >= begin,
+            (Some(t), None, Some(end)) => t.timestamp() <= end,
+            (Some(t), Some(begin), Some(end)) => t.timestamp() >= begin && t.timestamp() <= end,
         }
     }
 }
@@ -208,25 +217,30 @@ impl PyEventLog {
         m.into_iter().collect()
     }
 
-    fn begin(&mut self, start: usize) {
+    fn begin(&mut self, start: i64) {
         self.start = Some(start);
     }
 
-    fn until(&mut self, stop: usize) {
+    fn until(&mut self, stop: i64) {
         self.stop = Some(stop);
     }
 
-    fn unbounded(&mut self) {
+    fn clear_bounds(&mut self) {
         self.start = None;
         self.stop = None;
     }
 
     /// Get events that fit the given subject perspective perspective
-    fn by_subject(&self, path: String) -> Vec<PyEvent> {
-        analyze(&self.rs, Perspective::Subject(path), &self.rs_trust)
-            .iter()
-            .flat_map(|e| expand_on_gid(e))
-            .collect()
+    fn by_subject(&self, path: &str) -> Vec<PyEvent> {
+        analyze(
+            &self.rs,
+            Perspective::Subject(path.to_string()),
+            &self.rs_trust,
+        )
+        .iter()
+        .flat_map(|e| expand_on_gid(e))
+        .filter(|e| self.temporal_filter(e))
+        .collect()
     }
 
     /// Get events that fit the given user perspective
@@ -234,6 +248,7 @@ impl PyEventLog {
         analyze(&self.rs, Perspective::User(uid), &self.rs_trust)
             .iter()
             .flat_map(|e| expand_on_gid(e).into_iter().filter(|e| e.uid() == uid))
+            .filter(|e| self.temporal_filter(e))
             .collect()
     }
 
@@ -242,7 +257,73 @@ impl PyEventLog {
         analyze(&self.rs, Perspective::Group(gid), &self.rs_trust)
             .iter()
             .flat_map(|e| expand_on_gid(e).into_iter().filter(|e| e.gid() == gid))
+            .filter(|e| self.temporal_filter(e))
             .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::{DateTime, NaiveDateTime, Utc};
+    use fapolicy_rules::{Decision, Object, Permission, Subject};
+
+    const TEST_PATH: &str = "/bin/bash";
+
+    fn events() -> EventDB {
+        let t = Event {
+            rule_id: 0,
+            dec: Decision::AllowAudit,
+            perm: Permission::Any,
+            uid: 0,
+            gid: vec![0],
+            pid: 0,
+            subj: Subject::from_exe(TEST_PATH),
+            obj: Object::from_path(TEST_PATH),
+            when: None,
+        };
+        let events = (0..=5)
+            .map(|i| Event {
+                rule_id: i,
+                when: Some(DateTime::from_utc(
+                    NaiveDateTime::from_timestamp(i as i64, 0),
+                    Utc,
+                )),
+                ..t.clone()
+            })
+            .collect();
+        EventDB::from(events)
+    }
+
+    #[test]
+    fn temporal_filtering() {
+        let e = events();
+        let all = e.len();
+        let mut log = PyEventLog {
+            rs: e,
+            rs_trust: Default::default(),
+            start: Some(0),
+            stop: Some(5),
+        };
+        assert_eq!(all, log.by_subject(TEST_PATH).len());
+
+        log.begin(1);
+        assert_eq!(all - 1, log.by_subject(TEST_PATH).len());
+
+        log.until(4);
+        assert_eq!(all - 2, log.by_subject(TEST_PATH).len());
+
+        log.until(3);
+        assert_eq!(all - 3, log.by_subject(TEST_PATH).len());
+
+        log.begin(2);
+        assert_eq!(all - 4, log.by_subject(TEST_PATH).len());
+
+        log.clear_bounds();
+        assert_eq!(all, log.by_subject(TEST_PATH).len());
+
+        log.until(3);
+        assert_eq!(all - 2, log.by_subject(TEST_PATH).len());
     }
 }
 

--- a/crates/pyo3/src/system.rs
+++ b/crates/pyo3/src/system.rs
@@ -128,20 +128,14 @@ impl PySystem {
     fn load_debuglog(&self, log: &str) -> PyResult<PyEventLog> {
         let xs = events::read::from_debug(log)
             .map_err(|e| exceptions::PyRuntimeError::new_err(format!("{:?}", e)))?;
-        Ok(PyEventLog {
-            rs: EventDB::from(xs),
-            rs_trust: self.rs.trust_db.clone(),
-        })
+        Ok(PyEventLog::new(EventDB::from(xs), self.rs.trust_db.clone()))
     }
 
     /// Parse events from syslog at the specified path
     fn load_syslog(&self) -> PyResult<PyEventLog> {
         let xs = events::read::from_syslog(&self.rs.config.system.syslog_file_path)
             .map_err(|e| exceptions::PyRuntimeError::new_err(format!("{:?}", e)))?;
-        Ok(PyEventLog {
-            rs: EventDB::from(xs),
-            rs_trust: self.rs.trust_db.clone(),
-        })
+        Ok(PyEventLog::new(EventDB::from(xs), self.rs.trust_db.clone()))
     }
 
     fn rules(&self) -> Vec<PyRule> {

--- a/examples/parse_events.py
+++ b/examples/parse_events.py
@@ -25,7 +25,7 @@ def main():
     parser.add_argument("--start", type=int, required=False, help="Bound results to this starting point.  As seconds since epoch.")
     parser.add_argument("--until", type=int, required=False, help="Bound results to this ending point.  As seconds since epoch.")
     parser.add_argument("-v", "--verbose", action="store_true", help="Enable verbose mode")
-    parser.add_argument("-i", "--input", default="events0.log", help="Specify the fapolicyd event debug log [default: events0.log ]")
+    parser.add_argument("-i", "--input", default="syslog", help="Specify the fapolicyd event debug source. Use 'syslog' or a path to debug log. [default: 'syslog']")
 
     args = parser.parse_args()
 
@@ -34,10 +34,6 @@ def main():
         logging.root.setLevel(logging.DEBUG)
         logging.debug("Verbosity enabled.")
 
-    # Set input fapolicyd event log [default: events0.log]
-    if args.input:
-        fapd_debug_log=args.input
-    
     # config loaded from $HOME/.config/fapolicy-analyzer/fapolicy-analyzer.toml
     s1 = System()
     print(f"found {len(s1.users())} system users")
@@ -56,7 +52,11 @@ def main():
         for g in gmap:
             logging.debug(f"{g}:\t{gmap[g]}")
 
-    event_log = s1.load_debuglog(args.input)
+    if args.input == "syslog":
+        event_log = s1.load_syslog()
+    else:
+        event_log = s1.load_debuglog(args.input)
+
     if args.start:
         event_log.begin(args.start)
 

--- a/examples/parse_events.py
+++ b/examples/parse_events.py
@@ -56,16 +56,16 @@ def main():
         for g in gmap:
             logging.debug(f"{g}:\t{gmap[g]}")
 
-    debug_log = s1.load_debuglog(args.input)
+    event_log = s1.load_debuglog(args.input)
     if args.start:
-        debug_log.begin(args.start)
+        event_log.begin(args.start)
 
     if args.until:
-        debug_log.until(args.until)
+        event_log.until(args.until)
 
-    for s in debug_log.subjects():
+    for s in event_log.subjects():
         logging.debug(f" - Getting all events associated with subject: {s}")
-        for e in debug_log.by_subject(s):
+        for e in event_log.by_subject(s):
             print({"u": umap[e.uid],
                    "g": gmap[e.gid], 
                    "s": {

--- a/examples/parse_events.py
+++ b/examples/parse_events.py
@@ -19,38 +19,22 @@ logging.basicConfig(level=logging.WARNING)
 import argparse
 from fapolicy_analyzer import *
 
-# Globals
-verbose_mode = False
-fapd_debug_log="events0.log"
 
-def parse_cmdline():
-    global verbose_mode
-    global fapd_debug_log
-    
+def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument(
-        "-v", "--verbose", action="store_true", help="Enable verbose mode"
-    )
-    parser.add_argument(
-        "-i",
-        "--input",
-        help="Specify the fapolicyd event debug log [default: events0.log ]",
-    )
+    parser.add_argument("-v", "--verbose", action="store_true", help="Enable verbose mode")
+    parser.add_argument("-i", "--input", default="events0.log", help="Specify the fapolicyd event debug log [default: events0.log ]")
 
     args = parser.parse_args()
 
     # Set Verbosity Level
     if args.verbose:
-        verbose_mode = True
         logging.root.setLevel(logging.DEBUG)
         logging.debug("Verbosity enabled.")
 
     # Set input fapolicyd event log [default: events0.log]
     if args.input:
         fapd_debug_log=args.input
-
-def main():
-    parse_cmdline()
     
     # config loaded from $HOME/.config/fapolicy-analyzer/fapolicy-analyzer.toml
     s1 = System()
@@ -61,7 +45,7 @@ def main():
     gmap = {g.id: g.name for g in s1.groups()}
 
     # Only iterate and print maps if in verbose mode
-    if verbose_mode:
+    if args.verbose:
         logging.debug("\n\nUser Map:")
         for u in umap:
             logging.debug(f"{u}:\t{umap[u]}")
@@ -70,7 +54,7 @@ def main():
         for g in gmap:
             logging.debug(f"{g}:\t{gmap[g]}")
 
-    debug_log = s1.load_debuglog(fapd_debug_log)
+    debug_log = s1.load_debuglog(args.input)
     for s in debug_log.subjects():
         logging.debug(f" - Getting all events associated with subject: {s}")
         for e in debug_log.by_subject(s):
@@ -88,6 +72,7 @@ def main():
                        "mode": e.object.mode
                    }})
         print("...")
+
 
 if __name__ == "__main__":
     main()

--- a/examples/parse_events.py
+++ b/examples/parse_events.py
@@ -22,6 +22,8 @@ from fapolicy_analyzer import *
 
 def main():
     parser = argparse.ArgumentParser()
+    parser.add_argument("--start", type=int, required=False, help="Bound results to this starting point.  As seconds since epoch.")
+    parser.add_argument("--until", type=int, required=False, help="Bound results to this ending point.  As seconds since epoch.")
     parser.add_argument("-v", "--verbose", action="store_true", help="Enable verbose mode")
     parser.add_argument("-i", "--input", default="events0.log", help="Specify the fapolicyd event debug log [default: events0.log ]")
 
@@ -55,6 +57,12 @@ def main():
             logging.debug(f"{g}:\t{gmap[g]}")
 
     debug_log = s1.load_debuglog(args.input)
+    if args.start:
+        debug_log.begin(args.start)
+
+    if args.until:
+        debug_log.until(args.until)
+
     for s in debug_log.subjects():
         logging.debug(f" - Getting all events associated with subject: {s}")
         for e in debug_log.by_subject(s):


### PR DESCRIPTION
Allow filtering events by a start and stop bounds.

Python API only.

Supports #465 