### PR TITLE
Fix service valid check

### DIFF
--- a/crates/pyo3/src/daemon.rs
+++ b/crates/pyo3/src/daemon.rs
@@ -70,11 +70,9 @@ impl PyHandle {
             .map_err(|e| PyRuntimeError::new_err(format!("{:?}", e)))
     }
 
-    /// returns true if the unit exists, false otherwise
-    pub fn is_valid(&self) -> PyResult<bool> {
-        self.rs
-            .valid()
-            .map_err(|e| PyRuntimeError::new_err(format!("{:?}", e)))
+    /// returns true if the unit is valid, false otherwise
+    pub fn is_valid(&self) -> bool {
+        self.rs.valid().unwrap_or(false)
     }
 
     #[args(timeout = 15)]


### PR DESCRIPTION
Fix a regression in 594bee0 by flattening the service valid check to false.

The original contract of the valid check was that it was infallible in order to provide a simple way to check service status.  The change was an unintentional artifact left from debugging while improving the service status checks.

Closes #860 