### PR TITLE
Fix lost target info

### DIFF
--- a/fapolicy_analyzer/ui/profiler_page.py
+++ b/fapolicy_analyzer/ui/profiler_page.py
@@ -100,9 +100,9 @@ class ProfilerPage(UIConnectedWidget, UIPage, Events):
         }
 
     def on_event(self, state: ProfilerState):
+        self.refresh_view(state)
         if state.__class__ in self.profiling_handlers:
             self.profiling_handlers.get(state.__class__)(state)
-        self.refresh_view(state)
         self.refresh_toolbar()
 
     def handle_tick(self, state: ProfilerTick):


### PR DESCRIPTION
The text fields were being restored after the output, causing the empty entries in the target info.

Closes #818