### PR TITLE
Copr workflow

### DIFF
--- a/.copr/Makefile
+++ b/.copr/Makefile
@@ -5,7 +5,7 @@ OS_ID_FN = $(shell grep /etc/os-release -e "^ID=" | tr -d '"' | cut -d= -f2 | cu
 OS_ID   ?= $(OS_ID_FN)
 
 identify:
-	@echo $(shell grep /etc/os-release -e "^PRETTY_NAME=" | tr -d '"' | cut -d= -f2 | cut -d: -f1)
+	@echo "Platform $(shell grep /etc/os-release -e '^PRETTY_NAME=' | cut -d= -f2 | cut -d: -f1)"
 	@echo "Platform ID: $(OS_ID)"
 
 prepfs: prep_outdir prep_rpmbuild_dir

--- a/.copr/Makefile
+++ b/.copr/Makefile
@@ -6,7 +6,7 @@ OS_ID_FN = $(shell grep /etc/os-release -e "^ID=" | tr -d '"' | cut -d= -f2 | cu
 OS_ID   ?= $(OS_ID_FN)
 
 identify:
-	$(shell env)
+	env
 	@echo "Platform: $(OS_PRETTY_NAME) (id: $(OS_ID))"
 
 prepfs: prep_outdir prep_rpmbuild_dir

--- a/.copr/Makefile
+++ b/.copr/Makefile
@@ -5,7 +5,8 @@ OS_ID_FN = $(shell grep /etc/os-release -e "^ID=" | tr -d '"' | cut -d= -f2 | cu
 OS_ID   ?= $(OS_ID_FN)
 
 identify:
-	@echo "Platform $(OS_ID)"
+	@echo $(shell grep /etc/os-release -e "^PRETTY_NAME=" | tr -d '"' | cut -d= -f2 | cut -d: -f1)
+	@echo "Platform ID: $(OS_ID)"
 
 prepfs: prep_outdir prep_rpmbuild_dir
 

--- a/.copr/Makefile
+++ b/.copr/Makefile
@@ -2,11 +2,10 @@
 .SILENT: clean
 
 OS_PRETTY_NAME = $(shell grep /etc/os-release -e "^PRETTY_NAME=" | tr -d '"' | cut -d= -f2 | cut -d: -f1)
-OS_ID_FN = $(shell grep /etc/os-release -e "^ID=" | tr -d '"' | cut -d= -f2 | cut -d: -f1)
-OS_ID   ?= $(OS_ID_FN)
+OS_ID_FN =       $(shell grep /etc/os-release -e "^ID=" | tr -d '"' | cut -d= -f2 | cut -d: -f1)
+OS_ID   ?=       $(OS_ID_FN)
 
 identify:
-	env
 	@echo "Platform: $(OS_PRETTY_NAME) (id: $(OS_ID))"
 
 prepfs: prep_outdir prep_rpmbuild_dir

--- a/.copr/Makefile
+++ b/.copr/Makefile
@@ -6,6 +6,7 @@ OS_ID_FN = $(shell grep /etc/os-release -e "^ID=" | tr -d '"' | cut -d= -f2 | cu
 OS_ID   ?= $(OS_ID_FN)
 
 identify:
+	$(shell env)
 	@echo "Platform: $(OS_PRETTY_NAME) (id: $(OS_ID))"
 
 prepfs: prep_outdir prep_rpmbuild_dir

--- a/.copr/Makefile
+++ b/.copr/Makefile
@@ -1,12 +1,12 @@
 .PHONY: clean identify prepfs dnf vendor vendor-app vendor-py vendor-rs dep srpm
 .SILENT: clean
 
+OS_PRETTY_NAME = $(shell grep /etc/os-release -e "^PRETTY_NAME=" | tr -d '"' | cut -d= -f2 | cut -d: -f1)
 OS_ID_FN = $(shell grep /etc/os-release -e "^ID=" | tr -d '"' | cut -d= -f2 | cut -d: -f1)
 OS_ID   ?= $(OS_ID_FN)
 
 identify:
-	@echo "Platform $(shell grep /etc/os-release -e '^PRETTY_NAME=' | cut -d= -f2 | cut -d: -f1)"
-	@echo "Platform ID: $(OS_ID)"
+	@echo "Platform: $(OS_PRETTY_NAME) (id: $(OS_ID))"
 
 prepfs: prep_outdir prep_rpmbuild_dir
 

--- a/.github/workflows/copr.yml
+++ b/.github/workflows/copr.yml
@@ -50,6 +50,7 @@ jobs:
           COPR_LOGIN: ${{ secrets.COPR_API_LOGIN }}
           COPR_TOKEN: ${{ secrets.COPR_API_TOKEN }}
 
+
       # run on tag or PR
       # fapolicy-analyzer:custom:master
       # fapolicy-analyzer:pr:${{ github.event.pull_request.number }}

--- a/.github/workflows/copr.yml
+++ b/.github/workflows/copr.yml
@@ -59,7 +59,7 @@ jobs:
         run: |
           copr-cli buildscm \
           --method make_srpm \
-          --commit ${{ github.sha }} \
+          --commit ${{ github.event.pull_request.head.sha }} \
           --spec scripts/srpm/fapolicy-analyzer.spec \
           --clone-url ${{ github.server_url }}/${{ github.repository }} \
           fapolicy-analyzer:pr:${{ github.event.pull_request.number }}

--- a/.github/workflows/copr.yml
+++ b/.github/workflows/copr.yml
@@ -47,6 +47,7 @@ jobs:
           echo "${{ secrets.COPR_CONFIG }}" > ~/.config/copr
 
       # run on tag or PR
+      # fapolicy-analyzer:custom:${{ steps.tag_name.outputs.VERSION }}
       - name: Submit Build
         run: |
           copr-cli buildscm \
@@ -55,4 +56,3 @@ jobs:
           --spec scripts/srpm/fapolicy-analyzer.spec \
           --clone-url ${{ github.server_url }}/${{ github.repository }} \
           fapolicy-analyzer:pr:${{ github.event.pull_request.number }}
-          #fapolicy-analyzer:custom:${{ steps.tag_name.outputs.VERSION }}

--- a/.github/workflows/copr.yml
+++ b/.github/workflows/copr.yml
@@ -8,11 +8,11 @@ on:
     branches:
       - 'master'
 
-name: Copr Build
+name: Copr
 
 jobs:
   build:
-    name: Copr ${{ matrix.props.name }} Build
+    name: Build ${{ matrix.props.name }}
     strategy:
       matrix:
         props:
@@ -87,13 +87,3 @@ jobs:
           --chroot ${{ matrix.props.chroot }} \
           fapolicy-analyzer:pr:${{ github.event.pull_request.number }} \
           /tmp/fapolicy-analyzer-*.${{ matrix.props.name }}.src.rpm
-
-
-#       - name: Submit Build
-#        run: |
-#          copr-cli buildscm \
-#          --method make_srpm \
-#          --commit ${{ github.event.pull_request.head.sha }} \
-#          --spec scripts/srpm/fapolicy-analyzer.spec \
-#          --clone-url ${{ github.server_url }}/${{ github.repository }} \
-#          fapolicy-analyzer:pr:${{ github.event.pull_request.number }}

--- a/.github/workflows/copr.yml
+++ b/.github/workflows/copr.yml
@@ -34,6 +34,13 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/v')
         run: echo ::set-output name=VERSION::$(echo $GITHUB_REF | cut -d/ -f3)
 
+      - name: Download artifact
+        id: download-artifact
+        uses: dawidd6/action-download-artifact@v2
+        with:
+          workflow: rpm.yml
+          path: /tmp
+
       - name: Install Copr CLI
         run: |
           dnf install -y copr-cli
@@ -50,16 +57,19 @@ jobs:
           COPR_LOGIN: ${{ secrets.COPR_API_LOGIN }}
           COPR_TOKEN: ${{ secrets.COPR_API_TOKEN }}
 
+      - name: debug
+        run: |
+          ls /tmp
 
       # run on tag or PR
       # fapolicy-analyzer:custom:master
       # fapolicy-analyzer:pr:${{ github.event.pull_request.number }}
       # fapolicy-analyzer:custom:${{ steps.tag_name.outputs.VERSION }}
-      - name: Submit Build
-        run: |
-          copr-cli buildscm \
-          --method make_srpm \
-          --commit ${{ github.event.pull_request.head.sha }} \
-          --spec scripts/srpm/fapolicy-analyzer.spec \
-          --clone-url ${{ github.server_url }}/${{ github.repository }} \
-          fapolicy-analyzer:pr:${{ github.event.pull_request.number }}
+#      - name: Submit Build
+#        run: |
+#          copr-cli buildscm \
+#          --method make_srpm \
+#          --commit ${{ github.event.pull_request.head.sha }} \
+#          --spec scripts/srpm/fapolicy-analyzer.spec \
+#          --clone-url ${{ github.server_url }}/${{ github.repository }} \
+#          fapolicy-analyzer:pr:${{ github.event.pull_request.number }}

--- a/.github/workflows/copr.yml
+++ b/.github/workflows/copr.yml
@@ -77,13 +77,17 @@ jobs:
         run: |
           ls /tmp
 
-      # run on tag or PR
-      # fapolicy-analyzer:custom:master
-      # fapolicy-analyzer:pr:${{ github.event.pull_request.number }}
-      # fapolicy-analyzer:custom:${{ steps.tag_name.outputs.VERSION }}
-      - name: Submit Build
+      - name: Copr Release Build
+        if: startsWith(github.ref, 'refs/tags/v')
         run: |
-          copr-cli build \
-          --chroot ${{ matrix.props.chroot }} \
-          fapolicy-analyzer:pr:${{ github.event.pull_request.number }} \
-          /tmp/fapolicy-analyzer-*.${{ matrix.props.name }}.src.rpm
+          copr-cli build --chroot ${{ matrix.props.chroot }} fapolicy-analyzer /tmp/fapolicy-analyzer-*.${{ matrix.props.name }}.src.rpm
+
+      - name: Copr Latest Build
+        if: github.ref == 'refs/heads/master'
+        run: |
+          copr-cli build --chroot ${{ matrix.props.chroot }} fapolicy-analyzer-latest /tmp/fapolicy-analyzer-*.${{ matrix.props.name }}.src.rpm
+
+      - name: Copr PR Build
+        if: github.event_name == 'pull_request'
+        run: |
+          copr-cli build --chroot ${{ matrix.props.chroot }} fapolicy-analyzer-latest:pr:${{ github.event.pull_request.number }} /tmp/fapolicy-analyzer-*.${{ matrix.props.name }}.src.rpm

--- a/.github/workflows/copr.yml
+++ b/.github/workflows/copr.yml
@@ -18,17 +18,14 @@ jobs:
         props:
           - {
             name: 'fc37',
-            spec: 'fapolicy-analyzer.spec',
             chroot: 'fedora-37-x86_64',
           }
           - {
             name: 'fc38',
-            spec: 'fapolicy-analyzer.spec',
             chroot: 'fedora-rawhide-x86_64',
           }
           - {
             name: 'el8',
-            spec: 'scripts/srpm/fapolicy-analyzer.spec',
             chroot: 'epel-8-x86_64',
           }
     runs-on: ubuntu-latest

--- a/.github/workflows/copr.yml
+++ b/.github/workflows/copr.yml
@@ -41,9 +41,16 @@ jobs:
       - name: Install Config
         run: |
           mkdir -p ~/.config
-          echo "$COPR_CONF" > ~/.config/copr
+          echo  > ~/.config/copr <<EOF
+            [copr-cli]
+            username = ctc-oss
+            login = ${COPR_API_LOGIN}
+            token = ${COPR_API_TOKEN}
+            copr_url = https://copr.fedorainfracloud.org
+          EOF
         env:
-          COPR_CONF: ${{ secrets.COPR_CONFIG }}
+          COPR_API_LOGIN: ${{ secrets.COPR_API_LOGIN }}
+          COPR_API_TOKEN: ${{ secrets.COPR_API_TOKEN }}
 
       # run on tag or PR
       # fapolicy-analyzer:custom:master

--- a/.github/workflows/copr.yml
+++ b/.github/workflows/copr.yml
@@ -54,6 +54,5 @@ jobs:
           --commit ${{ github.sha }} \
           --spec scripts/srpm/fapolicy-analyzer.spec \
           --clone-url ${{ github.server_url }}/${{ github.repository }} \
-          
           fapolicy-analyzer:pr:${{ github.event.pull_request.number }}
-          fapolicy-analyzer:custom:${{ steps.tag_name.outputs.VERSION }}
+          #fapolicy-analyzer:custom:${{ steps.tag_name.outputs.VERSION }}

--- a/.github/workflows/copr.yml
+++ b/.github/workflows/copr.yml
@@ -1,0 +1,40 @@
+on:
+  push:
+    tags:
+      - 'v*'
+
+name: Copr Release
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    container: 'rockylinux:8.6'
+    steps:
+      - name: Enable EPEL
+        run: |
+          dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
+
+      - name: Install Copr CLI
+        run: |
+          dnf install -y copr-cli
+
+      - name: Install Config
+        run: |
+          mkdir -p ~/.config
+          cat > ~/.config/copr <<EOF
+            [copr-cli]
+            login = foo
+            username = foo
+            token = foo
+            copr_url = https://copr.fedorainfracloud.org
+          EOF
+
+      - name: Submit Build
+        run: |
+          copr-cli buildscm \
+          --method make_srpm \
+          --commit ${{ github.sha }} \
+          --spec scripts/srpm/fapolicy-analyzer.spec \
+          --clone-url ${{ github.server_url }}/${{ github.repository }} \
+          fapolicy-analyzer:custom:test

--- a/.github/workflows/copr.yml
+++ b/.github/workflows/copr.yml
@@ -44,13 +44,7 @@ jobs:
       - name: Install Config
         run: |
           mkdir -p ~/.config
-          cat > ~/.config/copr <<EOF
-            [copr-cli]
-            login = foo
-            username = foo
-            token = foo
-            copr_url = https://copr.fedorainfracloud.org
-          EOF
+          echo "${{ secrets.COPR_CONFIG }}" > ~/.config/copr
 
       # run on tag or PR
       - name: Submit Build

--- a/.github/workflows/copr.yml
+++ b/.github/workflows/copr.yml
@@ -42,10 +42,10 @@ jobs:
         run: |
           mkdir -p $HOME/.config
           echo "[copr-cli]" > $HOME/.config/copr 
-          echo "username = ctc-oss" > $HOME/.config/copr
-          echo "login = ${COPR_LOGIN}" > $HOME/.config/copr
-          echo "token = ${COPR_TOKEN}" > $HOME/.config/copr
-          echo "copr_url = https://copr.fedorainfracloud.org" > $HOME/.config/copr
+          echo "username = ctc-oss" >> $HOME/.config/copr
+          echo "login = ${COPR_LOGIN}" >> $HOME/.config/copr
+          echo "token = ${COPR_TOKEN}" >> $HOME/.config/copr
+          echo "copr_url = https://copr.fedorainfracloud.org" >> $HOME/.config/copr
         env:
           COPR_LOGIN: ${{ secrets.COPR_API_LOGIN }}
           COPR_TOKEN: ${{ secrets.COPR_API_TOKEN }}

--- a/.github/workflows/copr.yml
+++ b/.github/workflows/copr.yml
@@ -12,7 +12,25 @@ name: Copr Build
 
 jobs:
   build:
-    name: Build
+    name: Copr ${{ matrix.props.name }} Build
+    strategy:
+      matrix:
+        props:
+          - {
+            name: 'fc37',
+            spec: 'fapolicy-analyzer.spec',
+            chroot: 'fedora-37-x86_64',
+          }
+          - {
+            name: 'fc38',
+            spec: 'fapolicy-analyzer.spec',
+            chroot: 'fedora-rawhide-x86_64',
+          }
+          - {
+            name: 'el8',
+            spec: 'scripts/srpm/fapolicy-analyzer.spec',
+            chroot: 'epel-8-x86_64',
+          }
     runs-on: ubuntu-latest
     container: 'rockylinux:8.6'
     steps:
@@ -66,7 +84,15 @@ jobs:
       # fapolicy-analyzer:custom:master
       # fapolicy-analyzer:pr:${{ github.event.pull_request.number }}
       # fapolicy-analyzer:custom:${{ steps.tag_name.outputs.VERSION }}
-#      - name: Submit Build
+      - name: Submit Build
+        run: |
+          copr-cli build \
+          --chroot ${{ matrix.props.chroot }} \
+          fapolicy-analyzer:pr:${{ github.event.pull_request.number }} \
+          /tmp/fapolicy-analyzer-*.${{ matrix.props.name }}.src.rpm
+
+
+#       - name: Submit Build
 #        run: |
 #          copr-cli buildscm \
 #          --method make_srpm \

--- a/.github/workflows/copr.yml
+++ b/.github/workflows/copr.yml
@@ -43,12 +43,12 @@ jobs:
           mkdir -p $HOME/.config
           echo "[copr-cli]" > $HOME/.config/copr 
           echo "username = ctc-oss" > $HOME/.config/copr
-          echo "login = ${COPR_API_LOGIN}" > $HOME/.config/copr
-          echo "token = ${COPR_API_TOKEN}" > $HOME/.config/copr
+          echo "login = ${COPR_LOGIN}" > $HOME/.config/copr
+          echo "token = ${COPR_TOKEN}" > $HOME/.config/copr
           echo "copr_url = https://copr.fedorainfracloud.org" > $HOME/.config/copr
         env:
-          COPR_API_LOGIN: ${{ secrets.COPR_API_LOGIN }}
-          COPR_API_TOKEN: ${{ secrets.COPR_API_TOKEN }}
+          COPR_LOGIN: ${{ secrets.COPR_API_LOGIN }}
+          COPR_TOKEN: ${{ secrets.COPR_API_TOKEN }}
 
       # run on tag or PR
       # fapolicy-analyzer:custom:master

--- a/.github/workflows/copr.yml
+++ b/.github/workflows/copr.yml
@@ -41,7 +41,9 @@ jobs:
       - name: Install Config
         run: |
           mkdir -p ~/.config
-          echo "${{ secrets.COPR_CONFIG }}" > ~/.config/copr
+          echo "$COPR_CONF" > ~/.config/copr
+        env:
+          COPR_CONF: ${{ secrets.COPR_CONFIG }}
 
       # run on tag or PR
       # fapolicy-analyzer:custom:master

--- a/.github/workflows/copr.yml
+++ b/.github/workflows/copr.yml
@@ -40,14 +40,12 @@ jobs:
 
       - name: Install Config
         run: |
-          mkdir -p ~/.config
-          echo  > ~/.config/copr <<EOF
-            [copr-cli]
-            username = ctc-oss
-            login = ${COPR_API_LOGIN}
-            token = ${COPR_API_TOKEN}
-            copr_url = https://copr.fedorainfracloud.org
-          EOF
+          mkdir -p $HOME/.config
+          echo "[copr-cli]" > $HOME/.config/copr 
+          echo "username = ctc-oss" > $HOME/.config/copr
+          echo "login = ${COPR_API_LOGIN}" > $HOME/.config/copr
+          echo "token = ${COPR_API_TOKEN}" > $HOME/.config/copr
+          echo "copr_url = https://copr.fedorainfracloud.org" > $HOME/.config/copr
         env:
           COPR_API_LOGIN: ${{ secrets.COPR_API_LOGIN }}
           COPR_API_TOKEN: ${{ secrets.COPR_API_TOKEN }}

--- a/.github/workflows/copr.yml
+++ b/.github/workflows/copr.yml
@@ -2,14 +2,11 @@ on:
   push:
     branches:
       - 'master'
-      - 'release-*'
-      - 'rpm/test/*'
     tags:
       - 'v*'
   pull_request:
     branches:
       - 'master'
-      - 'release-*'
 
 name: Copr Build
 
@@ -47,6 +44,8 @@ jobs:
           echo "${{ secrets.COPR_CONFIG }}" > ~/.config/copr
 
       # run on tag or PR
+      # fapolicy-analyzer:custom:master
+      # fapolicy-analyzer:pr:${{ github.event.pull_request.number }}
       # fapolicy-analyzer:custom:${{ steps.tag_name.outputs.VERSION }}
       - name: Submit Build
         run: |

--- a/.github/workflows/copr.yml
+++ b/.github/workflows/copr.yml
@@ -1,9 +1,17 @@
 on:
   push:
+    branches:
+      - 'master'
+      - 'release-*'
+      - 'rpm/test/*'
     tags:
       - 'v*'
+  pull_request:
+    branches:
+      - 'master'
+      - 'release-*'
 
-name: Copr Release
+name: Copr Build
 
 jobs:
   build:
@@ -14,6 +22,20 @@ jobs:
       - name: Enable EPEL
         run: |
           dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
+
+      - name: Dnf
+        run: |
+          dnf install -y git
+
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.ref }}
+          fetch-depth: 0
+
+      - name: Strip ref to tag
+        id: tag_name
+        if: startsWith(github.ref, 'refs/tags/v')
+        run: echo ::set-output name=VERSION::$(echo $GITHUB_REF | cut -d/ -f3)
 
       - name: Install Copr CLI
         run: |
@@ -30,6 +52,7 @@ jobs:
             copr_url = https://copr.fedorainfracloud.org
           EOF
 
+      # run on tag or PR
       - name: Submit Build
         run: |
           copr-cli buildscm \
@@ -37,4 +60,6 @@ jobs:
           --commit ${{ github.sha }} \
           --spec scripts/srpm/fapolicy-analyzer.spec \
           --clone-url ${{ github.server_url }}/${{ github.repository }} \
-          fapolicy-analyzer:custom:test
+          
+          fapolicy-analyzer:pr:${{ github.event.pull_request.number }}
+          fapolicy-analyzer:custom:${{ steps.tag_name.outputs.VERSION }}

--- a/.github/workflows/copr.yml
+++ b/.github/workflows/copr.yml
@@ -38,6 +38,7 @@ jobs:
         id: download-artifact
         uses: dawidd6/action-download-artifact@v2
         with:
+          name: srpm-artifacts
           workflow: rpm.yml
           path: /tmp
 

--- a/.github/workflows/rpm.yml
+++ b/.github/workflows/rpm.yml
@@ -127,7 +127,7 @@ jobs:
       - name: Upload tarballs
         uses: actions/upload-artifact@v2
         with:
-          name: rpm-artifacts
+          name: tarball-artifacts
           path: |
             /tmp/archives/*.tar.gz
 

--- a/.github/workflows/rpm.yml
+++ b/.github/workflows/rpm.yml
@@ -110,12 +110,26 @@ jobs:
         env:
           PLATFORM: ${{ matrix.props.name }}
 
-      - name: Archive artifacts
+      - name: Upload SRPMs
         uses: actions/upload-artifact@v2
         with:
           name: srpm-artifacts
           path: |
-            /tmp/archives/*
+            /tmp/archives/*.src.rpm
+
+      - name: Upload RPMs
+        uses: actions/upload-artifact@v2
+        with:
+          name: rpm-artifacts
+          path: |
+            /tmp/archives/*.x86_64.rpm
+
+      - name: Upload tarballs
+        uses: actions/upload-artifact@v2
+        with:
+          name: rpm-artifacts
+          path: |
+            /tmp/archives/*.tar.gz
 
       - name: Release artifacts
         uses: softprops/action-gh-release@v1

--- a/scripts/srpm/fapolicy-analyzer.spec
+++ b/scripts/srpm/fapolicy-analyzer.spec
@@ -13,7 +13,7 @@ Source1:       vendor-rs.tar.gz
 # this tarball contains documentation used to generate help docs
 Source2:       vendor-docs.tar.gz
 
-# on copr the source containter is never el
+# we need to provide some updates to python on el8
 %if 0%{?rhel}
 Source10:      %{pypi_source setuptools-rust 1.1.2}
 Source11:      %{pypi_source pip 21.3.1}
@@ -47,7 +47,7 @@ BuildRequires: git
 BuildRequires: rust-packaging
 BuildRequires: python3dist(setuptools-rust)
 
-# crates
+# crates available for rawhide
 BuildRequires: rust-arrayvec0.5-devel
 BuildRequires: rust-atty-devel
 BuildRequires: rust-autocfg-devel
@@ -148,8 +148,7 @@ Requires:      gtk3
 Requires:      dbus-libs
 Requires:      gtksourceview3
 
-# for rendering our html user guide documentation
-# will be addressed with future upgrade of yelp
+# runtime required for rendering user guide documentation
 Requires:      webkit2gtk3
 Requires:      mesa-dri-drivers
 

--- a/scripts/srpm/fapolicy-analyzer.spec
+++ b/scripts/srpm/fapolicy-analyzer.spec
@@ -14,16 +14,15 @@ Source1:       vendor-rs.tar.gz
 Source2:       vendor-docs.tar.gz
 
 # on copr the source containter is never el
-# we check for low fc version here to remedy that
-%if 0%{?rhel} || 0%{?fedora} < 37
-Source10:       %{pypi_source setuptools-rust 1.1.2}
-Source11:       %{pypi_source pip 21.3.1}
-Source12:       %{pypi_source setuptools 59.6.0}
-Source13:       %{pypi_source wheel 0.37.0}
-Source14:       %{pypi_source setuptools_scm 6.4.2}
-Source15:       %{pypi_source semantic_version 2.8.2}
-Source16:       %{pypi_source packaging 21.3}
-Source17:       %{pypi_source pyparsing 2.1.0}
+%if 0%{?rhel}
+Source10:      %{pypi_source setuptools-rust 1.1.2}
+Source11:      %{pypi_source pip 21.3.1}
+Source12:      %{pypi_source setuptools 59.6.0}
+Source13:      %{pypi_source wheel 0.37.0}
+Source14:      %{pypi_source setuptools_scm 6.4.2}
+Source15:      %{pypi_source semantic_version 2.8.2}
+Source16:      %{pypi_source packaging 21.3}
+Source17:      %{pypi_source pyparsing 2.1.0}
 Source18:      %{pypi_source tomli 1.2.3}
 Source19:      %{pypi_source flit_core 3.7.1}
 Source20:      %{pypi_source typing_extensions 3.7.4.3}


### PR DESCRIPTION
Trigger Copr build from CI workflow to avoid manual initiation of builds.

Using the SRPM produced in CI to build on Copr for consistency and to avoid issues with differences between the src chroot and the build chroot.  The Copr and RPM workflows run partially parallel as the Copr workflow starts as soon as the SRPM artifact is uploaded from the RPM workflow, which is done prior to the slow RPM rebuild stage.

Supports three types of builds
- tagged releases
- latest master commit
- PR commits   

Two Copr repositories are used to provide stable and unstable streams.  The stable (fapolicy-analyzer) repo receives builds from tagged versions (eg. v1.0.0).  The unstable (fapolicy-analyzer-latest) repo receives builds from the latest commit on master.  PR commits are built using a special pr tag on the package ID which keeps the build off the public facing repo.

See the ctc-oss Copr project at https://copr.fedorainfracloud.org/coprs/ctc-oss 

Also splits the RPM artifacts up into RPM and SRPM.

Closes #654