### PR TITLE
Use Pyo3 compat packages

### DIFF
--- a/.github/rpm-matrix.json
+++ b/.github/rpm-matrix.json
@@ -8,6 +8,13 @@
       "chroot": "fedora-rawhide-x86_64"
     },
     {
+      "platform": "fedora",
+      "dist": "fc37",
+      "spec": "fapolicy-analyzer.spec",
+      "image": "registry.fedoraproject.org/fedora:37",
+      "chroot": "fedora-37-x86_64"
+    },
+    {
       "platform": "rhel",
       "dist": "el8",
       "spec": "scripts/srpm/fapolicy-analyzer.spec",

--- a/fapolicy-analyzer.spec
+++ b/fapolicy-analyzer.spec
@@ -62,10 +62,10 @@ BuildRequires: rust-parking_lot_core-devel
 BuildRequires: rust-pkg-config-devel
 BuildRequires: rust-proc-macro-hack-devel
 BuildRequires: rust-proc-macro2-devel
-BuildRequires: rust-pyo3_0.15-devel
-BuildRequires: rust-pyo3-build-config0.15-devel
-BuildRequires: rust-pyo3-macros0.15-devel
-BuildRequires: rust-pyo3-macros-backend0.15-devel
+BuildRequires: (crate(pyo3/default) >= 0.15.0 with crate(pyo3/default) < 0.16.0)
+BuildRequires: (crate(pyo3-macros/default) >= 0.15.0 with crate(pyo3-macros/default) < 0.16.0)
+BuildRequires: (crate(pyo3-build-config/default) >= 0.15.0 with crate(pyo3-build-config/default) < 0.16.0)
+BuildRequires: (crate(pyo3-macros-backend/default) >= 0.15.0 with crate(pyo3-macros-backend/default) < 0.16.0)
 BuildRequires: rust-quote-devel
 BuildRequires: rust-rayon-devel
 BuildRequires: rust-rayon-core-devel

--- a/fapolicy-analyzer.spec
+++ b/fapolicy-analyzer.spec
@@ -62,10 +62,10 @@ BuildRequires: rust-parking_lot_core-devel
 BuildRequires: rust-pkg-config-devel
 BuildRequires: rust-proc-macro-hack-devel
 BuildRequires: rust-proc-macro2-devel
-BuildRequires: rust-pyo3-devel
-BuildRequires: rust-pyo3-build-config-devel
-BuildRequires: rust-pyo3-macros-devel
-BuildRequires: rust-pyo3-macros-backend-devel
+BuildRequires: rust-pyo3_0.15-devel
+BuildRequires: rust-pyo3-build-config0.15-devel
+BuildRequires: rust-pyo3-macros0.15-devel
+BuildRequires: rust-pyo3-macros-backend0.15-devel
 BuildRequires: rust-quote-devel
 BuildRequires: rust-rayon-devel
 BuildRequires: rust-rayon-core-devel


### PR DESCRIPTION
Move the pyo3 spec dependency to the new 0.15 compat package

This resolves the breakage that occurred when rawhide moved to 0.16.

This also restores the FC 37 build to ensure backwards compatibility.

Closes #745 