### PR TITLE
Updated rules validation to clear validation notifications

### DIFF
--- a/fapolicy_analyzer/tests/reducers/test_notification_reducer.py
+++ b/fapolicy_analyzer/tests/reducers/test_notification_reducer.py
@@ -13,8 +13,10 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import context  # noqa: F401
 from unittest.mock import MagicMock
+
+import context  # noqa: F401
+
 from fapolicy_analyzer.ui.actions import Notification, NotificationType
 from fapolicy_analyzer.ui.reducers.notification_reducer import (
     handle_add_notification,
@@ -29,10 +31,11 @@ def test_handle_add_notification():
 
 def test_handle_remove_notification():
     state = [
-        Notification(id=99, text=None, type=NotificationType.ERROR),
-        Notification(id=100, text=None, type=NotificationType.ERROR),
+        Notification(id=99, text=None, type=NotificationType.ERROR, category=None),
+        Notification(id=100, text=None, type=NotificationType.ERROR, category=None),
     ]
     result = handle_remove_notification(
-        state, MagicMock(payload=Notification(id=99, text=None, type=None))
+        state,
+        MagicMock(payload=Notification(id=99, text=None, type=None, category=None)),
     )
     assert result == state[1:]

--- a/fapolicy_analyzer/tests/reducers/test_notification_reducer.py
+++ b/fapolicy_analyzer/tests/reducers/test_notification_reducer.py
@@ -13,9 +13,9 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-from unittest.mock import MagicMock
+import context  # noqa: F401 # isort: skip
 
-import context  # noqa: F401
+from unittest.mock import MagicMock
 
 from fapolicy_analyzer.ui.actions import Notification, NotificationType
 from fapolicy_analyzer.ui.reducers.notification_reducer import (

--- a/fapolicy_analyzer/tests/rules/test_rules_admin_page.py
+++ b/fapolicy_analyzer/tests/rules/test_rules_admin_page.py
@@ -19,6 +19,9 @@ from unittest.mock import MagicMock
 import gi
 import pytest
 from callee import Attrs, InstanceOf
+from mocks import mock_rule, mock_System
+from rx.subject import Subject
+
 from fapolicy_analyzer.redux import Action
 from fapolicy_analyzer.ui.actions import (
     ADD_NOTIFICATION,
@@ -37,8 +40,6 @@ from fapolicy_analyzer.ui.strings import (
     RULES_VALIDATION_ERROR,
     RULES_VALIDATION_WARNING,
 )
-from mocks import mock_rule, mock_System
-from rx.subject import Subject
 
 gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk  # isort: skip
@@ -198,7 +199,7 @@ def test_validate_clicked_valid(widget, mock_dispatch):
 def test_validate_clicked_invalid(widget, mock_dispatch):
     widget._text_view.rules_changed("bar baz bah")
     widget.on_validate_clicked()
-    mock_dispatch.assert_called_with(
+    mock_dispatch.assert_any_call(
         InstanceOf(Action)
         & Attrs(
             type=ADD_NOTIFICATION,
@@ -210,7 +211,7 @@ def test_validate_clicked_invalid(widget, mock_dispatch):
 def test_validate_clicked_warning(widget, mock_dispatch):
     widget._text_view.rules_changed("allow perm=any exe=/foo : all")
     widget.on_validate_clicked()
-    mock_dispatch.assert_called_with(
+    mock_dispatch.assert_any_call(
         InstanceOf(Action)
         & Attrs(
             type=ADD_NOTIFICATION,

--- a/fapolicy_analyzer/tests/test_notification.py
+++ b/fapolicy_analyzer/tests/test_notification.py
@@ -19,13 +19,14 @@ from time import sleep
 import gi
 import pytest
 from callee import Attrs, InstanceOf
+from rx.subject import Subject
+
 from fapolicy_analyzer.redux import Action
 from fapolicy_analyzer.ui.actions import REMOVE_NOTIFICATION
 from fapolicy_analyzer.ui.actions import Notification as Note
 from fapolicy_analyzer.ui.actions import NotificationType
 from fapolicy_analyzer.ui.notification import Notification
 from fapolicy_analyzer.ui.session_manager import sessionManager
-from rx.subject import Subject
 
 gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk  # isort: skip
@@ -67,7 +68,7 @@ def state():
 @pytest.mark.usefixtures("mock_notifications_feature")
 @pytest.mark.parametrize(
     "notifications, notification_type",
-    [([Note(0, "foo", t)], t) for t in list(NotificationType)],
+    [([Note(0, "foo", t, None)], t) for t in list(NotificationType)],
 )
 def test_shows_notification(widget, notification_type):
     assert widget.get_ref().get_child_revealed()
@@ -82,7 +83,7 @@ def test_shows_notification(widget, notification_type):
 @pytest.mark.usefixtures("mock_notifications_feature")
 @pytest.mark.parametrize(
     "notifications",
-    [[Note(0, "foo", t)] for t in list(NotificationType)],
+    [[Note(0, "foo", t, None)] for t in list(NotificationType)],
 )
 def test_closes_notification(widget, mock_dispatch, mock_notifications_feature):
     assert widget.get_ref().get_child_revealed()
@@ -97,7 +98,14 @@ def test_closes_notification(widget, mock_dispatch, mock_notifications_feature):
 @pytest.mark.usefixtures("mock_notifications_feature")
 @pytest.mark.parametrize(
     "notifications",
-    [[Note(0, "foo", t)] for t in [NotificationType.SUCCESS, NotificationType.INFO, NotificationType.WARN]],
+    [
+        [Note(0, "foo", t, None)]
+        for t in [
+            NotificationType.SUCCESS,
+            NotificationType.INFO,
+            NotificationType.WARN,
+        ]
+    ],
 )
 def test_notification_times_out(widget, mock_dispatch, mock_notifications_feature):
     assert widget.get_ref().get_child_revealed()
@@ -120,7 +128,7 @@ def test_notification_times_out(widget, mock_dispatch, mock_notifications_featur
 @pytest.mark.usefixtures("mock_notifications_feature")
 @pytest.mark.parametrize(
     "notifications",
-    [[Note(0, "foo", t)] for t in [NotificationType.ERROR]],
+    [[Note(0, "foo", t, None)] for t in [NotificationType.ERROR]],
 )
 def test_notification_does_not_time_out(widget, mock_dispatch):
     assert widget.get_ref().get_child_revealed()

--- a/fapolicy_analyzer/tests/test_notification.py
+++ b/fapolicy_analyzer/tests/test_notification.py
@@ -137,3 +137,35 @@ def test_notification_does_not_time_out(widget, mock_dispatch):
         InstanceOf(Action) & Attrs(type=REMOVE_NOTIFICATION)
     )
     assert widget.get_ref().get_child_revealed()
+
+
+@pytest.mark.parametrize(
+    "notifications",
+    [[Note(0, "foo", t, None)] for t in [NotificationType.WARN]],
+)
+def test_turns_off_timer(widget, mock_notifications_feature, mock_dispatch):
+    mock_notifications_feature.on_next(
+        [Note(1, "warning", NotificationType.ERROR, None)]
+    )
+    sleep(1.2)
+    mock_dispatch.assert_not_any_call(
+        InstanceOf(Action) & Attrs(type=REMOVE_NOTIFICATION)
+    )
+    assert widget.get_ref().get_child_revealed()
+
+
+@pytest.mark.parametrize(
+    "notifications",
+    [[Note(0, "foo", t, None)] for t in [NotificationType.ERROR]],
+)
+def test_changes_styles(widget, mock_notifications_feature):
+    container = widget.get_object("container")
+    style = container.get_style_context()
+    assert NotificationType.ERROR.value in style.list_classes()
+    assert NotificationType.WARN.value not in style.list_classes()
+
+    mock_notifications_feature.on_next(
+        [Note(1, "warning", NotificationType.WARN, None)]
+    )
+    assert NotificationType.ERROR.value not in style.list_classes()
+    assert NotificationType.WARN.value in style.list_classes()

--- a/fapolicy_analyzer/ui/actions.py
+++ b/fapolicy_analyzer/ui/actions.py
@@ -92,15 +92,20 @@ class NotificationType(Enum):
 class Notification(NamedTuple):
     id: int
     text: str
-    type: Optional[NotificationType]
+    type: NotificationType
+    category: Optional[str]
 
 
-def add_notification(text: str, type: NotificationType) -> Action:
-    return _create_action(ADD_NOTIFICATION, (Notification(next(_ids), text, type)))
+def add_notification(
+    text: str, type: NotificationType = NotificationType.INFO, category: str = None
+) -> Action:
+    return _create_action(
+        ADD_NOTIFICATION, (Notification(next(_ids), text, type, category))
+    )
 
 
 def remove_notification(id: int) -> Action:
-    return _create_action(REMOVE_NOTIFICATION, (Notification(id, "", None)))
+    return _create_action(REMOVE_NOTIFICATION, (Notification(id, "", None, None)))
 
 
 def add_changesets(*changesets: Changeset) -> Action:

--- a/fapolicy_analyzer/ui/notification.py
+++ b/fapolicy_analyzer/ui/notification.py
@@ -14,10 +14,16 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 from threading import Timer
+from typing import Sequence
 
 import gi
+
 from fapolicy_analyzer.ui import get_resource
-from fapolicy_analyzer.ui.actions import NotificationType, remove_notification
+from fapolicy_analyzer.ui.actions import (
+    Notification,
+    NotificationType,
+    remove_notification,
+)
 from fapolicy_analyzer.ui.store import dispatch, get_notifications_feature
 from fapolicy_analyzer.ui.ui_widget import UIConnectedWidget
 
@@ -26,51 +32,68 @@ from gi.repository import Gtk  # isort: skip
 
 
 class Notification(UIConnectedWidget):
-    def __init__(self, timer_duration=10):
+    def __init__(self, timer_duration: int = 10):
         super().__init__(
             get_notifications_feature(), on_next=self.on_next_notifications
         )
-        self.message = self.get_object("message")
-        self.container = self.get_object("container")
-        self.closeBtn = self.get_object("closeBtn")
+        self.__message = self.get_object("message")
+        self.__container = self.get_object("container")
+        self.__closeBtn = self.get_object("closeBtn")
         self.timerDuration = timer_duration
-        self.timer = None
-        self.notification_id = None
+        self.__timer = None
+        self.__notification_id = None
 
         styleProvider = Gtk.CssProvider()
         styleProvider.load_from_data(get_resource("notification.css").encode())
 
-        self.style = self.container.get_style_context()
-        self.style.add_provider(styleProvider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION)
-        self.closeBtn.get_style_context().add_provider(
+        self.__style = self.__container.get_style_context()
+        self.__style.add_provider(
+            styleProvider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION
+        )
+        self.__closeBtn.get_style_context().add_provider(
             styleProvider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION
         )
 
     def __start_timer(self):
-        self.timer = Timer(self.timerDuration, self.closeBtn.clicked)
-        self.timer.start()
+        self.__timer = Timer(self.timerDuration, self.__closeBtn.clicked)
+        self.__timer.start()
 
     def __stop_timer(self):
-        self.timer.cancel()
-        self.timer = None
+        if self.__timer:
+            self.__timer.cancel()
+            self.__timer = None
 
-    def on_next_notifications(self, notifications):
+    def __set_notification_style(self, notification_type: NotificationType):
+        # first remove old styles
+        for t in NotificationType:
+            self.__style.remove_class(t.value)
+
+        self.__style.add_class(notification_type.value)
+
+    def __create_notification(self, notification: Notification):
+        message = notification.text
+        notification_type = notification.type
+        self.__set_notification_style(notification_type)
+        self.__message.set_label(message)
+        self.__notification_id = notification.id
+
+    def on_next_notifications(self, notifications: Sequence[Notification]):
         first = next(iter(notifications), None)
         if first:
-            message = first.text
-            notificationType = first.type
-            self.style.add_class(notificationType.value)
-            self.message.set_label(message)
-            self.notification_id = first.id
+            # stop old timer
+            self.__stop_timer()
+
+            # create new notification
+            self.__create_notification(first)
             self.get_ref().set_reveal_child(True)
 
-            if notificationType not in [NotificationType.ERROR]:
+            # start new timer if needed
+            if first.type not in [NotificationType.ERROR]:
                 self.__start_timer()
         else:
             self.get_ref().set_reveal_child(False)
-            self.notification_id = None
+            self.__notification_id = None
 
     def on_closeBtn_clicked(self, *args):
-        if self.timer:
-            self.__stop_timer()
-        dispatch(remove_notification(self.notification_id))
+        self.__stop_timer()
+        dispatch(remove_notification(self.__notification_id))

--- a/fapolicy_analyzer/ui/rules/rules_admin_page.py
+++ b/fapolicy_analyzer/ui/rules/rules_admin_page.py
@@ -18,10 +18,12 @@ from typing import Any, Optional, Sequence, Tuple
 
 from fapolicy_analyzer import Rule, System
 from fapolicy_analyzer.ui.actions import (
+    Notification,
     NotificationType,
     add_notification,
     apply_changesets,
     modify_rules_text,
+    remove_notification,
     request_rules,
     request_rules_text,
 )
@@ -29,7 +31,11 @@ from fapolicy_analyzer.ui.changeset_wrapper import Changeset, RuleChangeset
 from fapolicy_analyzer.ui.rules.rules_list_view import RulesListView
 from fapolicy_analyzer.ui.rules.rules_status_info import RulesStatusInfo
 from fapolicy_analyzer.ui.rules.rules_text_view import RulesTextView
-from fapolicy_analyzer.ui.store import dispatch, get_system_feature
+from fapolicy_analyzer.ui.store import (
+    dispatch,
+    get_notifications_feature,
+    get_system_feature,
+)
 from fapolicy_analyzer.ui.strings import (
     APPLY_CHANGESETS_ERROR_MESSAGE,
     RULES_CHANGESET_PARSE_ERROR,
@@ -41,12 +47,19 @@ from fapolicy_analyzer.ui.strings import (
 from fapolicy_analyzer.ui.ui_page import UIAction, UIPage
 from fapolicy_analyzer.ui.ui_widget import UIConnectedWidget
 
+VALIDATION_NOTE_CATEGORY = "invalid rules"
+
 
 class RulesAdminPage(UIConnectedWidget, UIPage):
     def __init__(self):
         UIConnectedWidget.__init__(
             self, get_system_feature(), on_next=self.on_next_system
         )
+
+        self.__notification_subscription = get_notifications_feature().subscribe(
+            on_next=self.on_next_notifications,
+        )
+
         actions = {
             "rules": [
                 UIAction(
@@ -54,7 +67,7 @@ class RulesAdminPage(UIConnectedWidget, UIPage):
                     tooltip="Validate Rules",
                     icon="emblem-default",
                     signals={"clicked": self.on_validate_clicked},
-                    sensitivity_func=self.__rules_dirty,
+                    sensitivity_func=self.__rules_unvalidated,
                 ),
                 UIAction(
                     name="Save",
@@ -72,6 +85,7 @@ class RulesAdminPage(UIConnectedWidget, UIPage):
         self.__rules: Sequence[Rule] = []
         self.__modified_rules_text: str = ""
         self.__rules_text: str = ""
+        self.__rules_validated: bool = True
         self.__error_rules: Optional[str] = None
         self.__error_text: Optional[str] = None
         self.__loading_rules: bool = False
@@ -79,6 +93,7 @@ class RulesAdminPage(UIConnectedWidget, UIPage):
         self.__changesets: Sequence[Changeset] = []
         self.__saving: bool = False
         self.__system: System = None
+        self.__validation_notifications: Sequence[Notification] = []
 
         self.__load_rules()
 
@@ -103,6 +118,10 @@ class RulesAdminPage(UIConnectedWidget, UIPage):
         self.__loading_text = True
         dispatch(request_rules_text())
 
+    def __rules_unvalidated(self) -> bool:
+        print("check: rules_validated")
+        return not self.__rules_validated
+
     def __rules_dirty(self) -> bool:
         return (
             bool(self.__modified_rules_text)
@@ -116,6 +135,10 @@ class RulesAdminPage(UIConnectedWidget, UIPage):
                 self._list_view.render_rules(tmp_system.rules())
             except Exception:
                 logging.warning("Failed to parse validating changeset")
+
+    def __clear_validation_notifications(self):
+        for note in self.__validation_notifications:
+            dispatch(remove_notification(note.id))
 
     def __build_and_validate_changeset(self) -> Tuple[RuleChangeset, bool]:
         changeset = RuleChangeset()
@@ -133,6 +156,8 @@ class RulesAdminPage(UIConnectedWidget, UIPage):
             )
             return changeset, False
 
+        self.__rules_validated = True
+        self.__clear_validation_notifications()
         rules = changeset.rules()
 
         if not all([r.is_valid for r in rules]):
@@ -140,6 +165,7 @@ class RulesAdminPage(UIConnectedWidget, UIPage):
                 add_notification(
                     RULES_VALIDATION_ERROR,
                     NotificationType.ERROR,
+                    category=VALIDATION_NOTE_CATEGORY,
                 )
             )
             valid = False
@@ -149,9 +175,15 @@ class RulesAdminPage(UIConnectedWidget, UIPage):
                 add_notification(
                     RULES_VALIDATION_WARNING,
                     NotificationType.WARN,
+                    category=VALIDATION_NOTE_CATEGORY,
                 )
             )
         return changeset, valid
+
+    def _dispose(self):
+        UIConnectedWidget._dispose(self)
+        if self.__notification_subscription:
+            self.__notification_subscription.dispose()
 
     def on_save_clicked(self, *args):
         changeset, valid = self.__build_and_validate_changeset()
@@ -163,12 +195,14 @@ class RulesAdminPage(UIConnectedWidget, UIPage):
             self.__status_info.render_rule_status(changeset.rules())
 
     def on_validate_clicked(self, *args):
+        print("validating")
         changeset, _ = self.__build_and_validate_changeset()
         self.__update_list_view(changeset)
         self.__status_info.render_rule_status(changeset.rules())
 
     def on_text_view_rules_changed(self, rules: str):
         self.__modified_rules_text = rules
+        self.__rules_validated = False
         dispatch(modify_rules_text(rules))
 
     def highlight_row_from_data(self, data: Any):
@@ -227,3 +261,9 @@ class RulesAdminPage(UIConnectedWidget, UIPage):
             self.__loading_text = False
             self.__rules_text = text_state.rules_text
             self._text_view.render_rules(self.__rules_text)
+            self.__rules_validated = True
+
+    def on_next_notifications(self, notifications: Sequence[Notification]):
+        self.__validation_notifications = [
+            n for n in notifications if n.category == VALIDATION_NOTE_CATEGORY
+        ]

--- a/fapolicy_analyzer/ui/rules/rules_admin_page.py
+++ b/fapolicy_analyzer/ui/rules/rules_admin_page.py
@@ -119,7 +119,6 @@ class RulesAdminPage(UIConnectedWidget, UIPage):
         dispatch(request_rules_text())
 
     def __rules_unvalidated(self) -> bool:
-        print("check: rules_validated")
         return not self.__rules_validated
 
     def __rules_dirty(self) -> bool:
@@ -195,10 +194,12 @@ class RulesAdminPage(UIConnectedWidget, UIPage):
             self.__status_info.render_rule_status(changeset.rules())
 
     def on_validate_clicked(self, *args):
-        print("validating")
         changeset, _ = self.__build_and_validate_changeset()
         self.__update_list_view(changeset)
         self.__status_info.render_rule_status(changeset.rules())
+
+        # dispatch to force toolbar refresh
+        dispatch(modify_rules_text(self.__rules_validated))
 
     def on_text_view_rules_changed(self, rules: str):
         self.__modified_rules_text = rules


### PR DESCRIPTION
The rules admin text editor will now allow validation anytime the text has changed and it will clear the validation notification toasters when it's valid.

Also fixed a couple minor issues with the toaster notifications. 
1. The color of the notification was always stuck on whatever the first notification displayed was. For example if notification 1 was a warning and yellow, notification 2 of an error would still be yellow instead of read.
2. The timeout did not reset when a new notification was added. This lead to issue where error notification were timing out if the notification before it was a warning.

closes #687 