### PR TITLE
Fix WebKit crash on exit

### DIFF
--- a/fapolicy_analyzer/ui/main_window.py
+++ b/fapolicy_analyzer/ui/main_window.py
@@ -356,6 +356,7 @@ class MainWindow(UIConnectedWidget):
         else:
             if path.isfile("/usr/share/help/C/fapolicy-analyzer/User-Guide.html"):
                 uri = "help:fapolicy-analyzer/User-Guide.html"
+                logging.debug(f"loading help from {uri}")
             elif path.isfile("help/C/User-Guide.html"):
                 # This should only happen in a development environment
                 uri = f"file://{os.getcwd()}/help/C/User-Guide.html"


### PR DESCRIPTION
The issue appears to be a bug in the WebKit code when using the default `WebContext` object. I switch the code so we load a new context every time the browser is launched and that seems to fix the issue.

closes #692 