### PR TITLE
More Coverity

### DIFF
--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -2,6 +2,9 @@ on:
   push:
     branches:
       - 'master'
+  pull_request:
+    branches:
+      - 'master'
 
 name: Coverity Scan
 

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -17,5 +17,6 @@ jobs:
         with:
           build_language: python
           command: --no-command --fs-capture-search fapolicy_analyzer
+          project: ctc-oss/fapolicy-analyzer
           email: ${{ secrets.COVERITY_SCAN_EMAIL }}
           token: ${{ secrets.COVERITY_SCAN_TOKEN }}

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -8,6 +8,7 @@ on:
 
 name: Coverity Scan
 
+
 jobs:
   coverity:
     runs-on: ubuntu-latest

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -2,12 +2,8 @@ on:
   push:
     branches:
       - 'master'
-  pull_request:
-    branches:
-      - 'master'
 
 name: Coverity Scan
-
 
 jobs:
   coverity:

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -8,6 +8,7 @@ on:
 
 name: Coverity Scan
 
+# ___
 jobs:
   coverity:
     runs-on: ubuntu-latest

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -16,7 +16,6 @@ jobs:
       - uses: actions/checkout@v3
       - uses: vapier/coverity-scan-action@v1
         with:
-          build_language: python
           command: --no-command --fs-capture-search fapolicy_analyzer
           project: ctc-oss/fapolicy-analyzer
           email: ${{ secrets.COVERITY_SCAN_EMAIL }}

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -2,13 +2,9 @@ on:
   push:
     branches:
       - 'master'
-  pull_request:
-    branches:
-      - 'master'
 
 name: Coverity Scan
 
-# ___
 jobs:
   coverity:
     runs-on: ubuntu-latest

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -12,5 +12,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: vapier/coverity-scan-action@v1
         with:
+          build_language: python
+          command: --no-command --fs-capture-search fapolicy_analyzer
           email: ${{ secrets.COVERITY_SCAN_EMAIL }}
           token: ${{ secrets.COVERITY_SCAN_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Tools to assist with the configuration and management of [fapolicyd](https://git
 [![Release](https://shields.io/github/v/release/ctc-oss/fapolicy-analyzer?color=blue&display_name=tag&sort=semver&label=Release)](https://github.com/ctc-oss/fapolicy-analyzer/releases)
 ![GitHub checks status](https://img.shields.io/github/checks-status/ctc-oss/fapolicy-analyzer/master?label=CI)
 [![Copr build status](https://img.shields.io/badge/dynamic/json?color=B87333&label=Copr&query=builds.latest.state&url=https%3A%2F%2Fcopr.fedorainfracloud.org%2Fapi_3%2Fpackage%3Fownername%3Dctc-oss%26projectname%3Dfapolicy-analyzer%26packagename%3Dfapolicy-analyzer%26with_latest_build%3DTrue)](https://copr.fedorainfracloud.org/coprs/ctc-oss/fapolicy-analyzer/package/fapolicy-analyzer/)
-![Coverity Scan](https://img.shields.io/coverity/scan/26261?label=Coverity)
+[![Coverity Scan](https://img.shields.io/coverity/scan/26261?label=Coverity)](https://scan.coverity.com/projects/ctc-oss-fapolicy-analyzer)
 ![GitHub](https://img.shields.io/github/license/ctc-oss/fapolicy-analyzer?color=red&label=License)
 
 ## Install


### PR DESCRIPTION
Fixes up issues with Coverity scanning.

Needed to use the `--no-command` option to support scanning Python.  Limits the scanning to the Python code under `fapolicy_analyzer`.