### PR TITLE
Bindings for app config path

### DIFF
--- a/crates/app/src/cfg.rs
+++ b/crates/app/src/cfg.rs
@@ -41,3 +41,14 @@ impl All {
         self.application.data_dir.as_str()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn check_config_dir() {
+        let path = All::config_dir().expect("conf path");
+        assert!(path.ends_with(format!(".config/{}", PROJECT_NAME)));
+    }
+}

--- a/crates/app/src/cfg.rs
+++ b/crates/app/src/cfg.rs
@@ -6,8 +6,11 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
+use confy::ConfyError;
+use directories::ProjectDirs;
 use serde::Deserialize;
 use serde::Serialize;
+use std::path::PathBuf;
 
 use crate::error::Error;
 use crate::error::Error::ConfigError;
@@ -25,6 +28,13 @@ pub struct All {
 impl All {
     pub fn load() -> Result<All, Error> {
         confy::load(PROJECT_NAME).map_err(ConfigError)
+    }
+
+    pub fn config_dir() -> Result<PathBuf, Error> {
+        // the arguments here match the confy::load impl
+        ProjectDirs::from("rs", "", PROJECT_NAME)
+            .ok_or(ConfigError(ConfyError::BadConfigDirectoryStr))
+            .map(|d| d.config_dir().to_path_buf())
     }
 
     pub fn data_dir(&self) -> &str {

--- a/crates/app/src/cfg.rs
+++ b/crates/app/src/cfg.rs
@@ -30,11 +30,13 @@ impl All {
         confy::load(PROJECT_NAME).map_err(ConfigError)
     }
 
-    pub fn config_dir() -> Result<PathBuf, Error> {
-        // the arguments here match the confy::load impl
-        ProjectDirs::from("rs", "", PROJECT_NAME)
-            .ok_or(ConfigError(ConfyError::BadConfigDirectoryStr))
-            .map(|d| d.config_dir().to_path_buf())
+    pub fn config_file() -> Result<PathBuf, Error> {
+        // this matches the confy impl
+        let project =
+            ProjectDirs::from("rs", "", PROJECT_NAME).ok_or(ConfyError::BadConfigDirectoryStr)?;
+        let mut config = project.config_dir().to_path_buf();
+        config.push("config.toml");
+        Ok(config)
     }
 
     pub fn data_dir(&self) -> &str {
@@ -48,7 +50,7 @@ mod tests {
 
     #[test]
     fn check_config_dir() {
-        let path = All::config_dir().expect("conf path");
-        assert!(path.ends_with(format!(".config/{}", PROJECT_NAME)));
+        let path = All::config_file().expect("conf path");
+        assert!(path.ends_with(format!(".config/{}/config.toml", PROJECT_NAME)));
     }
 }

--- a/crates/app/src/cfg.rs
+++ b/crates/app/src/cfg.rs
@@ -27,11 +27,12 @@ pub struct All {
 
 impl All {
     pub fn load() -> Result<All, Error> {
-        confy::load(PROJECT_NAME).map_err(ConfigError)
+        let conf_file = All::config_file()?;
+        confy::load_path(conf_file).map_err(ConfigError)
     }
 
     pub fn config_file() -> Result<PathBuf, Error> {
-        // this matches the confy impl
+        // this matches the default confy impl
         let project =
             ProjectDirs::from("rs", "", PROJECT_NAME).ok_or(ConfyError::BadConfigDirectoryStr)?;
         let mut config = project.config_dir().to_path_buf();

--- a/crates/pyo3/src/config.rs
+++ b/crates/pyo3/src/config.rs
@@ -1,0 +1,17 @@
+use pyo3::exceptions::PyRuntimeError;
+use pyo3::prelude::*;
+
+use fapolicy_app::cfg;
+
+/// Provide path to the application config file
+#[pyfunction]
+fn config_file_path() -> PyResult<String> {
+    cfg::All::config_dir()
+        .map(|p| p.display().to_string())
+        .map_err(|e| PyRuntimeError::new_err(format!("{:?}", e)))
+}
+
+pub fn init_module(_py: Python, m: &PyModule) -> PyResult<()> {
+    m.add_function(wrap_pyfunction!(config_file_path, m)?)?;
+    Ok(())
+}

--- a/crates/pyo3/src/config.rs
+++ b/crates/pyo3/src/config.rs
@@ -14,7 +14,7 @@ use fapolicy_app::cfg;
 /// Provide path to the application config file
 #[pyfunction]
 fn config_file_path() -> PyResult<String> {
-    cfg::All::config_dir()
+    cfg::All::config_file()
         .map(|p| p.display().to_string())
         .map_err(|e| PyRuntimeError::new_err(format!("{:?}", e)))
 }

--- a/crates/pyo3/src/config.rs
+++ b/crates/pyo3/src/config.rs
@@ -1,3 +1,11 @@
+/*
+ * Copyright Concurrent Technologies Corporation 2023
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
 use pyo3::exceptions::PyRuntimeError;
 use pyo3::prelude::*;
 

--- a/crates/pyo3/src/lib.rs
+++ b/crates/pyo3/src/lib.rs
@@ -11,6 +11,7 @@ use pyo3::prelude::*;
 pub mod acl;
 pub mod analysis;
 pub mod check;
+pub mod config;
 pub mod daemon;
 pub mod profiler;
 pub mod rules;
@@ -22,6 +23,7 @@ fn rust(_py: Python, m: &PyModule) -> PyResult<()> {
     acl::init_module(_py, m)?;
     analysis::init_module(_py, m)?;
     check::init_module(_py, m)?;
+    config::init_module(_py, m)?;
     daemon::init_module(_py, m)?;
     profiler::init_module(_py, m)?;
     rules::init_module(_py, m)?;

--- a/fapolicy_analyzer/tests/test_bindings.py
+++ b/fapolicy_analyzer/tests/test_bindings.py
@@ -17,4 +17,4 @@ from fapolicy_analyzer import config_file_path
 
 
 def test_config_file_path():
-    assert config_file_path().endswith(".config/fapolicy-analyzer")
+    assert config_file_path().endswith(".config/fapolicy-analyzer/config.toml")

--- a/fapolicy_analyzer/tests/test_bindings.py
+++ b/fapolicy_analyzer/tests/test_bindings.py
@@ -14,9 +14,8 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 from fapolicy_analyzer import config_file_path
-import test_xdg_utils
+
 
 def test_config_file_path():
     result = config_file_path()
     assert result.endswith(".config/fapolicy-analyzer")
-

--- a/fapolicy_analyzer/tests/test_bindings.py
+++ b/fapolicy_analyzer/tests/test_bindings.py
@@ -1,0 +1,22 @@
+# Copyright Concurrent Technologies Corporation 2023
+#
+# This aogram is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+from fapolicy_analyzer import config_file_path
+import test_xdg_utils
+
+def test_config_file_path():
+    result = config_file_path()
+    assert result.endswith(".config/fapolicy-analyzer")
+

--- a/fapolicy_analyzer/tests/test_bindings.py
+++ b/fapolicy_analyzer/tests/test_bindings.py
@@ -17,5 +17,4 @@ from fapolicy_analyzer import config_file_path
 
 
 def test_config_file_path():
-    result = config_file_path()
-    assert result.endswith(".config/fapolicy-analyzer")
+    assert config_file_path().endswith(".config/fapolicy-analyzer")


### PR DESCRIPTION
Provide path to the app config through bindings

The Python side may need access to the configuration file, and while there is no need to provide fine grained config modeling in the bindings, having single authoritative path is useful.

This adds a single function `config_file_path` that provides the path to the application config as a string.

This also changes the config file name from `fapolicy-analyzer.toml` to `config.toml`.  The file is already namespaced  by the config dir, there is no need to duplicate it in the filename.  This improves the readability of documentation and other discussions.

Closes #786