### PR TITLE
Turn off rule validation toasters

### DIFF
--- a/fapolicy_analyzer/tests/rules/test_rules_admin_page.py
+++ b/fapolicy_analyzer/tests/rules/test_rules_admin_page.py
@@ -226,7 +226,7 @@ def test_validate_clicked_valid(widget, mock_dispatch):
 def test_validate_clicked_invalid(widget, mock_dispatch):
     widget._text_view.rules_changed("bar baz bah")
     widget.on_validate_clicked()
-    mock_dispatch.assert_any_call(
+    mock_dispatch.assert_not_any_call(
         InstanceOf(Action)
         & Attrs(
             type=ADD_NOTIFICATION,
@@ -238,7 +238,7 @@ def test_validate_clicked_invalid(widget, mock_dispatch):
 def test_validate_clicked_warning(widget, mock_dispatch):
     widget._text_view.rules_changed("allow perm=any exe=/foo : all")
     widget.on_validate_clicked()
-    mock_dispatch.assert_any_call(
+    mock_dispatch.assert_not_any_call(
         InstanceOf(Action)
         & Attrs(
             type=ADD_NOTIFICATION,

--- a/fapolicy_analyzer/ui/rules/rules_admin_page.py
+++ b/fapolicy_analyzer/ui/rules/rules_admin_page.py
@@ -139,7 +139,7 @@ class RulesAdminPage(UIConnectedWidget, UIPage):
         for note in self.__validation_notifications:
             dispatch(remove_notification(note.id))
 
-    def __build_and_validate_changeset(self) -> Tuple[RuleChangeset, bool]:
+    def __build_and_validate_changeset(self, show_notifications=True) -> Tuple[RuleChangeset, bool]:
         changeset = RuleChangeset()
         valid = True
 
@@ -160,23 +160,25 @@ class RulesAdminPage(UIConnectedWidget, UIPage):
         rules = changeset.rules()
 
         if not all([r.is_valid for r in rules]):
-            dispatch(
-                add_notification(
-                    RULES_VALIDATION_ERROR,
-                    NotificationType.ERROR,
-                    category=VALIDATION_NOTE_CATEGORY,
+            if show_notifications:
+                dispatch(
+                    add_notification(
+                        RULES_VALIDATION_ERROR,
+                        NotificationType.ERROR,
+                        category=VALIDATION_NOTE_CATEGORY,
+                    )
                 )
-            )
             valid = False
 
         if any([True for r in rules for i in r.info if i.category.lower() == "w"]):
-            dispatch(
-                add_notification(
-                    RULES_VALIDATION_WARNING,
-                    NotificationType.WARN,
-                    category=VALIDATION_NOTE_CATEGORY,
+            if show_notifications:
+                dispatch(
+                    add_notification(
+                        RULES_VALIDATION_WARNING,
+                        NotificationType.WARN,
+                        category=VALIDATION_NOTE_CATEGORY,
+                    )
                 )
-            )
         return changeset, valid
 
     def _dispose(self):
@@ -194,7 +196,7 @@ class RulesAdminPage(UIConnectedWidget, UIPage):
             self.__status_info.render_rule_status(changeset.rules())
 
     def on_validate_clicked(self, *args):
-        changeset, _ = self.__build_and_validate_changeset()
+        changeset, _ = self.__build_and_validate_changeset(show_notifications=False)
         self.__update_list_view(changeset)
         self.__status_info.render_rule_status(changeset.rules())
 


### PR DESCRIPTION
Toasters should only appear on save pressed.

Allows for a less noisy rule development experience without toasts.

Closes #801 