### PR TITLE
Add RC support to RPM build

### DIFF
--- a/fapolicy-analyzer.spec
+++ b/fapolicy-analyzer.spec
@@ -129,7 +129,8 @@ Requires:      gtksourceview3
 Requires:      webkit2gtk3
 Requires:      mesa-dri-drivers
 
-%global module fapolicy_analyzer
+%global module          fapolicy_analyzer
+%global module_version  %{lua:v = string.gsub(rpm.expand("%{?version}"), "~", ""); print(v)}
 
 %description
 Tools to assist with the configuration and management of fapolicyd.
@@ -161,7 +162,7 @@ rm Cargo.lock
 
 # our setup.py looks up the version from git describe
 # this overrides that check to the RPM version
-echo %{version} > VERSION
+echo %{module_version} > VERSION
 
 %build
 
@@ -171,7 +172,7 @@ python3 setup.py bdist_wheel
 
 %install
 
-%{py3_install_wheel %{module}-%{version}*%{_arch}.whl}
+%{py3_install_wheel %{module}-%{module_version}*%{_arch}.whl}
 install bin/%{name} %{buildroot}%{_sbindir}/%{name} -D
 mkdir -p %{buildroot}/%{_datadir}/help/{C,es}/%{name}/media
 install -p -D build/help/C/%{name}/*.html   %{buildroot}/%{_datadir}/help/C/%{name}/
@@ -185,7 +186,7 @@ install -p -D build/help/es/%{name}/media/* %{buildroot}/%{_datadir}/help/es/%{n
 %doc scripts/srpm/README
 %license LICENSE
 %{python3_sitearch}/%{module}
-%{python3_sitearch}/%{module}-%{version}*
+%{python3_sitearch}/%{module}-%{module_version}*
 %attr(755,root,root) %{_sbindir}/fapolicy-analyzer
 %{_datadir}/help/C/fapolicy-analyzer
 %{_datadir}/help/es/fapolicy-analyzer

--- a/scripts/srpm/fapolicy-analyzer.spec
+++ b/scripts/srpm/fapolicy-analyzer.spec
@@ -157,11 +157,12 @@ Requires:      python3-dataclasses
 Requires:      python3-importlib-resources
 %endif
 
-%global module       fapolicy_analyzer
-%global venv_dir     %{_builddir}/vendor-py
-%global venv_py3     %{venv_dir}/bin/python3
-%global venv_lib     %{venv_dir}/lib/python3.6/site-packages
-%global venv_install %{venv_py3} -m pip install --find-links=%{_sourcedir} --no-index --quiet
+%global module          fapolicy_analyzer
+%global module_version  %{lua:v = string.gsub(rpm.expand("%{?version}"), "~", ""); print(v)}
+%global venv_dir        %{_builddir}/vendor-py
+%global venv_py3        %{venv_dir}/bin/python3
+%global venv_lib        %{venv_dir}/lib/python3.6/site-packages
+%global venv_install    %{venv_py3} -m pip install --find-links=%{_sourcedir} --no-index --quiet
 
 %description
 Tools to assist with the configuration and management of fapolicyd.
@@ -228,7 +229,7 @@ rm Cargo.lock
 
 # our setup.py looks up the version from git describe
 # this overrides that check to the RPM version
-echo %{version} > VERSION
+echo %{module_version} > VERSION
 
 %build
 
@@ -243,7 +244,7 @@ python3 setup.py bdist_wheel
 
 %install
 
-%{py3_install_wheel %{module}-%{version}*%{_arch}.whl}
+%{py3_install_wheel %{module}-%{module_version}*%{_arch}.whl}
 install bin/%{name} %{buildroot}%{_sbindir}/%{name} -D
 mkdir -p %{buildroot}/%{_datadir}/help/{C,es}/%{name}/media
 install -p -D build/help/C/%{name}/*.html   %{buildroot}/%{_datadir}/help/C/%{name}/
@@ -257,7 +258,7 @@ install -p -D build/help/es/%{name}/media/* %{buildroot}/%{_datadir}/help/es/%{n
 %doc scripts/srpm/README
 %license LICENSE
 %{python3_sitearch}/%{module}
-%{python3_sitearch}/%{module}-%{version}*
+%{python3_sitearch}/%{module}-%{module_version}*
 %attr(755,root,root) %{_sbindir}/fapolicy-analyzer
 %{_datadir}/help/C/fapolicy-analyzer
 %{_datadir}/help/es/fapolicy-analyzer

--- a/setup.py
+++ b/setup.py
@@ -24,8 +24,7 @@ def get_version():
         return os.getenv("VERSION")
     if os.path.exists("VERSION"):
         with open("VERSION", "r") as version:
-            v = version.readline().strip().replace("~", "")
-            print(f"========================== {v} ======================")
+            v = version.readline().strip()
             if len(v):
                 return v
     try:

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ def get_version():
     if os.path.exists("VERSION"):
         with open("VERSION", "r") as version:
             v = version.readline().strip().replace("~", "")
+            print(f"========================== {v} ======================")
             if len(v):
                 return v
     try:

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ def get_version():
         return os.getenv("VERSION")
     if os.path.exists("VERSION"):
         with open("VERSION", "r") as version:
-            v = version.readline().strip()
+            v = version.readline().strip().replace("~", "")
             if len(v):
                 return v
     try:


### PR DESCRIPTION
This adds support for producing release candidate RPMs with a `rcX` suffix.

Before this change there was an issue assigning the tilde separated suffix to the Python artifact (details in the referenced issue).  In the past this issue was avoided by releasing RCs with no suffix, which eventually causes issues knowing whether the installed package is the final or RC version.

Closes #707 