### PR TITLE
Map check errors to missing

### DIFF
--- a/crates/pyo3/src/check.rs
+++ b/crates/pyo3/src/check.rs
@@ -120,7 +120,7 @@ fn check_disk_trust(recs: Vec<Rec>, update: PyObject, done: PyObject) -> PyResul
             for batch in thread_load {
                 let updates = batch
                     .into_iter()
-                    .flat_map(|r| check(&r.trusted))
+                    .map(|r| check(&r.trusted).unwrap_or(Status::Missing(r.trusted)))
                     .collect::<Vec<_>>();
                 if ttx.send(Update::Items(updates)).is_err() {
                     eprintln!("failed to send Items msg");


### PR DESCRIPTION
This is an improvement over flattening IO errors away, but this should be addressed in a more robust way.

For now it at least ensures the UI sees the issue, even if it is somewhat obfuscated.