### PR TITLE
Convert to spdx license ids

### DIFF
--- a/fapolicy-analyzer.spec
+++ b/fapolicy-analyzer.spec
@@ -2,7 +2,7 @@ Summary:       File Access Policy Analyzer
 Name:          fapolicy-analyzer
 Version:       1.0.1
 Release:       1%{?dist}
-License:       GPLv3+
+License:       GPL-3.0-or-later
 URL:           https://github.com/ctc-oss/fapolicy-analyzer
 Source0:       %{url}/releases/download/v%{version}/%{name}.tar.gz
 

--- a/scripts/srpm/fapolicy-analyzer.spec
+++ b/scripts/srpm/fapolicy-analyzer.spec
@@ -2,7 +2,7 @@ Summary:       File Access Policy Analyzer
 Name:          fapolicy-analyzer
 Version:       1.0.1
 Release:       1%{?dist}
-License:       GPLv3+
+License:       GPL-3.0-or-later
 URL:           https://github.com/ctc-oss/fapolicy-analyzer
 Source0:       %{url}/releases/download/v%{version}/%{name}.tar.gz
 


### PR DESCRIPTION
Fedora is converting to spdx license ids.  This amounts to /GPLv3+/GPL-3.0-or-later/ in the spec files.

See https://fedoraproject.org/wiki/Changes/SPDX_Licenses_Phase_1

Closes #822