### PR TITLE
Fix service active check

### DIFF
--- a/.copr/Makefile
+++ b/.copr/Makefile
@@ -36,6 +36,7 @@ dnf-fc:
 dnf-el:
 	dnf install -y rpmdevtools
 	dnf install -y rust-toolset
+	# v0.5.9 requires rust 1.64
 	cargo install cargo-vendor-filterer@0.5.8
 
 ifeq ($(OS_ID),rhel)

--- a/.copr/Makefile
+++ b/.copr/Makefile
@@ -36,7 +36,7 @@ dnf-fc:
 dnf-el:
 	dnf install -y rpmdevtools
 	dnf install -y rust-toolset
-	cargo install cargo-vendor-filterer
+	cargo install cargo-vendor-filterer@0.5.8
 
 ifeq ($(OS_ID),rhel)
 # we only need to vendor rust and python on rhel

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -307,7 +307,7 @@ dependencies = [
 
 [[package]]
 name = "fapolicy-rules"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "assert_matches",
  "log",

--- a/crates/daemon/src/svc.rs
+++ b/crates/daemon/src/svc.rs
@@ -166,10 +166,7 @@ impl Handle {
         );
 
         if let MessageItem::Str(state) = p.get("LoadState")? {
-            Ok(match state.as_str() {
-                "loaded" => true,
-                _ => false,
-            })
+            Ok(matches!(state.as_str(), "loaded"))
         } else {
             Err(ServiceCheckFailure(
                 "DBUS unit valid check failed".to_string(),

--- a/crates/pyo3/src/daemon.rs
+++ b/crates/pyo3/src/daemon.rs
@@ -71,8 +71,10 @@ impl PyHandle {
     }
 
     /// returns true if the unit exists, false otherwise
-    pub fn is_valid(&self) -> bool {
-        self.rs.active().is_ok()
+    pub fn is_valid(&self) -> PyResult<bool> {
+        self.rs
+            .valid()
+            .map_err(|e| PyRuntimeError::new_err(format!("{:?}", e)))
     }
 
     #[args(timeout = 15)]

--- a/fapolicy_analyzer/tests/test_fapd_manager.py
+++ b/fapolicy_analyzer/tests/test_fapd_manager.py
@@ -155,7 +155,7 @@ def test_initial_daemon_status(fapdManager, mocker):
 
 def test_initial_daemon_status_w_exception(mocker):
     mocker.patch(
-        "fapolicy_analyzer.ui.fapd_manager.Handle.is_active",
+        "fapolicy_analyzer.ui.fapd_manager.Handle.is_valid",
         side_effect=IOError()
     )
 


### PR DESCRIPTION
The active check now uses the unit loaded status to determine validity.

This check may not be generally accurate, but it is an improvement and works in the cases we are concerned about.

Also: The cargo-vendor-filterer crate recently released a new version that requires Rust 1.64.  This PR pins our install in the Makefile to the previous v0.5.8 for el8 compat.

Also: Commits the lock file which was missed back in #845

Closes #851 