### PR TITLE
Rust vendoring fix

### DIFF
--- a/scripts/srpm/lock2spec.py
+++ b/scripts/srpm/lock2spec.py
@@ -79,7 +79,7 @@ if __name__ == '__main__':
         os_id, os_version = os.environ.get("TARGET_PLATFORM").split(":")
         print(f"overriding platform to {os_id}:{os_version}")
 
-    vendoring_all = False
+    vendoring_all = os_id != "fedora" or int(float(os_version)) < 37
     print(f"{os_id}:{os_version}")
     if vendoring_all:
         print("== vendoring all ==")

--- a/scripts/srpm/lock2spec.py
+++ b/scripts/srpm/lock2spec.py
@@ -61,7 +61,8 @@ def available_packages():
 
 
 if __name__ == '__main__':
-    vendor_dir = "vendor-rs"
+    # this needs to stay synched up with the path in vendor-rs.sh
+    vendor_dir = "vendor-rs/vendor"
     os_id = None
     os_version = None
     with open("/etc/os-release") as file:
@@ -78,7 +79,7 @@ if __name__ == '__main__':
         os_id, os_version = os.environ.get("TARGET_PLATFORM").split(":")
         print(f"overriding platform to {os_id}:{os_version}")
 
-    vendoring_all = os_id != "fedora" or int(float(os_version)) < 37
+    vendoring_all = False
     print(f"{os_id}:{os_version}")
     if vendoring_all:
         print("== vendoring all ==")
@@ -129,6 +130,7 @@ if __name__ == '__main__':
 
         for c in unvendor:
             print(f"[unvendor] {c}")
-            shutil.rmtree(f"{vendor_dir}/{c}", ignore_errors=True)
+            shutil.rmtree(f"{vendor_dir}/{c}")
+
         print(f"Official {len(unvendor)}")
         print(f"Vendored {len(crates) - len(excluded_crates)}")

--- a/scripts/srpm/vendor-rs.sh
+++ b/scripts/srpm/vendor-rs.sh
@@ -19,6 +19,7 @@ set -e
 
 # rust
 rm -rf vendor-rs
+# the dest path here needs to stay synced up with the path in lock2spec.py
 cargo vendor-filterer --platform=x86_64-unknown-linux-gnu vendor-rs/vendor &> /dev/null
 python3 scripts/srpm/lock2spec.py
 tar czf vendor-rs.tar.gz -C vendor-rs .


### PR DESCRIPTION
Fix an issue with unvendoring Rust dependencies in lock2spec.py.  This was preventing the pruning of crates available as packages from the final tarball.  The symptom was that the release artifacts were all the same size.

Closes #697