### PR TITLE
Fix Go To Rule from debug log analysis

### DIFF
--- a/fapolicy_analyzer/ui/main_window.py
+++ b/fapolicy_analyzer/ui/main_window.py
@@ -413,7 +413,7 @@ class MainWindow(UIConnectedWidget):
         fcd.destroy()
 
     def activate_file_analyzer(self, file):
-        page = router(PAGE_SELECTION.ANALYZE_FROM_DEBUG, False, _file)
+        page = router(PAGE_SELECTION.ANALYZE_FROM_DEBUG, False, file)
         page.object_list.rule_view_activate += self.on_rulesAdminMenu_activate
         self.__pack_main_content(page)
 

--- a/fapolicy_analyzer/ui/main_window.py
+++ b/fapolicy_analyzer/ui/main_window.py
@@ -413,7 +413,9 @@ class MainWindow(UIConnectedWidget):
         fcd.destroy()
 
     def activate_file_analyzer(self, file):
-        self.__pack_main_content(router(PAGE_SELECTION.ANALYZE_FROM_DEBUG, False, file))
+        page = router(PAGE_SELECTION.ANALYZE_FROM_DEBUG, False, _file)
+        page.object_list.rule_view_activate += self.on_rulesAdminMenu_activate
+        self.__pack_main_content(page)
 
     def on_trustDbMenu_activate(self, menuitem, *args):
         self.__pack_main_content(router(PAGE_SELECTION.TRUST_DATABASE_ADMIN))


### PR DESCRIPTION
This fixes the Go To Rule action when analyzing a debug log.

Closes #831