### PR TITLE
Unlatest runs-on

### DIFF
--- a/.github/workflows/common.yml
+++ b/.github/workflows/common.yml
@@ -13,7 +13,7 @@ name: Common CI
 jobs:
   headers:
     name: License header check
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - name: Check for required headers

--- a/.github/workflows/copr.yml
+++ b/.github/workflows/copr.yml
@@ -4,9 +4,6 @@ on:
       - 'master'
     tags:
       - 'v*'
-  pull_request:
-    branches:
-      - 'master'
 
 name: Copr
 
@@ -87,7 +84,7 @@ jobs:
         run: |
           copr-cli build --chroot ${{ matrix.props.chroot }} fapolicy-analyzer-latest /tmp/fapolicy-analyzer-*.${{ matrix.props.name }}.src.rpm
 
-      - name: Copr PR Build
-        if: github.event_name == 'pull_request'
-        run: |
-          copr-cli build --chroot ${{ matrix.props.chroot }} fapolicy-analyzer-latest:pr:${{ github.event.pull_request.number }} /tmp/fapolicy-analyzer-*.${{ matrix.props.name }}.src.rpm
+#      - name: Copr PR Build
+#        if: github.event_name == 'pull_request'
+#        run: |
+#          copr-cli build --chroot ${{ matrix.props.chroot }} fapolicy-analyzer-latest:pr:${{ github.event.pull_request.number }} /tmp/fapolicy-analyzer-*.${{ matrix.props.name }}.src.rpm

--- a/.github/workflows/copr.yml
+++ b/.github/workflows/copr.yml
@@ -28,7 +28,7 @@ jobs:
             name: 'el8',
             chroot: 'epel-8-x86_64',
           }
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     container: 'rockylinux:8.6'
     steps:
       - name: Enable EPEL

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -7,7 +7,7 @@ name: Coverity Scan
 
 jobs:
   coverity:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
       - uses: vapier/coverity-scan-action@v1

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -13,7 +13,7 @@ name: Python CI
 jobs:
   py_build:
     name: Build Python Bindings for Python ${{ matrix.python-version }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         python-version: ["3.6", "3.9"]
@@ -50,7 +50,7 @@ jobs:
 
   ui_lint:
     name: UI Lint
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python 3.6
@@ -67,7 +67,7 @@ jobs:
 
   ui_test:
     name: UI Test Suite for Python ${{ matrix.python-version }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         python-version: ["3.6", "3.9"]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ name: Release
 
 jobs:
   release:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     name: Build
     steps:
     - name: Install git

--- a/.github/workflows/rpm.yml
+++ b/.github/workflows/rpm.yml
@@ -37,7 +37,7 @@ jobs:
             image: 'rockylinux:8.6',
             platform: 'rhel',
           }
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     container: ${{ matrix.props.image }}
     steps:
       - name: Enable EPEL

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -13,7 +13,7 @@ name: Rust CI
 jobs:
   fmt:
     name: Rustfmt
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
@@ -29,7 +29,7 @@ jobs:
 
   check:
     name: Check
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - name: Install requirements
@@ -47,7 +47,7 @@ jobs:
 
   clippy:
     name: Clippy
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - name: Install requirements
@@ -67,7 +67,7 @@ jobs:
 
   test:
     name: Test Suite
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - name: Install requirements

--- a/.github/workflows/tools.yml
+++ b/.github/workflows/tools.yml
@@ -15,7 +15,7 @@ name: Tools
 jobs:
   build:
     name: Build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     # 28 has glibc-2.27, compatible >= el8, fc, ubuntu 18.04
     container: fedora:28
     steps:


### PR DESCRIPTION
Specify non-latest ubuntu tag for runs-on to avoid issues related to the migration of the ubuntu-latest tag.

Also removes Copr build from PRs due to lack of secret sharing.   May enable this later with a conditional step based on secret being defined in the environment.

Closes #696