### PR TITLE
Build updates

### DIFF
--- a/.github/workflows/common.yml
+++ b/.github/workflows/common.yml
@@ -2,11 +2,11 @@ on:
   push:
     branches:
       - 'master'
-      - 'release-*'
+      - 'release/*'
   pull_request:
     branches:
       - 'master'
-      - 'release-*'
+      - 'release/*'
 
 name: Common CI
 

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -2,11 +2,11 @@ on:
   push:
     branches:
       - "master"
-      - "release-*"
+      - "release/*"
   pull_request:
     branches:
       - "master"
-      - "release-*"
+      - "release/*"
 
 name: Python CI
 

--- a/.github/workflows/rpm.yml
+++ b/.github/workflows/rpm.yml
@@ -2,14 +2,14 @@ on:
   push:
     branches:
       - 'master'
-      - 'release-*'
+      - 'release/*'
       - 'rpm/test/*'
     tags:
       - 'v*'
   pull_request:
     branches:
       - 'master'
-      - 'release-*'
+      - 'release/*'
 
 name: RPM
 

--- a/.github/workflows/rpm.yml
+++ b/.github/workflows/rpm.yml
@@ -122,7 +122,8 @@ jobs:
       - name: Export tarballs
         run: |
           mkdir -p /tmp/archives
-          mv vendor-rs.tar.gz /tmp/archives/vendor-rs.$PLATFORM.tar.gz
+          mv vendor-rs.tar.gz         /tmp/archives/vendor-rs.$PLATFORM.tar.gz
+          mv vendor-docs.tar.gz       /tmp/archives
           mv fapolicy-analyzer.tar.gz /tmp/archives
         env:
           PLATFORM: ${{ matrix.props.name }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,11 +2,11 @@ on:
   push:
     branches:
       - 'master'
-      - 'release-*'
+      - 'release/*'
   pull_request:
     branches:
       - 'master'
-      - 'release-*'
+      - 'release/*'
 
 name: Rust CI
 

--- a/.github/workflows/tools.yml
+++ b/.github/workflows/tools.yml
@@ -2,13 +2,13 @@ on:
   push:
     branches:
       - 'master'
-      - 'release-*'
+      - 'release/*'
     tags:
       - 'v*'
   pull_request:
     branches:
       - 'master'
-      - 'release-*'
+      - 'release/*'
 
 name: Tools
 

--- a/fapolicy-analyzer.spec
+++ b/fapolicy-analyzer.spec
@@ -1,6 +1,6 @@
 Summary:       File Access Policy Analyzer
 Name:          fapolicy-analyzer
-Version:       0.6.1
+Version:       1.0.0
 Release:       1%{?dist}
 License:       GPLv3+
 URL:           https://github.com/ctc-oss/fapolicy-analyzer
@@ -192,5 +192,5 @@ install -p -D build/help/es/%{name}/media/* %{buildroot}/%{_datadir}/help/es/%{n
 %{_datadir}/help/es/fapolicy-analyzer
 
 %changelog
-* Fri Sep 09 2022 John Wass <jwass3@gmail.com> 0.6.1-1
+* Fri Dec 16 2022 John Wass <jwass3@gmail.com> 1.0.0-1
 - New release

--- a/scripts/srpm/fapolicy-analyzer.spec
+++ b/scripts/srpm/fapolicy-analyzer.spec
@@ -1,6 +1,6 @@
 Summary:       File Access Policy Analyzer
 Name:          fapolicy-analyzer
-Version:       0.6.1
+Version:       1.0.0
 Release:       1%{?dist}
 License:       GPLv3+
 URL:           https://github.com/ctc-oss/fapolicy-analyzer
@@ -264,5 +264,5 @@ install -p -D build/help/es/%{name}/media/* %{buildroot}/%{_datadir}/help/es/%{n
 %{_datadir}/help/es/fapolicy-analyzer
 
 %changelog
-* Fri Sep 09 2022 John Wass <jwass3@gmail.com> 0.6.1-1
+* Fri Dec 16 2022 John Wass <jwass3@gmail.com> 1.0.0-1
 - New release


### PR DESCRIPTION
A few changes ported back from release branches

- The doc tarball needs to be copied into the archives dir to ensure it is captured as a release artifact
- Change to the release branch pattern to match on slash rather than dash.
- Update the master spec versions to 1.0.0

Closes #709 