### PR TITLE
Refresh rules text after saving

### DIFF
--- a/fapolicy_analyzer/ui/rules/rules_admin_page.py
+++ b/fapolicy_analyzer/ui/rules/rules_admin_page.py
@@ -218,6 +218,7 @@ class RulesAdminPage(UIConnectedWidget, UIPage):
         if self.__system != system_state.system:
             self.__system = system_state.system
 
+        # Handle return from saving changeset
         if self.__saving and changesetState.error:
             self.__saving = False
             logging.error(
@@ -226,12 +227,14 @@ class RulesAdminPage(UIConnectedWidget, UIPage):
             dispatch(
                 add_notification(APPLY_CHANGESETS_ERROR_MESSAGE, NotificationType.ERROR)
             )
-
         elif self.__changesets != changesetState.changesets:
             self.__saving = False
             self.__changesets = changesetState.changesets
+            self.__rules_text = ""
+            self.__rules = []
             self.__load_rules()
 
+        # Handle return from loading parsed rules object
         if not rules_state.loading and self.__error_rules != rules_state.error:
             self.__error_rules = rules_state.error
             self.__loading_rules = False
@@ -248,6 +251,7 @@ class RulesAdminPage(UIConnectedWidget, UIPage):
             self._list_view.render_rules(self.__rules)
             self.__status_info.render_rule_status(self.__rules)
 
+        # Handle return from loading rule text
         if not text_state.loading and self.__error_text != text_state.error:
             self.__error_text = text_state.error
             self.__loading_text = False


### PR DESCRIPTION
This fixes an issue where the user adds something like a trailing white space to the rules, which the rust parser strips. Previously the UI was not being refreshed with the newly stripped text, so what was showing in the UI was out of sync with what was actually saved in the `System` object.

To Test this:
1. Edit the rules text by adding a single trailing space
2. Save the rules
3. Check in the editor and the trailing white space should be gone

Closes #725 