### PR TITLE
Python code reformat and add CI check

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,5 +1,6 @@
 [flake8]
-ignore = E402,W503
+; extend-ignore = E402,W503
+extend-ignore = E203,E402
 max-line-length = 120
 i18nfuncs = gettext ngettext _
 inline-quotes = double

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -46,6 +46,16 @@ jobs:
           pipenv run python setup.py bdist_wheel
           echo ::set-output name=virt_env::$(pipenv --venv)
 
+  ui_format_check:
+    name: UI formatter check
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v3
+      - name: Format check with black
+        uses: rickstaa/action-black@v1
+        with:
+          black_args: ". --check --diff"
+
   ui_lint:
     name: UI Lint
     runs-on: ubuntu-20.04

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -56,9 +56,11 @@ jobs:
         with:
           python-version: 3.6
       - name: Format check with black
-        uses: rickstaa/action-black@v1
+        uses: psf/black@stable
         with:
-          black_args: "fapolicy_analyzer/ --check --diff -t py36"
+          options: "--check --diff -t py36"
+          src: "./fapolicy_analyzer"
+          version: "~= 22.0"
 
   ui_lint:
     name: UI Lint

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Format check with black
         uses: rickstaa/action-black@v1
         with:
-          black_args: "fapolicy_analyzer/ --check --diff"
+          black_args: "fapolicy_analyzer/ --check --diff -t py36"
 
   ui_lint:
     name: UI Lint

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -51,10 +51,14 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
+      - name: Set up Python 3.6
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.6
       - name: Format check with black
         uses: rickstaa/action-black@v1
         with:
-                black_args: "fapolicy_analyzer/ --check --diff"
+          black_args: "fapolicy_analyzer/ --check --diff"
 
   ui_lint:
     name: UI Lint

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Format check with black
         uses: rickstaa/action-black@v1
         with:
-          black_args: ". --check --diff"
+                black_args: "fapolicy_analyzer/ --check --diff"
 
   ui_lint:
     name: UI Lint

--- a/Pipfile
+++ b/Pipfile
@@ -45,7 +45,7 @@ allow_prereleases = true
 [scripts]
 test = "pipenv run xvfb-run -a pytest -s --cov=fapolicy_analyzer fapolicy_analyzer/tests/"
 lint = "pipenv run flake8 fapolicy_analyzer/"
-format = "pipenv run black fapolicy_analyzer/"
+format = "pipenv run black fapolicy_analyzer/ -t py36"
 watch-test = "pipenv run xvfb-run -a pytest-watch fapolicy_analyzer/ -- --testmon -s"
 extract_messages = "pipenv run python setup.py extract_messages"
 compile_catalog = "pipenv run python setup.py compile_catalog -f"

--- a/Pipfile
+++ b/Pipfile
@@ -9,7 +9,7 @@ python_version = "3.6"
 [dev-packages]
 semantic-version = "2.8.5"
 setuptools-rust = "0.12.1"
-flake8 = "*"
+flake8 = "~=4.0.1"
 black = "*"
 pytest = "*"
 pytest-cov = "*"
@@ -25,6 +25,7 @@ flake8-quotes = "*"
 autoflake = "*"
 markdown2 = "*"
 beautifulsoup4 = "*"
+flake8-black = "*"
 
 [packages]
 pycairo = "1.20.0"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "47bc7db279f235f46dbdc8d3cdee30d273e73eed13c0411865b792d0c565fae2"
+            "sha256": "fb7316e4dccdff5c48a699d8f172bd2c9ab34dd2e599b7e5e01766eb18578a87"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -108,7 +108,7 @@
                 "sha256:71c644c5369f4a6e07636f0aa966270449561fcea2e3d6747b8d23efaa9d7832",
                 "sha256:9fe5ea21568a0a70e50f273397638d39b03353731e6cbbb3fd8502a33fec40bc"
             ],
-            "markers": "python_full_version >= '3.6.0'",
+            "markers": "python_version >= '3.6'",
             "version": "==3.6.0"
         }
     },
@@ -145,11 +145,11 @@
         },
         "beautifulsoup4": {
             "hashes": [
-                "sha256:0e79446b10b3ecb499c1556f7e228a53e64a2bfcebd455f370d8927cb5b59e39",
-                "sha256:bc4bdda6717de5a2987436fb8d72f45dc90dd856bdfd512a1314ce90349a0106"
+                "sha256:492bbc69dca35d12daac71c4db1bfff0c876c00ef4a2ffacce226d4638eb72da",
+                "sha256:bd2520ca0d9d7d12694a53d44ac482d181b4ec1888909b035a3dbf40d0f57d4a"
             ],
             "index": "pypi",
-            "version": "==4.11.2"
+            "version": "==4.12.2"
         },
         "black": {
             "hashes": [
@@ -275,11 +275,19 @@
         },
         "flake8": {
             "hashes": [
-                "sha256:6fbe320aad8d6b95cec8b8e47bc933004678dc63095be98528b7bdd2a9f510db",
-                "sha256:7a1cf6b73744f5806ab95e526f6f0d8c01c66d7bbe349562d22dfca20610b248"
+                "sha256:479b1304f72536a55948cb40a32dce8bb0ffe3501e26eaf292c7e60eb5e0428d",
+                "sha256:806e034dda44114815e23c16ef92f95c91e4c71100ff52813adf7132a6ad870d"
             ],
             "index": "pypi",
-            "version": "==5.0.4"
+            "version": "==4.0.1"
+        },
+        "flake8-black": {
+            "hashes": [
+                "sha256:655281c61c77114d03d4f07ab1b84203f41ecc152fccf4b02c1a707557b6a376",
+                "sha256:f250cc658d6dd2a2928a4f91cbdcf78836577106f688a6dafaf4f1386860eaea"
+            ],
+            "index": "pypi",
+            "version": "==0.3.0"
         },
         "flake8-i18n": {
             "hashes": [
@@ -320,11 +328,11 @@
         },
         "mccabe": {
             "hashes": [
-                "sha256:348e0240c33b60bbdf4e523192ef919f28cb2c3d7d5c7794f74009290f236325",
-                "sha256:6c2d30ab6be0e4a46919781807b4f0d834ebdd6c6e3dca0bda5a15f863427b6e"
+                "sha256:ab8a6258860da4b6677da4bd2fe5dc2c659cff31b3ee4f7f5d64e79735b80d42",
+                "sha256:dd8d182285a0fe56bace7f45b5e7d1a6ebcbf524e8f3bd87eb0f125271b8831f"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==0.7.0"
+            "version": "==0.6.1"
         },
         "mypy-extensions": {
             "hashes": [
@@ -375,27 +383,27 @@
         },
         "pycodestyle": {
             "hashes": [
-                "sha256:2c9607871d58c76354b697b42f5d57e1ada7d261c261efac224b664affdc5785",
-                "sha256:d1735fc58b418fd7c5f658d28d943854f8a849b01a5d0a1e6f3f3fdd0166804b"
+                "sha256:720f8b39dde8b293825e7ff02c475f3077124006db4f440dcbc9a20b76548a20",
+                "sha256:eddd5847ef438ea1c7870ca7eb78a9d47ce0cdb4851a5523949f2601d0cbbe7f"
             ],
-            "markers": "python_version >= '3.6'",
-            "version": "==2.9.1"
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
+            "version": "==2.8.0"
         },
         "pyflakes": {
             "hashes": [
-                "sha256:4579f67d887f804e67edb544428f264b7b24f435b263c4614f384135cea553d2",
-                "sha256:491feb020dca48ccc562a8c0cbe8df07ee13078df59813b83959cbdada312ea3"
+                "sha256:05a85c2872edf37a4ed30b0cce2f6093e1d0581f8c19d7393122da7e25b2b24c",
+                "sha256:3bb3a3f256f4b7968c9c788781e4ff07dce46bdf12339dcda61053375426ee2e"
             ],
-            "markers": "python_version >= '3.6'",
-            "version": "==2.5.0"
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==2.4.0"
         },
         "pyparsing": {
             "hashes": [
-                "sha256:2b020ecf7d21b687f219b71ecad3631f644a47f01403fa1d1036b0c6416d70fb",
-                "sha256:5026bae9a10eeaefb61dab2f09052b9f4307d44aee4eda64b309723d8d206bbc"
+                "sha256:bc6926958617caafb8d3e07180f53aef29bd43ce913952c0991c4793b673b07c",
+                "sha256:bf0d2844c75e9510119142cfc4aba20c0043121a736010f47f2500a7fb2134c0"
             ],
             "markers": "python_full_version >= '3.6.8'",
-            "version": "==3.0.9"
+            "version": "==3.1.0b1"
         },
         "pytest": {
             "hashes": [
@@ -445,10 +453,10 @@
         },
         "pytz": {
             "hashes": [
-                "sha256:01a0681c4b9684a28304615eba55d1ab31ae00bf68ec157ec3708a8182dbbcd0",
-                "sha256:78f4f37d8198e0627c5f1143240bb0206b8691d8d7ac6d78fee88b78733f8c4a"
+                "sha256:1d8ce29db189191fb55338ee6d0387d82ab59f3d00eac103412d64e0ebd0c588",
+                "sha256:a151b3abb88eda1d4e34a9814df37de2a80e301e68ba0fd856fb9b46bfbbbffb"
             ],
-            "version": "==2022.7.1"
+            "version": "==2023.3"
         },
         "semantic-version": {
             "hashes": [
@@ -457,6 +465,14 @@
             ],
             "index": "pypi",
             "version": "==2.10.0"
+        },
+        "setuptools": {
+            "hashes": [
+                "sha256:22c7348c6d2976a52632c67f7ab0cdf40147db7789f9aed18734643fe9cf3373",
+                "sha256:4ce92f1e1f8f01233ee9952c04f6b81d1e02939d6e1b488428154974a4d0783e"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==59.6.0"
         },
         "setuptools-rust": {
             "hashes": [
@@ -474,12 +490,20 @@
             "markers": "python_version >= '3.6'",
             "version": "==2.3.2.post1"
         },
+        "toml": {
+            "hashes": [
+                "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b",
+                "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"
+            ],
+            "index": "pypi",
+            "version": "==0.10.2"
+        },
         "tomli": {
             "hashes": [
                 "sha256:05b6166bff487dc068d322585c7ea4ef78deed501cc124060e0f238e89a9231f",
                 "sha256:e3069e4be3ead9668e21cb9b074cd948f7b3113fd9c8bba083f48247aab8b11c"
             ],
-            "markers": "python_version >= '3.6'",
+            "markers": "python_full_version < '3.11.0a7'",
             "version": "==1.2.3"
         },
         "typed-ast": {
@@ -522,44 +546,44 @@
         },
         "watchdog": {
             "hashes": [
-                "sha256:102a60093090fc3ff76c983367b19849b7cc24ec414a43c0333680106e62aae1",
-                "sha256:17f1708f7410af92ddf591e94ae71a27a13974559e72f7e9fde3ec174b26ba2e",
-                "sha256:195ab1d9d611a4c1e5311cbf42273bc541e18ea8c32712f2fb703cfc6ff006f9",
-                "sha256:4cb5ecc332112017fbdb19ede78d92e29a8165c46b68a0b8ccbd0a154f196d5e",
-                "sha256:5100eae58133355d3ca6c1083a33b81355c4f452afa474c2633bd2fbbba398b3",
-                "sha256:61fdb8e9c57baf625e27e1420e7ca17f7d2023929cd0065eb79c83da1dfbeacd",
-                "sha256:6ccd8d84b9490a82b51b230740468116b8205822ea5fdc700a553d92661253a3",
-                "sha256:6e01d699cd260d59b84da6bda019dce0a3353e3fcc774408ae767fe88ee096b7",
-                "sha256:748ca797ff59962e83cc8e4b233f87113f3cf247c23e6be58b8a2885c7337aa3",
-                "sha256:83a7cead445008e880dbde833cb9e5cc7b9a0958edb697a96b936621975f15b9",
-                "sha256:8586d98c494690482c963ffb24c49bf9c8c2fe0589cec4dc2f753b78d1ec301d",
-                "sha256:8b5cde14e5c72b2df5d074774bdff69e9b55da77e102a91f36ef26ca35f9819c",
-                "sha256:8c28c23972ec9c524967895ccb1954bc6f6d4a557d36e681a36e84368660c4ce",
-                "sha256:967636031fa4c4955f0f3f22da3c5c418aa65d50908d31b73b3b3ffd66d60640",
-                "sha256:96cbeb494e6cbe3ae6aacc430e678ce4b4dd3ae5125035f72b6eb4e5e9eb4f4e",
-                "sha256:978a1aed55de0b807913b7482d09943b23a2d634040b112bdf31811a422f6344",
-                "sha256:a09483249d25cbdb4c268e020cb861c51baab2d1affd9a6affc68ffe6a231260",
-                "sha256:a480d122740debf0afac4ddd583c6c0bb519c24f817b42ed6f850e2f6f9d64a8",
-                "sha256:adaf2ece15f3afa33a6b45f76b333a7da9256e1360003032524d61bdb4c422ae",
-                "sha256:bc43c1b24d2f86b6e1cc15f68635a959388219426109233e606517ff7d0a5a73",
-                "sha256:c27d8c1535fd4474e40a4b5e01f4ba6720bac58e6751c667895cbc5c8a7af33c",
-                "sha256:cdcc23c9528601a8a293eb4369cbd14f6b4f34f07ae8769421252e9c22718b6f",
-                "sha256:cece1aa596027ff56369f0b50a9de209920e1df9ac6d02c7f9e5d8162eb4f02b",
-                "sha256:d0f29fd9f3f149a5277929de33b4f121a04cf84bb494634707cfa8ea8ae106a8",
-                "sha256:d6b87477752bd86ac5392ecb9eeed92b416898c30bd40c7e2dd03c3146105646",
-                "sha256:e038be858425c4f621900b8ff1a3a1330d9edcfeaa1c0468aeb7e330fb87693e",
-                "sha256:e618a4863726bc7a3c64f95c218437f3349fb9d909eb9ea3a1ed3b567417c661",
-                "sha256:f8ac23ff2c2df4471a61af6490f847633024e5aa120567e08d07af5718c9d092"
+                "sha256:03f342a9432fe08107defbe8e405a2cb922c5d00c4c6c168c68b633c64ce6190",
+                "sha256:0d9878be36d2b9271e3abaa6f4f051b363ff54dbbe7e7df1af3c920e4311ee43",
+                "sha256:0e1dd6d449267cc7d6935d7fe27ee0426af6ee16578eed93bacb1be9ff824d2d",
+                "sha256:2caf77ae137935c1466f8cefd4a3aec7017b6969f425d086e6a528241cba7256",
+                "sha256:3d2dbcf1acd96e7a9c9aefed201c47c8e311075105d94ce5e899f118155709fd",
+                "sha256:4109cccf214b7e3462e8403ab1e5b17b302ecce6c103eb2fc3afa534a7f27b96",
+                "sha256:4cd61f98cb37143206818cb1786d2438626aa78d682a8f2ecee239055a9771d5",
+                "sha256:53f3e95081280898d9e4fc51c5c69017715929e4eea1ab45801d5e903dd518ad",
+                "sha256:564e7739abd4bd348aeafbf71cc006b6c0ccda3160c7053c4a53b67d14091d42",
+                "sha256:5b848c71ef2b15d0ef02f69da8cc120d335cec0ed82a3fa7779e27a5a8527225",
+                "sha256:5defe4f0918a2a1a4afbe4dbb967f743ac3a93d546ea4674567806375b024adb",
+                "sha256:6f5d0f7eac86807275eba40b577c671b306f6f335ba63a5c5a348da151aba0fc",
+                "sha256:7a1876f660e32027a1a46f8a0fa5747ad4fcf86cb451860eae61a26e102c8c79",
+                "sha256:7a596f9415a378d0339681efc08d2249e48975daae391d58f2e22a3673b977cf",
+                "sha256:85bf2263290591b7c5fa01140601b64c831be88084de41efbcba6ea289874f44",
+                "sha256:8a4d484e846dcd75e96b96d80d80445302621be40e293bfdf34a631cab3b33dc",
+                "sha256:8f2df370cd8e4e18499dd0bfdef476431bcc396108b97195d9448d90924e3131",
+                "sha256:91fd146d723392b3e6eb1ac21f122fcce149a194a2ba0a82c5e4d0ee29cd954c",
+                "sha256:95ad708a9454050a46f741ba5e2f3468655ea22da1114e4c40b8cbdaca572565",
+                "sha256:964fd236cd443933268ae49b59706569c8b741073dbfd7ca705492bae9d39aab",
+                "sha256:9da7acb9af7e4a272089bd2af0171d23e0d6271385c51d4d9bde91fe918c53ed",
+                "sha256:a073c91a6ef0dda488087669586768195c3080c66866144880f03445ca23ef16",
+                "sha256:a74155398434937ac2780fd257c045954de5b11b5c52fc844e2199ce3eecf4cf",
+                "sha256:aa8b028750b43e80eea9946d01925168eeadb488dfdef1d82be4b1e28067f375",
+                "sha256:d1f1200d4ec53b88bf04ab636f9133cb703eb19768a39351cee649de21a33697",
+                "sha256:d9f9ed26ed22a9d331820a8432c3680707ea8b54121ddcc9dc7d9f2ceeb36906",
+                "sha256:ea5d86d1bcf4a9d24610aa2f6f25492f441960cf04aed2bd9a97db439b643a7b",
+                "sha256:efe3252137392a471a2174d721e1037a0e6a5da7beb72a021e662b7000a9903f"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==2.2.1"
+            "version": "==2.3.1"
         },
         "zipp": {
             "hashes": [
                 "sha256:71c644c5369f4a6e07636f0aa966270449561fcea2e3d6747b8d23efaa9d7832",
                 "sha256:9fe5ea21568a0a70e50f273397638d39b03353731e6cbbb3fd8502a33fec40bc"
             ],
-            "markers": "python_full_version >= '3.6.0'",
+            "markers": "python_version >= '3.6'",
             "version": "==3.6.0"
         }
     }

--- a/fapolicy_analyzer/redux/__init__.py
+++ b/fapolicy_analyzer/redux/__init__.py
@@ -30,13 +30,18 @@ from typing import Tuple
 
 from ._internal.action import create_action, of_type, select_action_payload
 from ._internal.epic import combine_epics
-from ._internal.feature import (create_feature_module, of_init_feature,
-                                select_feature)
+from ._internal.feature import create_feature_module, of_init_feature, select_feature
 from ._internal.reducer import combine_reducers, handle_actions
 from ._internal.selectors import select
 from ._internal.store import create_store
-from ._internal.types import (Action, Epic, Reducer, ReduxFeatureModule,
-                              ReduxRootStore, StateType)
+from ._internal.types import (
+    Action,
+    Epic,
+    Reducer,
+    ReduxFeatureModule,
+    ReduxRootStore,
+    StateType,
+)
 
 __all__: Tuple[str, ...] = (
     "Action",

--- a/fapolicy_analyzer/redux/_internal/action.py
+++ b/fapolicy_analyzer/redux/_internal/action.py
@@ -33,91 +33,88 @@ from .types import Action, PayloadType
 
 
 def create_action(type_name: str) -> Mapper[PayloadType, Action]:
-    """ Creates a function that produces an action of the given type
+    """Creates a function that produces an action of the given type
 
-        Args:
-            type_name: type of the action
+    Args:
+        type_name: type of the action
 
-        Returns:
-            A function that accepts the action payload and creates the action
+    Returns:
+        A function that accepts the action payload and creates the action
     """
     return partial(Action, type_name)
 
 
 def select_action_type(action: Action) -> str:
-    """ Selects the type from the action
+    """Selects the type from the action
 
-        Args:
-            action: the action object
+    Args:
+        action: the action object
 
-        Returns:
-            the type of the action
+    Returns:
+        the type of the action
     """
     return action.type
 
 
 def select_action_payload(action: Action) -> PayloadType:
-    """ Selects the payload from the action
+    """Selects the payload from the action
 
-        Args:
-            action: the action object
+    Args:
+        action: the action object
 
-        Returns:
-            the payload of the action
+    Returns:
+        the payload of the action
     """
     return action.payload
 
 
 def _is_by_selector(value: Any, selector: Mapper[Action, Any], action: Action) -> bool:
-    """ Checks if selector on an action matches a value
+    """Checks if selector on an action matches a value
 
-        Args:
-            action: the action object
+    Args:
+        action: the action object
 
-        Returns:
-            true if the selector result of the action matches, else false
+    Returns:
+        true if the selector result of the action matches, else false
 
     """
 
     return selector(action) is value
 
 
-def is_by_selector(
-    value: Any, selector: Mapper[Action, Any]
-) -> Predicate[Action]:
-    """ Returns a function that checks if the selector on an action equals a particular value
+def is_by_selector(value: Any, selector: Mapper[Action, Any]) -> Predicate[Action]:
+    """Returns a function that checks if the selector on an action equals a particular value
 
-        Args:
-            value: the value to compare against
-            selector: the selector to use to extract the value from the action
+    Args:
+        value: the value to compare against
+        selector: the selector to use to extract the value from the action
 
-        Returns:
-            Function to execute the check against an action
+    Returns:
+        Function to execute the check against an action
     """
     return partial(_is_by_selector, value, selector)
 
 
 def is_type(type_name) -> Predicate[Action]:
-    """ Returns a function that checks if the action is of a particular type
+    """Returns a function that checks if the action is of a particular type
 
-        Args:
-            type_name: type of the action to check for
+    Args:
+        type_name: type of the action to check for
 
-        Returns:
-            Function to execute the check against an action
+    Returns:
+        Function to execute the check against an action
     """
 
     return is_by_selector(type_name, select_action_type)
 
 
-def of_type(
-        type_name: str) -> Mapper[Observable, Observable]:
-    """ Returns a reactive operator that filters for actions of the given type
+def of_type(type_name: str) -> Mapper[Observable, Observable]:
+    """Returns a reactive operator that filters for actions of the given type
 
-        Args:
-            type_name: type of the action to filter for
+    Args:
+        type_name: type of the action to filter for
 
-        Returns:
-            The filter operator function
+    Returns:
+        The filter operator function
     """
     return op.filter(is_type(type_name))

--- a/fapolicy_analyzer/redux/_internal/epic.py
+++ b/fapolicy_analyzer/redux/_internal/epic.py
@@ -35,8 +35,9 @@ from .types import Epic
 logger = getLogger(__name__)
 
 
-def _wrapped_epic(epic: Mapper[Observable, Observable],
-                  action_: Observable, _: Observable) -> Observable:
+def _wrapped_epic(
+    epic: Mapper[Observable, Observable], action_: Observable, _: Observable
+) -> Observable:
     return epic(action_)
 
 
@@ -59,14 +60,14 @@ def _run_epic(action_: Observable, state_: Observable, epic: Epic) -> Observable
 
 
 def run_epic(action_: Observable, state_: Observable) -> Mapper[Epic, Observable]:
-    """ Runs a single epic agains the given action and state observables
+    """Runs a single epic agains the given action and state observables
 
-        Args:
-            action_: the action observable
-            state_: the state observable
+    Args:
+        action_: the action observable
+        state_: the state observable
 
-        Returns:
-            A callback function that will run the given epic on the observables
+    Returns:
+        A callback function that will run the given epic on the observables
     """
 
     assert isinstance(action_, Observable)
@@ -76,28 +77,27 @@ def run_epic(action_: Observable, state_: Observable) -> Mapper[Epic, Observable
 
 
 def _combine_epics(
-    norm_epics: Iterable[Epic],
-    action_: Observable, state_: Observable
+    norm_epics: Iterable[Epic], action_: Observable, state_: Observable
 ) -> Observable:
-    """ Merges the epics into one
+    """Merges the epics into one
 
-        Args:
-            action_: the action observable
-            state_: the state observable
+    Args:
+        action_: the action observable
+        state_: the state observable
 
-        Returns:
-            the merged epic
+    Returns:
+        the merged epic
     """
     return merge(*map(run_epic(action_, state_), norm_epics))
 
 
 def combine_epics(*epics: Iterable[Epic]) -> Epic:
-    """ Combines a sequence of epics into one single epic by merging them
+    """Combines a sequence of epics into one single epic by merging them
 
-        Args:
-            epics: the epics to merge
+    Args:
+        epics: the epics to merge
 
-        Returns:
-            The merged epic
+    Returns:
+        The merged epic
     """
     return partial(_combine_epics, tuple(map(normalize_epic, epics)))

--- a/fapolicy_analyzer/redux/_internal/feature.py
+++ b/fapolicy_analyzer/redux/_internal/feature.py
@@ -32,34 +32,32 @@ from rx.core.typing import Mapper, Predicate
 
 from .action import is_by_selector, is_type, select_action_payload
 from .constants import INIT_ACTION
-from .types import (Action, Epic, Reducer, ReduxFeatureModule, ReduxRootState,
-                    StateType)
+from .types import Action, Epic, Reducer, ReduxFeatureModule, ReduxRootState, StateType
 
 logger = getLogger(__name__)
 
 
 def has_payload(payload: Any) -> Predicate[Action]:
-    """ Returns a function that checks if the action has a particular payload
+    """Returns a function that checks if the action has a particular payload
 
-        Args:
-            payload: payload to test against
+    Args:
+        payload: payload to test against
 
-        Returns:
-            Function to execute the check against an action
+    Returns:
+        Function to execute the check against an action
     """
 
     return is_by_selector(payload, select_action_payload)
 
 
-def of_init_feature(
-        identifier: str) -> Mapper[Observable, Observable]:
-    """ Operator to test for the initialization action of a feature
+def of_init_feature(identifier: str) -> Mapper[Observable, Observable]:
+    """Operator to test for the initialization action of a feature
 
-        Args:
-            identifier: the identifier of the feature
+    Args:
+        identifier: the identifier of the feature
 
-        Returns:
-            Operator function that accepts init actions for the feature, once
+    Returns:
+        Operator function that accepts init actions for the feature, once
 
     """
     return pipe(
@@ -67,7 +65,7 @@ def of_init_feature(
         op.filter(has_payload(identifier)),
         op.take(1),
         op.map(lambda x: identifier),
-        op.do_action(logger.debug)
+        op.do_action(logger.debug),
     )
 
 
@@ -77,40 +75,39 @@ def create_feature_module(
     epic: Optional[Epic] = None,
     dependencies: Iterable[ReduxFeatureModule] = (),
 ) -> ReduxFeatureModule:
-    """ Constructs a new feature module descriptor
+    """Constructs a new feature module descriptor
 
-        Args:
-            identifier: the identifier of the feature
-            reducer: optional reducer
-            epic: optional epic
-            dependencies: optional dependencies on other features
+    Args:
+        identifier: the identifier of the feature
+        reducer: optional reducer
+        epic: optional epic
+        dependencies: optional dependencies on other features
 
-        Returns:
-            The feature module descriptor
+    Returns:
+        The feature module descriptor
 
     """
     return ReduxFeatureModule(identifier, reducer, epic, dependencies)
 
 
 def _select_feature_by_id(
-        identifier: str,
-        initial_state: Optional[StateType],
-        state: ReduxRootState) -> Optional[StateType]:
-    """ Selector function that selects the feature state from the root state"""
+    identifier: str, initial_state: Optional[StateType], state: ReduxRootState
+) -> Optional[StateType]:
+    """Selector function that selects the feature state from the root state"""
     return state.get(identifier, initial_state)
 
 
 def select_feature(
     identifier: str, initial_state: Optional[StateType] = None
 ) -> Callable[[ReduxRootState], Optional[StateType]]:
-    """ Returns a function that returns the feature state from the root state
+    """Returns a function that returns the feature state from the root state
 
-        Args:
-            identifier: identifier of the feature
-            initial_state: fallback state used if the feature state is not defined
+    Args:
+        identifier: identifier of the feature
+        initial_state: fallback state used if the feature state is not defined
 
-        Returns:
-            The selector function
+    Returns:
+        The selector function
 
     """
     return partial(_select_feature_by_id, identifier, initial_state)

--- a/fapolicy_analyzer/redux/_internal/reducer.py
+++ b/fapolicy_analyzer/redux/_internal/reducer.py
@@ -30,56 +30,58 @@ from .types import Action, Reducer, StateType
 
 
 def _default_reducer(
-        initial_state: Optional[StateType],
-        state: StateType,
-        _: Action) -> Optional[StateType]:
+    initial_state: Optional[StateType], state: StateType, _: Action
+) -> Optional[StateType]:
     #: default handling
     return state if state else initial_state
 
 
 def default_reducer(initial_state: Optional[StateType]) -> Reducer:
-    """ Creates a reducer that returns the original state or the default state.
+    """Creates a reducer that returns the original state or the default state.
 
-        Args:
-            inital_state: optional initial state used as a fallback
+    Args:
+        inital_state: optional initial state used as a fallback
 
-        Returns:
-            A reducer that reduces the current state or the initial state as a fallback
+    Returns:
+        A reducer that reduces the current state or the initial state as a fallback
 
     """
     return partial(_default_reducer, initial_state)
 
 
 def _handle_actions_reducer(
-        action_map: Mapping[str, Reducer],
-        def_reducer: Reducer,
-        state: StateType,
-        action: Action) -> Optional[StateType]:
+    action_map: Mapping[str, Reducer],
+    def_reducer: Reducer,
+    state: StateType,
+    action: Action,
+) -> Optional[StateType]:
     #: dispatch
-    return action_map.get(select_action_type(action),
-                          def_reducer)(state, action)
+    return action_map.get(select_action_type(action), def_reducer)(state, action)
 
 
 def handle_actions(
-    action_map: Mapping[str, Reducer], initial_state: Optional[StateType] = None,
+    action_map: Mapping[str, Reducer],
+    initial_state: Optional[StateType] = None,
 ) -> Reducer:
-    """ Creates a new reducer from a mapping of action name to reducer for that action.
+    """Creates a new reducer from a mapping of action name to reducer for that action.
 
-        Args:
-            action_map: mapping from action name to reducer for that action
-            initial_state: optional initial state used if no reducer matches
+    Args:
+        action_map: mapping from action name to reducer for that action
+        initial_state: optional initial state used if no reducer matches
 
-        Returns:
-            A reducer function that handles the actions in the map
+    Returns:
+        A reducer function that handles the actions in the map
 
     """
-    return partial(_handle_actions_reducer, {**action_map}, default_reducer(initial_state))
+    return partial(
+        _handle_actions_reducer, {**action_map}, default_reducer(initial_state)
+    )
 
 
-def _combine_reducers(items: Iterable[Tuple[str, Reducer]],
-                      state: Mapping[str, StateType],
-                      action: Action) -> Mapping[str, StateType]:
-    """ Updates the state object from the reducer mappings. """
+def _combine_reducers(
+    items: Iterable[Tuple[str, Reducer]], state: Mapping[str, StateType], action: Action
+) -> Mapping[str, StateType]:
+    """Updates the state object from the reducer mappings."""
     result = state if state else {}
     mutable: Optional[MutableMapping[str, StateType]] = None
     for key, value in items:
@@ -94,14 +96,15 @@ def _combine_reducers(items: Iterable[Tuple[str, Reducer]],
 
 
 def combine_reducers(
-        reducers: Mapping[str, Reducer]) -> Reducer[Mapping[str, StateType]]:
-    """ Creates a new reducer from a mapping of reducers.
+    reducers: Mapping[str, Reducer]
+) -> Reducer[Mapping[str, StateType]]:
+    """Creates a new reducer from a mapping of reducers.
 
-        Args:
-            reducers: the mapping from state partition to reducer
+    Args:
+        reducers: the mapping from state partition to reducer
 
-        Returns:
-            A reducer that dispatches actions against each of the mapped reducers
+    Returns:
+        A reducer that dispatches actions against each of the mapped reducers
 
     """
     return partial(_combine_reducers, tuple(reducers.items()))

--- a/fapolicy_analyzer/redux/_internal/selectors.py
+++ b/fapolicy_analyzer/redux/_internal/selectors.py
@@ -33,16 +33,15 @@ T2 = TypeVar("T2")
 Mapper = Callable[[T1], T2]
 
 
-def select(selector: Mapper[T1, T2]
-           ) -> Callable[[Observable], Observable]:
-    """ Reactive operator that applies a selector
-        and shares the result across multiple subscribers
+def select(selector: Mapper[T1, T2]) -> Callable[[Observable], Observable]:
+    """Reactive operator that applies a selector
+    and shares the result across multiple subscribers
 
-        Args:
-            selector: the selector function
+    Args:
+        selector: the selector function
 
-        Returns:
-            The reactive operator
+    Returns:
+        The reactive operator
     """
     return pipe(
         op.map(selector),

--- a/fapolicy_analyzer/redux/_internal/store.py
+++ b/fapolicy_analyzer/redux/_internal/store.py
@@ -33,116 +33,126 @@ from .action import create_action
 from .constants import INIT_ACTION
 from .epic import normalize_epic, run_epic
 from .reducer import combine_reducers
-from .types import (Action, Epic, Reducer, ReduxFeatureModule, ReduxRootState,
-                    ReduxRootStore, StateType)
+from .types import (
+    Action,
+    Epic,
+    Reducer,
+    ReduxFeatureModule,
+    ReduxRootState,
+    ReduxRootStore,
+    StateType,
+)
 
 logger = getLogger(__name__)
 
 
 def select_id(module: ReduxFeatureModule) -> str:
-    """ Selects the ID from a module
+    """Selects the ID from a module
 
-        Args:
-            module: the module
+    Args:
+        module: the module
 
-        Returns:
-            The module identifier
+    Returns:
+        The module identifier
     """
     return module.id
 
 
-def select_dependencies(
-        module: ReduxFeatureModule) -> Iterable[ReduxFeatureModule]:
-    """ Selects the dependencies from a module
+def select_dependencies(module: ReduxFeatureModule) -> Iterable[ReduxFeatureModule]:
+    """Selects the dependencies from a module
 
-        Args:
-            module: the module
+    Args:
+        module: the module
 
-        Returns:
-            The module dependencies
+    Returns:
+        The module dependencies
     """
     return module.dependencies
 
 
 def select_reducer(module: ReduxFeatureModule) -> Optional[Reducer]:
-    """ Selects the reducer from a module
+    """Selects the reducer from a module
 
-        Args:
-            module: the module
+    Args:
+        module: the module
 
-        Returns:
-            The module reducer
+    Returns:
+        The module reducer
     """
     return module.reducer
 
 
 def select_epic(module: ReduxFeatureModule) -> Optional[Epic]:
-    """ Selects the epic from a module
+    """Selects the epic from a module
 
-        Args:
-            module: the module
+    Args:
+        module: the module
 
-        Returns:
-            The module epic
+    Returns:
+        The module epic
     """
     return module.epic
 
 
 def has_reducer(module: ReduxFeatureModule) -> bool:
-    """ Tests if a module defines a reducer
+    """Tests if a module defines a reducer
 
-        Args:
-            module: the module
+    Args:
+        module: the module
 
-        Returns:
-            True if the module has a reducer, else False
+    Returns:
+        True if the module has a reducer, else False
 
     """
     return bool(select_reducer(module))
 
 
 def identity_reducer(state: StateType, _: Action) -> StateType:
-    """ Reducer function that returns the original state
-    """
+    """Reducer function that returns the original state"""
     return state
 
 
 def reduce_reducers(
     dst: Mapping[str, Reducer], module: ReduxFeatureModule
 ) -> Mapping[str, Reducer]:
-    """ Reduces the reducer on a module into a dictionary
+    """Reduces the reducer on a module into a dictionary
 
-        Args:
-            dst: the target dictionary
-            module: the module to reduce
+    Args:
+        dst: the target dictionary
+        module: the module to reduce
 
-        Returns:
-            the reduced dictionary
+    Returns:
+        the reduced dictionary
 
     """
     reducer: Optional[Reducer] = select_reducer(module)
-    return cast(Mapping[str, Reducer], {
-                **dst, select_id(module): reducer}) if reducer else dst
+    return (
+        cast(Mapping[str, Reducer], {**dst, select_id(module): reducer})
+        if reducer
+        else dst
+    )
 
 
-def create_store(initial_state: Optional[ReduxRootState] = None) -> ReduxRootStore:  # pylint: disable=too-many-locals
-    """ Constructs a new store that can handle feature modules.
+def create_store(
+    initial_state: Optional[ReduxRootState] = None,
+) -> ReduxRootStore:  # pylint: disable=too-many-locals
+    """Constructs a new store that can handle feature modules.
 
-        Args:
-            initial_state: optional initial state of the store, will typically be the empty dict
+    Args:
+        initial_state: optional initial state of the store, will typically be the empty dict
 
-        Returns:
-            An implementation of the store
+    Returns:
+        An implementation of the store
     """
 
     # current reducer
     reducer: Reducer = identity_reducer
 
     def replace_reducer(new_reducer: Reducer) -> None:
-        """ Callback that replaces the current reducer
+        """Callback that replaces the current reducer
 
-            Args:
-                new_reducer: the new reducer
+        Args:
+            new_reducer: the new reducer
 
         """
         nonlocal reducer
@@ -180,30 +190,21 @@ def create_store(initial_state: Optional[ReduxRootState] = None) -> ReduxRootSto
     )
 
     # Build the epic
-    epic_ = module_.pipe(
-        op.map(select_epic),
-        op.filter(bool),
-        op.map(normalize_epic)
-    )
+    epic_ = module_.pipe(op.map(select_epic), op.filter(bool), op.map(normalize_epic))
 
     # Root epic that combines all of the incoming epics
-    def root_epic(
-        action_: Observable, state_: Observable
-    ) -> Observable:
-        """ Implementation of the root epic. If listens for new epics
-            to come in and automatically subscribes.
+    def root_epic(action_: Observable, state_: Observable) -> Observable:
+        """Implementation of the root epic. If listens for new epics
+        to come in and automatically subscribes.
 
-            Args:
-                action_: the action observable
-                state_: the state observable
+        Args:
+            action_: the action observable
+            state_: the state observable
 
-            Returns
-                The observable of resulting actions
+        Returns
+            The observable of resulting actions
         """
-        return epic_.pipe(
-            op.flat_map(run_epic(action_, state_)),
-            op.map(_dispatch)
-        )
+        return epic_.pipe(op.flat_map(run_epic(action_, state_)), op.map(_dispatch))
 
     # notifications about new feature states
     new_module_ = module_.pipe(
@@ -213,10 +214,10 @@ def create_store(initial_state: Optional[ReduxRootState] = None) -> ReduxRootSto
     )
 
     def _add_feature_module(module: ReduxFeatureModule):
-        """ Registers a new feature module
+        """Registers a new feature module
 
-            Args:
-                module: the new feature module
+        Args:
+            module: the new feature module
 
         """
         module_id = select_id(module)
@@ -232,15 +233,15 @@ def create_store(initial_state: Optional[ReduxRootState] = None) -> ReduxRootSto
     )
 
     def _as_observable() -> Observable:
-        """ Returns the state as an observable
+        """Returns the state as an observable
 
-            Returns:
-                the observable
+        Returns:
+            the observable
         """
         return state
 
     def _on_completed() -> None:
-        """ Triggers the done event """
+        """Triggers the done event"""
         done_.on_next(None)
 
     merge(actions_, internal_).pipe(

--- a/fapolicy_analyzer/redux/_internal/types.py
+++ b/fapolicy_analyzer/redux/_internal/types.py
@@ -21,8 +21,7 @@
 """
     Module doc
 """
-from typing import (Any, Callable, Iterable, Mapping, NamedTuple, Optional,
-                    TypeVar)
+from typing import Any, Callable, Iterable, Mapping, NamedTuple, Optional, TypeVar
 
 from rx import Observable
 from rx.core.typing import OnCompleted
@@ -35,7 +34,7 @@ ReduxRootState = Mapping[str, StateType]
 
 
 class Action(NamedTuple):
-    """ Action implementation that takes a payload """
+    """Action implementation that takes a payload"""
 
     type: str
     """Identifier for the action, must be globally unique."""
@@ -50,12 +49,12 @@ Reducer = Callable[[StateType, Action], StateType]
 
 
 class ReduxFeatureModule(NamedTuple):
-    """ Defines the feature module. The ID identifies the section in the state and
-        is also used to globally discriminate features.
+    """Defines the feature module. The ID identifies the section in the state and
+    is also used to globally discriminate features.
 
-        After instantiating a feature store the store will fire an initialization action
-        for that feature. Use :py:meth:`~redux.of_init_feature` to
-        register for these initialization actions.
+    After instantiating a feature store the store will fire an initialization action
+    for that feature. Use :py:meth:`~redux.of_init_feature` to
+    register for these initialization actions.
     """
 
     id: str
@@ -72,8 +71,8 @@ class ReduxFeatureModule(NamedTuple):
 
 
 class ReduxRootStore(NamedTuple):
-    """ Implementation of a store that manages sub-state as features. Features are added
-        to the store automatically, when required by the select method.
+    """Implementation of a store that manages sub-state as features. Features are added
+    to the store automatically, when required by the select method.
     """
 
     as_observable: Callable[[], Observable]

--- a/fapolicy_analyzer/tests/features/test_profiler_feature.py
+++ b/fapolicy_analyzer/tests/features/test_profiler_feature.py
@@ -21,7 +21,12 @@ from callee.attributes import Attrs
 
 import fapolicy_analyzer.ui.store as store
 from fapolicy_analyzer.redux import Action, ReduxFeatureModule, create_store
-from fapolicy_analyzer.ui.actions import start_profiling, ERROR_PROFILER_INIT, ERROR_PROFILER_EXEC, stop_profiling
+from fapolicy_analyzer.ui.actions import (
+    start_profiling,
+    ERROR_PROFILER_INIT,
+    ERROR_PROFILER_EXEC,
+    stop_profiling,
+)
 from fapolicy_analyzer.ui.features import create_profiler_feature
 from fapolicy_analyzer.ui.strings import PROFILER_INIT_ERROR, PROFILER_EXEC_ERROR
 

--- a/fapolicy_analyzer/tests/reducers/test_profiler_reducer.py
+++ b/fapolicy_analyzer/tests/reducers/test_profiler_reducer.py
@@ -36,30 +36,34 @@ def test_handle_profiler_exec():
 def test_handle_profiler_tick():
     original = profiler_state(ProfilerState, cmd="foo")
     res = handle_profiler_tick(original, MagicMock(payload=999))
-    assert res == derive_profiler_state(ProfilerState, original, cmd="foo", duration=999)
+    assert res == derive_profiler_state(
+        ProfilerState, original, cmd="foo", duration=999
+    )
 
 
 def test_handle_clear_profiler_state():
     original = profiler_state(ProfilerState, cmd="foo", uid="root", pwd="/")
     res = handle_clear_profiler_state(original, MagicMock())
-    assert res == derive_profiler_state(ProfilerState, original, cmd=None, uid=None, pwd=None)
+    assert res == derive_profiler_state(
+        ProfilerState, original, cmd=None, uid=None, pwd=None
+    )
 
 
 def test_handle_start_profiling_request():
     args = {"cmd": "foo", "uid": "root"}
-    res = handle_start_profiling_request(empty_profiler_state(), MagicMock(payload=args))
+    res = handle_start_profiling_request(
+        empty_profiler_state(), MagicMock(payload=args)
+    )
     assert res == profiler_state(ProfilerState, uid="root")
 
     args = {"cmd": "foo", "pwd": "/"}
     res = handle_start_profiling_request(
-        empty_profiler_state(),
-        MagicMock(payload=args)
+        empty_profiler_state(), MagicMock(payload=args)
     )
     assert res == profiler_state(ProfilerState, pwd="/")
 
     args = {"cmd": "foo", "uid": "root", "pwd": "/"}
     res = handle_start_profiling_request(
-        empty_profiler_state(),
-        MagicMock(payload=args)
+        empty_profiler_state(), MagicMock(payload=args)
     )
     assert res == profiler_state(ProfilerState, uid="root", pwd="/")

--- a/fapolicy_analyzer/tests/redux/counter/feature.py
+++ b/fapolicy_analyzer/tests/redux/counter/feature.py
@@ -19,7 +19,11 @@
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 """ Exposes the feature creator """
-from fapolicy_analyzer.redux import ReduxFeatureModule, create_feature_module, select_feature
+from fapolicy_analyzer.redux import (
+    ReduxFeatureModule,
+    create_feature_module,
+    select_feature,
+)
 
 from .constants import FEATURE_NAME
 from .reducer import COUNTER_REDUCER

--- a/fapolicy_analyzer/tests/redux/counter/reducer.py
+++ b/fapolicy_analyzer/tests/redux/counter/reducer.py
@@ -34,4 +34,9 @@ def handle_decrement_action(state: int, action: Action) -> int:
 
 
 COUNTER_REDUCER = handle_actions(
-    {ACTION_INCREMENT: handle_increment_action, ACTION_DECREMENT: handle_decrement_action}, 0)
+    {
+        ACTION_INCREMENT: handle_increment_action,
+        ACTION_DECREMENT: handle_decrement_action,
+    },
+    0,
+)

--- a/fapolicy_analyzer/tests/redux/counter/test_counter.py
+++ b/fapolicy_analyzer/tests/redux/counter/test_counter.py
@@ -31,9 +31,7 @@ from .feature import create_counter_feature, select_counter_feature
 
 
 class TestCounter(TestCase):
-
     def test_type(self):
-
         def reduce_to_list(dst: Iterable[int], src: int) -> Iterable:
             return (*dst, src)
 
@@ -46,7 +44,7 @@ class TestCounter(TestCase):
         store_.pipe(
             operators.map(select_counter_feature),
             operators.reduce(reduce_to_list, ()),
-            operators.first()
+            operators.first(),
         ).subscribe(result)
 
         store.dispatch(INCREMENT_ACTION)

--- a/fapolicy_analyzer/tests/redux/feature/feature.py
+++ b/fapolicy_analyzer/tests/redux/feature/feature.py
@@ -44,7 +44,7 @@ select_sample_feature_module = select_feature(SAMPLE_FEATURE)
 
 def create_sample_feature() -> ReduxFeatureModule:
     """
-        Constructs a new sample feature
+    Constructs a new sample feature
     """
 
     def handle_sample_action(state: Any, action: Action) -> Any:
@@ -52,7 +52,10 @@ def create_sample_feature() -> ReduxFeatureModule:
 
     sample_reducer = handle_actions({ADD_SAMPLE_ACTION: handle_sample_action})
 
-    add_epic = pipe(of_type(ADD_SAMPLE_ACTION), ignore_elements(),)
+    add_epic = pipe(
+        of_type(ADD_SAMPLE_ACTION),
+        ignore_elements(),
+    )
 
     sample_epic = combine_epics(add_epic)
 

--- a/fapolicy_analyzer/tests/redux/init/feature.py
+++ b/fapolicy_analyzer/tests/redux/init/feature.py
@@ -45,7 +45,7 @@ select_init_feature_module = select_feature(INIT_FEATURE)
 
 def create_init_feature() -> ReduxFeatureModule:
     """
-        Constructs a new sample feature
+    Constructs a new sample feature
     """
 
     def handle_init_action(state: Any, action: Action) -> Any:
@@ -53,10 +53,14 @@ def create_init_feature() -> ReduxFeatureModule:
 
     sample_reducer = handle_actions({ADD_INIT_ACTION: handle_init_action})
 
-    add_epic = pipe(of_type(ADD_INIT_ACTION), ignore_elements(),)
+    add_epic = pipe(
+        of_type(ADD_INIT_ACTION),
+        ignore_elements(),
+    )
 
     init_epic = pipe(
-        of_init_feature(INIT_FEATURE), map(lambda x: add_init_action("init")),
+        of_init_feature(INIT_FEATURE),
+        map(lambda x: add_init_action("init")),
     )
 
     sample_epic = combine_epics(add_epic, init_epic)

--- a/fapolicy_analyzer/tests/redux/test_store.py
+++ b/fapolicy_analyzer/tests/redux/test_store.py
@@ -51,7 +51,8 @@ class TestReduxStore(TestCase):
         )
 
         test_ = init_state_.pipe(
-            map(lambda state: self.assertEqual(state, "init")), first(),
+            map(lambda state: self.assertEqual(state, "init")),
+            first(),
         )
 
         store.add_feature_module(create_init_feature())

--- a/fapolicy_analyzer/tests/redux/todos/action.py
+++ b/fapolicy_analyzer/tests/redux/todos/action.py
@@ -39,7 +39,8 @@ class VisibilityFilters(Enum):
 
 
 class TodoPayload(NamedTuple):
-    """ Todo payload """
+    """Todo payload"""
+
     id: int
     text: str
 
@@ -55,8 +56,8 @@ def add_todo(text: str) -> Action:
 
 # pylint: disable=unsubscriptable-object
 set_visibility_filter: Callable[[VisibilityFilters], Action] = create_action(
-    ACTION_SET_VISIBILITY_FILTER)
+    ACTION_SET_VISIBILITY_FILTER
+)
 
 # pylint: disable=unsubscriptable-object
-toggle_todo: Callable[[int], Action] = create_action(
-    ACTION_TOGGLE_TODO)
+toggle_todo: Callable[[int], Action] = create_action(ACTION_TOGGLE_TODO)

--- a/fapolicy_analyzer/tests/redux/todos/feature.py
+++ b/fapolicy_analyzer/tests/redux/todos/feature.py
@@ -19,7 +19,11 @@
 # WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-from fapolicy_analyzer.redux import ReduxFeatureModule, create_feature_module, select_feature
+from fapolicy_analyzer.redux import (
+    ReduxFeatureModule,
+    create_feature_module,
+    select_feature,
+)
 
 from .constants import FEATURE_NAME
 from .reducer import todo_reducer

--- a/fapolicy_analyzer/tests/redux/todos/reducer.py
+++ b/fapolicy_analyzer/tests/redux/todos/reducer.py
@@ -23,7 +23,6 @@ from fapolicy_analyzer.redux import Reducer, combine_reducers
 from .todo_reducer import todos
 from .visibility_reducer import visibility_filter
 
-todo_reducer: Reducer = combine_reducers({
-    "todos": todos,
-    "visibility_filter": visibility_filter
-})
+todo_reducer: Reducer = combine_reducers(
+    {"todos": todos, "visibility_filter": visibility_filter}
+)

--- a/fapolicy_analyzer/tests/redux/todos/test_action.py
+++ b/fapolicy_analyzer/tests/redux/todos/test_action.py
@@ -32,7 +32,6 @@ from .action import (
 
 
 class TestAction(TestCase):
-
     def test_add_todo(self):
 
         text = "My Action"

--- a/fapolicy_analyzer/tests/redux/todos/test_feature.py
+++ b/fapolicy_analyzer/tests/redux/todos/test_feature.py
@@ -28,7 +28,6 @@ from fapolicy_analyzer.redux import create_store
 
 
 class TestTodoReducer(TestCase):
-
     def test_add_todo(self):
 
         store = create_store()

--- a/fapolicy_analyzer/tests/redux/todos/test_todos_reducer.py
+++ b/fapolicy_analyzer/tests/redux/todos/test_todos_reducer.py
@@ -27,7 +27,6 @@ from .todo_reducer import todos
 
 
 class TestTodoReducer(TestCase):
-
     def test_initial_state(self):
         result = todos(None, Action("sample", None))
         assert result == ()

--- a/fapolicy_analyzer/tests/redux/todos/todo_reducer.py
+++ b/fapolicy_analyzer/tests/redux/todos/todo_reducer.py
@@ -26,20 +26,21 @@ from .action import ACTION_ADD_TODO, ACTION_TOGGLE_TODO, TodoPayload
 from .state import TodoItem
 
 
-def handle_add_todo(state: Sequence[TodoItem],
-                    action: Action) -> Sequence[TodoItem]:
+def handle_add_todo(state: Sequence[TodoItem], action: Action) -> Sequence[TodoItem]:
     payload = cast(TodoPayload, action.payload)
     return (*state, TodoItem(payload.id, payload.text, False))
 
 
-def handle_toggle_todo(
-        state: Sequence[TodoItem], action: Action) -> Sequence[TodoItem]:
+def handle_toggle_todo(state: Sequence[TodoItem], action: Action) -> Sequence[TodoItem]:
 
     key = cast(int, action.payload)
 
-    return [TodoItem(item.id, item.text, not item.completed)
-            if item.id == key else item for item in state]
+    return [
+        TodoItem(item.id, item.text, not item.completed) if item.id == key else item
+        for item in state
+    ]
 
 
 todos: Reducer = handle_actions(
-    {ACTION_ADD_TODO: handle_add_todo, ACTION_TOGGLE_TODO: handle_toggle_todo}, ())
+    {ACTION_ADD_TODO: handle_add_todo, ACTION_TOGGLE_TODO: handle_toggle_todo}, ()
+)

--- a/fapolicy_analyzer/tests/redux/todos/visibility_reducer.py
+++ b/fapolicy_analyzer/tests/redux/todos/visibility_reducer.py
@@ -25,12 +25,14 @@ from fapolicy_analyzer.redux import Action, Reducer, handle_actions
 from .action import ACTION_SET_VISIBILITY_FILTER, VisibilityFilters
 
 
-def handle_visibility_filter(state: VisibilityFilters,
-                             action: Action) -> VisibilityFilters:
+def handle_visibility_filter(
+    state: VisibilityFilters, action: Action
+) -> VisibilityFilters:
     payload = cast(VisibilityFilters, action.payload)
     print("payload", payload)
     return payload
 
 
 visibility_filter: Reducer = handle_actions(
-    {ACTION_SET_VISIBILITY_FILTER: handle_visibility_filter}, VisibilityFilters.SHOW_ALL)
+    {ACTION_SET_VISIBILITY_FILTER: handle_visibility_filter}, VisibilityFilters.SHOW_ALL
+)

--- a/fapolicy_analyzer/tests/rules/test_rules_admin_page.py
+++ b/fapolicy_analyzer/tests/rules/test_rules_admin_page.py
@@ -419,7 +419,7 @@ def test_preserve_list_row_collapse(widget):
             origin="Rule File 1",
             is_valid=True,
             info=[MagicMock(category="i", message="info message")],
-        )
+        ),
     ]
     widget._list_view.render_rules(mock_rules)
     model = widget._list_view.get_object("treeView").get_model()

--- a/fapolicy_analyzer/tests/test_confirm_deployment_dialog.py
+++ b/fapolicy_analyzer/tests/test_confirm_deployment_dialog.py
@@ -73,7 +73,11 @@ def test_load_rules(mocker):
         "fapolicy_analyzer.ui.rules.rules_difference_dialog.rules_difference",
         return_value="+allow perm=any all : all\n-deny perm=any all : all",
     )
-    widget = ConfirmDeploymentDialog([changeset], MagicMock(), MagicMock(), Gtk.Window())
+    widget = ConfirmDeploymentDialog(
+        [changeset], MagicMock(), MagicMock(), Gtk.Window()
+    )
     view = widget.get_object("changesTreeView")
     rows = [x for x in view.get_model()]
-    assert (CHANGESET_ACTION_RULES, "1 addition and 1 removal made") in [(r[0], r[1]) for r in rows]
+    assert (CHANGESET_ACTION_RULES, "1 addition and 1 removal made") in [
+        (r[0], r[1]) for r in rows
+    ]

--- a/fapolicy_analyzer/tests/test_fapd_manager.py
+++ b/fapolicy_analyzer/tests/test_fapd_manager.py
@@ -57,9 +57,7 @@ def test_stop_online(fapdManager, mocker):
 
 
 def test_stop_online_w_exception(fapdManager, mocker):
-    mockDispatch = mocker.patch(
-        "fapolicy_analyzer.ui.fapd_manager.dispatch"
-    )
+    mockDispatch = mocker.patch("fapolicy_analyzer.ui.fapd_manager.dispatch")
 
     mockFapdHandle = MagicMock()
     fapdManager._fapd_ref = mockFapdHandle
@@ -99,8 +97,7 @@ def test_start_profiling(fapdManager, mocker):
     fapdManager._fapd_ref.is_active.return_value = True
     mockProcess = MagicMock()
     mocker.patch(
-        "fapolicy_analyzer.ui.fapd_manager.subprocess.Popen",
-        return_value=mockProcess
+        "fapolicy_analyzer.ui.fapd_manager.subprocess.Popen", return_value=mockProcess
     )
     fapdManager.mode = FapdMode.ONLINE
     fapdManager.start(FapdMode.PROFILING)
@@ -155,8 +152,7 @@ def test_initial_daemon_status(fapdManager, mocker):
 
 def test_initial_daemon_status_w_exception(mocker):
     mocker.patch(
-        "fapolicy_analyzer.ui.fapd_manager.Handle.is_valid",
-        side_effect=IOError()
+        "fapolicy_analyzer.ui.fapd_manager.Handle.is_valid", side_effect=IOError()
     )
 
     with pytest.raises(IOError):
@@ -165,8 +161,7 @@ def test_initial_daemon_status_w_exception(mocker):
 
 def test_initial_daemon_status_w_invalid_handle(mocker):
     mocker.patch(
-        "fapolicy_analyzer.ui.fapd_manager.Handle.is_valid",
-        return_value=False
+        "fapolicy_analyzer.ui.fapd_manager.Handle.is_valid", return_value=False
     )
 
     fapdManager = FapdManager(True)

--- a/fapolicy_analyzer/tests/test_faprofiler.py
+++ b/fapolicy_analyzer/tests/test_faprofiler.py
@@ -42,7 +42,8 @@ def faProfSession(scope="session"):
 
 
 @pytest.mark.parametrize(
-    "dictArgs", [
+    "dictArgs",
+    [
         # Populate target dictionary w/unexpected keys
         {
             "cmd": "Now.sh",
@@ -57,7 +58,7 @@ def faProfSession(scope="session"):
             "uid": os.getenv("USER"),
             "env": "",
         },
-    ]
+    ],
 )
 def test_faprofsession_init_w_bad_keys(dictArgs):
     with pytest.raises(KeyError):
@@ -67,8 +68,7 @@ def test_faprofsession_init_w_bad_keys(dictArgs):
 def test_faprofsession_getpwnam_exception(mocker):
     # Emulate a getpwnam() exception
     mocker.patch(
-        "fapolicy_analyzer.ui.faprofiler.pwd.getpwnam",
-        side_effect=Exception()
+        "fapolicy_analyzer.ui.faprofiler.pwd.getpwnam", side_effect=Exception()
     )
 
     dictArgs = {
@@ -168,7 +168,8 @@ def test_validateArgs():
 
 
 @pytest.mark.parametrize(
-    "dictArgs, expected_status", [
+    "dictArgs, expected_status",
+    [
         (
             # Verify non-existent relative exec path is detected
             {
@@ -191,7 +192,7 @@ def test_validateArgs():
             },
             ProfSessionArgsStatus.OK,
         ),
-    ]
+    ],
 )
 def test_validateArgs_relative_exec(dictArgs, expected_status):
     dict_valid_args_return = FaProfSession.validateArgs(dictArgs)
@@ -200,7 +201,8 @@ def test_validateArgs_relative_exec(dictArgs, expected_status):
 
 
 @pytest.mark.parametrize(
-    "dictArgs, expected_status", [
+    "dictArgs, expected_status",
+    [
         (
             # Test w/good env var string; only OK key is in returned dict
             {
@@ -256,7 +258,7 @@ def test_validateArgs_relative_exec(dictArgs, expected_status):
             },
             ProfSessionArgsStatus.ENV_VARS_FORMATING,
         ),
-    ]
+    ],
 )
 def test_validateArgs_env_vars(dictArgs, expected_status):
     dict_valid_args_return = FaProfSession.validateArgs(dictArgs)

--- a/fapolicy_analyzer/tests/test_profiler_page.py
+++ b/fapolicy_analyzer/tests/test_profiler_page.py
@@ -23,13 +23,14 @@ from fapolicy_analyzer.ui.actions import (
     PROFILING_KILL_REQUEST,
     PROFILER_CLEAR_STATE_CMD,
     START_PROFILING_REQUEST,
-    ADD_NOTIFICATION
+    ADD_NOTIFICATION,
 )
 from fapolicy_analyzer.ui.reducers.profiler_reducer import profiler_state, ProfilerState
 from fapolicy_analyzer.ui.store import init_store
 from mocks import mock_System
 from fapolicy_analyzer.ui.profiler_page import ProfilerPage
 from fapolicy_analyzer.ui.fapd_manager import FapdManager
+
 gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk  # isort: skip
 
@@ -79,8 +80,7 @@ def test_stop_profiling_click(widget, mock_dispatch):
     widget.on_stop_clicked()
     assert widget.can_stop is False
     mock_dispatch.assert_called_with(
-        InstanceOf(Action)
-        & Attrs(type=PROFILING_KILL_REQUEST, payload=None)
+        InstanceOf(Action) & Attrs(type=PROFILING_KILL_REQUEST, payload=None)
     )
 
 
@@ -92,8 +92,7 @@ def test_clear_state_click(widget, mock_dispatch):
     assert widget.get_pwd_text() is None
     assert widget.get_env_text() is None
     mock_dispatch.assert_called_with(
-        InstanceOf(Action)
-        & Attrs(type=PROFILER_CLEAR_STATE_CMD, payload=None)
+        InstanceOf(Action) & Attrs(type=PROFILER_CLEAR_STATE_CMD, payload=None)
     )
 
 
@@ -111,8 +110,7 @@ def test_start_click(widget, mock_dispatch):
 
     widget.on_start_clicked()
     mock_dispatch.assert_called_with(
-        InstanceOf(Action)
-        & Attrs(type=START_PROFILING_REQUEST, payload=profiling_args)
+        InstanceOf(Action) & Attrs(type=START_PROFILING_REQUEST, payload=profiling_args)
     )
 
 
@@ -122,33 +120,23 @@ def test_start_click_with_env(widget, mock_dispatch):
 
     widget.on_start_clicked()
     mock_dispatch.assert_called_with(
-        InstanceOf(Action)
-        & Attrs(type=START_PROFILING_REQUEST, payload=profiling_args)
+        InstanceOf(Action) & Attrs(type=START_PROFILING_REQUEST, payload=profiling_args)
     )
 
 
 def test_start_click_with_bad_cmd(widget, mock_dispatch):
     widget.update_input_fields("xX_Xx", "root", "/tmp", "FOO=BAR,BAZ=BOO")
     widget.on_start_clicked()
-    mock_dispatch.assert_called_with(
-        InstanceOf(Action)
-        & Attrs(type=ADD_NOTIFICATION)
-    )
+    mock_dispatch.assert_called_with(InstanceOf(Action) & Attrs(type=ADD_NOTIFICATION))
 
 
 def test_start_click_with_bad_env(widget, mock_dispatch):
     widget.update_input_fields("ls", "root", "/tmp", "FOO")
     widget.on_start_clicked()
-    mock_dispatch.assert_called_with(
-        InstanceOf(Action)
-        & Attrs(type=ADD_NOTIFICATION)
-    )
+    mock_dispatch.assert_called_with(InstanceOf(Action) & Attrs(type=ADD_NOTIFICATION))
 
 
 def test_start_click_with_bad_uid(widget, mock_dispatch):
     widget.update_input_fields("ls", "foooooo", "/tmp", "FOO")
     widget.on_start_clicked()
-    mock_dispatch.assert_called_with(
-        InstanceOf(Action)
-        & Attrs(type=ADD_NOTIFICATION)
-    )
+    mock_dispatch.assert_called_with(InstanceOf(Action) & Attrs(type=ADD_NOTIFICATION))

--- a/fapolicy_analyzer/tests/test_subject_list.py
+++ b/fapolicy_analyzer/tests/test_subject_list.py
@@ -27,8 +27,7 @@ from fapolicy_analyzer.ui.actions import APPLY_CHANGESETS
 from fapolicy_analyzer.ui.changeset_wrapper import TrustChangeset
 from fapolicy_analyzer.ui.configs import Colors
 from fapolicy_analyzer.ui.strings import FILE_LABEL, FILES_LABEL
-from fapolicy_analyzer.ui.subject_list import (_TRUST_RESP, _UNTRUST_RESP,
-                                               SubjectList)
+from fapolicy_analyzer.ui.subject_list import _TRUST_RESP, _UNTRUST_RESP, SubjectList
 
 gi.require_version("Gtk", "3.0")
 from gi.repository import Gdk, Gtk  # isort: skip

--- a/fapolicy_analyzer/tests/test_time_select_dialog.py
+++ b/fapolicy_analyzer/tests/test_time_select_dialog.py
@@ -19,6 +19,7 @@ import pytest
 from fapolicy_analyzer.ui.time_select_dialog import (
     TimeSelectDialog,
 )
+
 gi.require_version("GtkSource", "3.0")
 from gi.repository import Gtk
 

--- a/fapolicy_analyzer/ui/__main__.py
+++ b/fapolicy_analyzer/ui/__main__.py
@@ -20,8 +20,7 @@ from fapolicy_analyzer.util.xdg_utils import (
     xdg_data_dir_prefix,
 )
 
-gf_handler = logging.FileHandler(xdg_data_dir_prefix("fapolicy-analyzer.log"),
-                                 mode="w")
+gf_handler = logging.FileHandler(xdg_data_dir_prefix("fapolicy-analyzer.log"), mode="w")
 gs_handler = logging.StreamHandler()
 logging.basicConfig(level=logging.DEBUG, handlers=[gf_handler, gs_handler])
 gs_handler.setLevel(logging.WARNING)
@@ -43,12 +42,15 @@ from gi.repository import Gtk, GtkSource, GObject  # isort: skip
 def _parse_cmdline():
     parser = argparse.ArgumentParser()
     parser.add_argument(
-        "-v", "--verbose", action="count", default=0,
+        "-v",
+        "--verbose",
+        action="count",
+        default=0,
         help="""
         Enable verbose output to stderr. A single `v` option will set the
         loglevel to INFO. Multiple 'v' options will set the level to DEBUG.
         Note that the '--loglevel' option overrides the default verbose levels
-        """
+        """,
     )
     parser.add_argument(
         "-a",
@@ -63,11 +65,12 @@ def _parse_cmdline():
         "-c", "--count", help="Specify the max number of session tmp files"
     )
     parser.add_argument(
-        "-l", "--loglevel",
+        "-l",
+        "--loglevel",
         choices=["CRITICAL", "ERROR", "WARNING", "INFO", "DEBUG"],
         help="""Specify the log level. [Default: WARNING.]
         This option overrides the loglevels associated with the '-v' and '-vv'
-        options"""
+        options""",
     )
     args = parser.parse_args()
 
@@ -91,12 +94,13 @@ def _parse_cmdline():
 
     # Enable edit session max autosave file count
     if args.loglevel:
-        dictOption2LogLevel = {"CRITICAL": logging.CRITICAL,
-                               "ERROR": logging.ERROR,
-                               "WARNING": logging.WARNING,
-                               "INFO": logging.INFO,
-                               "DEBUG": logging.DEBUG
-                               }
+        dictOption2LogLevel = {
+            "CRITICAL": logging.CRITICAL,
+            "ERROR": logging.ERROR,
+            "WARNING": logging.WARNING,
+            "INFO": logging.INFO,
+            "DEBUG": logging.DEBUG,
+        }
 
         gf_handler.setLevel(dictOption2LogLevel[args.loglevel])
 

--- a/fapolicy_analyzer/ui/confirm_deployment_dialog.py
+++ b/fapolicy_analyzer/ui/confirm_deployment_dialog.py
@@ -18,7 +18,10 @@ from typing import Sequence, Tuple
 
 import gi
 from fapolicy_analyzer import System
-from fapolicy_analyzer.ui.rules.rules_difference_dialog import RulesDifferenceDialog, filter_rule_diff
+from fapolicy_analyzer.ui.rules.rules_difference_dialog import (
+    RulesDifferenceDialog,
+    filter_rule_diff,
+)
 from fapolicy_analyzer.ui.changeset_wrapper import Changeset, TrustChangeset
 from fapolicy_analyzer.ui.configs import Colors
 from fapolicy_analyzer.ui.strings import (
@@ -108,7 +111,9 @@ class ConfirmDeploymentDialog(UIBuilderWidget):
 
         rule_messages, rule_diff = rules_changes()
         expand_btn = self.get_object("expandButton")
-        expand_btn.set_visible(True) if [*rule_messages] else expand_btn.set_visible(False)
+        expand_btn.set_visible(True) if [*rule_messages] else expand_btn.set_visible(
+            False
+        )
 
         return ([*trust_changes(), *rule_messages], rule_diff)
 
@@ -137,6 +142,8 @@ class ConfirmDeploymentDialog(UIBuilderWidget):
         return self.get_object("saveStateCbn").get_active()
 
     def on_expandButton_clicked(self, *args):
-        diff_dialog = RulesDifferenceDialog(self.__current_system, self.__previous_system).get_ref()
+        diff_dialog = RulesDifferenceDialog(
+            self.__current_system, self.__previous_system
+        ).get_ref()
         diff_dialog.run()
         diff_dialog.destroy()

--- a/fapolicy_analyzer/ui/fapd_manager.py
+++ b/fapolicy_analyzer/ui/fapd_manager.py
@@ -22,10 +22,12 @@ import subprocess
 from datetime import datetime as DT
 from enum import Enum
 from fapolicy_analyzer import Handle
-from fapolicy_analyzer.ui.actions import (NotificationType, add_notification)
+from fapolicy_analyzer.ui.actions import NotificationType, add_notification
 from fapolicy_analyzer.ui.store import dispatch
-from fapolicy_analyzer.ui.strings import (FAPD_DBUS_STOP_ERROR_MSG,
-                                          FAPD_DBUS_START_ERROR_MSG)
+from fapolicy_analyzer.ui.strings import (
+    FAPD_DBUS_STOP_ERROR_MSG,
+    FAPD_DBUS_START_ERROR_MSG,
+)
 from threading import Lock
 from time import time, sleep
 
@@ -46,10 +48,11 @@ def _promote():
     def result():
         os.setgid(0)
         os.setuid(0)
+
     return result
 
 
-class FapdManager():
+class FapdManager:
     def __init__(self, fapd_control_enabled=True):
         logging.info(f"FapdManager constructed, control:{fapd_control_enabled}")
 
@@ -138,7 +141,7 @@ class FapdManager():
 
         if instance == FapdMode.ONLINE:
             logging.debug("fapd is initiating an ONLINE session")
-            if (self._fapd_status != ServiceStatus.UNKNOWN):
+            if self._fapd_status != ServiceStatus.UNKNOWN:
                 try:
                     with self._fapd_lock:
                         self._fapd_ref.start()
@@ -147,8 +150,11 @@ class FapdManager():
                 except Exception:
                     self._fapd_status = ServiceStatus.UNKNOWN
                     logging.error(FAPD_DBUS_START_ERROR_MSG)
-                    dispatch(add_notification(FAPD_DBUS_START_ERROR_MSG,
-                                              NotificationType.ERROR))
+                    dispatch(
+                        add_notification(
+                            FAPD_DBUS_START_ERROR_MSG, NotificationType.ERROR
+                        )
+                    )
 
         else:
             # PROFILING
@@ -170,14 +176,12 @@ class FapdManager():
                 self._previous_instance = self._fapd_status
                 self._stop(FapdMode.ONLINE)
 
-            self.procProfile = subprocess.Popen(["/usr/sbin/fapolicyd",
-                                                 "--permissive",
-                                                 "--debug",
-                                                 "--no-details"],
-                                                stdout=fdStdoutPath,
-                                                stderr=fdStderrPath,
-                                                preexec_fn=_promote()
-                                                )
+            self.procProfile = subprocess.Popen(
+                ["/usr/sbin/fapolicyd", "--permissive", "--debug", "--no-details"],
+                stdout=fdStdoutPath,
+                stderr=fdStderrPath,
+                preexec_fn=_promote(),
+            )
             self._active_instance = FapdMode.PROFILING
             self._fapd_profiler_pid = self.procProfile.pid
             self.mode = FapdMode.PROFILING
@@ -202,15 +206,18 @@ class FapdManager():
 
         if instance == FapdMode.ONLINE:
             logging.debug("fapd is terminating an ONLINE session")
-            if (self._fapd_status != ServiceStatus.UNKNOWN):
+            if self._fapd_status != ServiceStatus.UNKNOWN:
                 try:
                     with self._fapd_lock:
                         self._fapd_ref.stop()
 
                 except Exception:
                     logging.error(FAPD_DBUS_STOP_ERROR_MSG)
-                    dispatch(add_notification(FAPD_DBUS_STOP_ERROR_MSG,
-                                              NotificationType.ERROR))
+                    dispatch(
+                        add_notification(
+                            FAPD_DBUS_STOP_ERROR_MSG, NotificationType.ERROR
+                        )
+                    )
 
         else:
             logging.debug("fapd is terminating a PROFILING session")
@@ -231,7 +238,11 @@ class FapdManager():
             if self._fapd_lock.acquire(blocking=False):
                 try:
                     valid = self._fapd_ref.is_valid()
-                    bStatus = ServiceStatus(self._fapd_ref.is_active()) if valid else ServiceStatus(None)
+                    bStatus = (
+                        ServiceStatus(self._fapd_ref.is_active())
+                        if valid
+                        else ServiceStatus(None)
+                    )
                     if bStatus != self._fapd_status:
                         logging.debug(f"_status({bStatus} updated")
                         self._fapd_status = bStatus
@@ -273,6 +284,8 @@ class FapdManager():
                 else:
                     self._fapd_status = ServiceStatus.UNKNOWN
             except Exception as e:
-                print(f"Fapd Handle is_valid() or is_active() exception: {e}",
-                      file=sys.stderr)
+                print(
+                    f"Fapd Handle is_valid() or is_active() exception: {e}",
+                    file=sys.stderr,
+                )
                 raise

--- a/fapolicy_analyzer/ui/faprofiler.py
+++ b/fapolicy_analyzer/ui/faprofiler.py
@@ -32,8 +32,8 @@ class ProfSessionArgsStatus(Enum):
     EXEC_NOT_FOUND = 4
     USER_DOESNT_EXIST = 5
     PWD_DOESNT_EXIST = 6
-    PWD_ISNT_DIR = 7,
-    ENV_VARS_FORMATING = 8,
+    PWD_ISNT_DIR = (7,)
+    ENV_VARS_FORMATING = (8,)
     UNKNOWN = 9
 
 
@@ -53,8 +53,7 @@ def expand_path(colon_separated_str, cwd="."):
     logging.debug(f"expand_path({colon_separated_str}, {cwd})")
 
     # Expand native PATH env var if in user provided PATH env var string
-    expanded_path = re.sub(r"\$\{?PATH\}?",
-                           os.environ.get("PATH"), colon_separated_str)
+    expanded_path = re.sub(r"\$\{?PATH\}?", os.environ.get("PATH"), colon_separated_str)
 
     # Expand implied and explicit '.' notation to supplied cwd argument
     expanded_path = re.sub(r":\.{0,1}$", f":{cwd}", expanded_path)
@@ -73,8 +72,7 @@ def expand_path(colon_separated_str, cwd="."):
 
 
 class ProfSessionException(RuntimeError):
-    def __init__(self, msg="Unknown error",
-                 enumError=ProfSessionArgsStatus.UNKNOWN):
+    def __init__(self, msg="Unknown error", enumError=ProfSessionArgsStatus.UNKNOWN):
         self.error_msg = f"Profiler Session: {msg}"
         self.error_enum = enumError
 
@@ -87,7 +85,7 @@ class FaProfSession:
         return FaProfSession._rel_tgt_which(
             dictProfTgt.get("cmd", ""),
             FaProfSession.comma_delimited_kv_string_to_dict(dictProfTgt.get("env", "")),
-            dictProfTgt.get("pwd", "")
+            dictProfTgt.get("pwd", ""),
         )
 
     @staticmethod
@@ -194,7 +192,9 @@ class FaProfSession:
             dictReturn[ProfSessionArgsStatus.ENV_VARS_FORMATING] = e
         except Exception as e:
             exec_env = None
-            dictReturn[ProfSessionArgsStatus.ENV_VARS_FORMATING] = s.PROF_ARG_ENV_VARS_FORMATING + f", {e}"
+            dictReturn[ProfSessionArgsStatus.ENV_VARS_FORMATING] = (
+                s.PROF_ARG_ENV_VARS_FORMATING + f", {e}"
+            )
 
         # exec empty?
         if not exec_path:
@@ -217,9 +217,7 @@ class FaProfSession:
                         )
             else:
                 # relative exec path
-                new_path = FaProfSession._rel_tgt_which(exec_path,
-                                                        exec_env,
-                                                        exec_pwd)
+                new_path = FaProfSession._rel_tgt_which(exec_path, exec_env, exec_pwd)
                 if not new_path:
                     dictReturn[ProfSessionArgsStatus.EXEC_NOT_FOUND] = (
                         exec_path + s.PROF_ARG_EXEC_NOT_FOUND

--- a/fapolicy_analyzer/ui/features/profiler_feature.py
+++ b/fapolicy_analyzer/ui/features/profiler_feature.py
@@ -29,7 +29,7 @@ from fapolicy_analyzer.redux import (
     create_feature_module,
     ReduxFeatureModule,
     combine_epics,
-    of_type
+    of_type,
 )
 from fapolicy_analyzer.ui.actions import (
     profiling_started,
@@ -42,7 +42,7 @@ from fapolicy_analyzer.ui.actions import (
     profiler_initialization_error,
     START_PROFILING_REQUEST,
     PROFILING_KILL_REQUEST,
-    profiler_termination_error
+    profiler_termination_error,
 )
 from fapolicy_analyzer.ui.reducers import profiler_reducer
 from fapolicy_analyzer.ui.strings import PROFILER_EXEC_ERROR, PROFILER_INIT_ERROR
@@ -150,13 +150,13 @@ def create_profiler_feature(dispatch: Callable) -> ReduxFeatureModule:
     start_profiling_epic = pipe(
         of_type(START_PROFILING_REQUEST),
         map(_start_profiling),
-        catch(lambda e, source: of(profiler_initialization_error(str(e))))
+        catch(lambda e, source: of(profiler_initialization_error(str(e)))),
     )
 
     kill_profiler_epic = pipe(
         of_type(PROFILING_KILL_REQUEST),
         map(_kill_profiler),
-        catch(lambda e, source: of(profiler_termination_error(str(e))))
+        catch(lambda e, source: of(profiler_termination_error(str(e)))),
     )
 
     profiler_epic = combine_epics(
@@ -164,4 +164,6 @@ def create_profiler_feature(dispatch: Callable) -> ReduxFeatureModule:
         kill_profiler_epic,
     )
 
-    return create_feature_module(PROFILING_FEATURE, profiler_reducer, epic=profiler_epic)
+    return create_feature_module(
+        PROFILING_FEATURE, profiler_reducer, epic=profiler_epic
+    )

--- a/fapolicy_analyzer/ui/object_list.py
+++ b/fapolicy_analyzer/ui/object_list.py
@@ -44,16 +44,12 @@ class ObjectList(SubjectList, Events):
         columns = super()._columns()
 
         rule_cell = Gtk.CellRendererText(background=Colors.LIGHT_GRAY)
-        rule_column = Gtk.TreeViewColumn(
-            FILE_LIST_RULE_ID_HEADER, rule_cell, markup=7
-        )
+        rule_column = Gtk.TreeViewColumn(FILE_LIST_RULE_ID_HEADER, rule_cell, markup=7)
         rule_column.set_sort_column_id(7)
         columns.insert(0, rule_column)
 
         perm_cell = Gtk.CellRendererText(background=Colors.LIGHT_GRAY, xalign=0.5)
-        perm_column = Gtk.TreeViewColumn(
-            FILE_LIST_PERM_HEADER, perm_cell, markup=6
-        )
+        perm_column = Gtk.TreeViewColumn(FILE_LIST_PERM_HEADER, perm_cell, markup=6)
         perm_column.set_sort_column_id(6)
         columns.insert(2, perm_column)
         return columns
@@ -102,9 +98,13 @@ class ObjectList(SubjectList, Events):
                 [o.perm],
             )
             access = self.__markup(o.access.upper(), ["A", "D"])
-            bg_color, txt_color, access_tooltip = self.__colors(o.access, o.trust_status, o.trust)
+            bg_color, txt_color, access_tooltip = self.__colors(
+                o.access, o.trust_status, o.trust
+            )
             tooltip = status_tooltip + "\n" + access_tooltip
-            store.append([status, access, o.file, o, bg_color, txt_color, perm, i, tooltip])
+            store.append(
+                [status, access, o.file, o, bg_color, txt_color, perm, i, tooltip]
+            )
 
         # call grandfather SearchableList's load_store method
         super(SubjectList, self).load_store(store)

--- a/fapolicy_analyzer/ui/policy_rules_admin_page.py
+++ b/fapolicy_analyzer/ui/policy_rules_admin_page.py
@@ -57,9 +57,7 @@ import time
 
 def time_format_config_dlg():
 
-    dlgTimeFormatConfig = Gtk.Dialog(
-        title=TIME_FORMAT_CONFIG_TITLE
-    )
+    dlgTimeFormatConfig = Gtk.Dialog(title=TIME_FORMAT_CONFIG_TITLE)
     dlgTimeFormatConfig.add_buttons(Gtk.STOCK_OK, Gtk.ResponseType.OK)
 
     label = Gtk.Label(label=SYSLOG_FORMAT_WARNING)
@@ -402,7 +400,9 @@ class PolicyRulesAdminPage(UIConnectedWidget, UIPage):
             or self.__selection_state["group"] is not None
         ):
             last_subject = self.__selection_state["subjects"][-1]
-            self.when_none = any([e.when() is None for e in self.__log.by_subject(last_subject)])
+            self.when_none = any(
+                [e.when() is None for e in self.__log.by_subject(last_subject)]
+            )
             data = list(
                 {
                     e.object.file: {e.rule_id: e.object}

--- a/fapolicy_analyzer/ui/profiler_page.py
+++ b/fapolicy_analyzer/ui/profiler_page.py
@@ -28,7 +28,8 @@ from fapolicy_analyzer.ui.actions import (
 )
 from fapolicy_analyzer.ui.actions import NotificationType, add_notification
 from fapolicy_analyzer.ui.faprofiler import (
-    EnumErrorPairs2Str, FaProfSession,
+    EnumErrorPairs2Str,
+    FaProfSession,
 )
 from fapolicy_analyzer.ui.reducers.profiler_reducer import (
     ProfilerState,
@@ -45,9 +46,7 @@ from gi.repository import Gtk  # isort: skip
 
 class ProfilerPage(UIConnectedWidget, UIPage, Events):
     def __init__(self, fapd_manager):
-        UIConnectedWidget.__init__(
-            self, get_profiling_feature(), on_next=self.on_event
-        )
+        UIConnectedWidget.__init__(self, get_profiling_feature(), on_next=self.on_event)
         self.__events__ = [
             "analyze_button_pushed",
             "refresh_toolbar",
@@ -82,7 +81,7 @@ class ProfilerPage(UIConnectedWidget, UIPage, Events):
                     "edit-clear",
                     {"clicked": self.on_clear_button_clicked},
                     sensitivity_func=self.clear_button_sensitivity,
-                )
+                ),
             ],
         }
 
@@ -115,16 +114,26 @@ class ProfilerPage(UIConnectedWidget, UIPage, Events):
             self.set_output_text(self.markup)
 
     def handle_done(self, state: ProfilerState):
-        self.display_log_output([
-            (f"`{state.cmd}` stdout", state.stdout_log),
-            (f"`{state.cmd}` stderr", state.stderr_log),
-            ("fapolicyd", state.events_log),
-        ])
+        self.display_log_output(
+            [
+                (f"`{state.cmd}` stdout", state.stdout_log),
+                (f"`{state.cmd}` stderr", state.stderr_log),
+                ("fapolicyd", state.events_log),
+            ]
+        )
         self.analysis_file = state.events_log
         self.terminating = False
 
-    def update_input_fields(self, cmd_args: Optional[str], uid: Optional[str], pwd: Optional[str], env: Optional[str]):
-        (cmd, args) = cmd_args.split(" ", 1) if cmd_args and " " in cmd_args else [cmd_args, None]
+    def update_input_fields(
+        self,
+        cmd_args: Optional[str],
+        uid: Optional[str],
+        pwd: Optional[str],
+        env: Optional[str],
+    ):
+        (cmd, args) = (
+            cmd_args.split(" ", 1) if cmd_args and " " in cmd_args else [cmd_args, None]
+        )
         self.get_object("argText").set_text(args if args else "")
         self.get_object("executeText").set_text(cmd if cmd else "")
         self.get_object("userText").set_text(uid if uid else "")
@@ -204,8 +213,12 @@ class ProfilerPage(UIConnectedWidget, UIPage, Events):
         }
 
     def get_entry_dict_markup(self):
-        return "<span size='x-large' underline='single'><b>Target</b></span>\n" + \
-            "\n".join([f"{key}: {value}" for key, value in self.get_entry_dict().items()])
+        return (
+            "<span size='x-large' underline='single'><b>Target</b></span>\n"
+            + "\n".join(
+                [f"{key}: {value}" for key, value in self.get_entry_dict().items()]
+            )
+        )
 
     def display_log_output(self, logs):
         markup = self.get_entry_dict_markup() + "\n\n"
@@ -226,7 +239,9 @@ class ProfilerPage(UIConnectedWidget, UIPage, Events):
         self.can_stop = False
         self.terminating = True
         self.refresh_toolbar()
-        self.update_output_text("\n<span size='large'><b>Profiler terminating...</b></span>")
+        self.update_output_text(
+            "\n<span size='large'><b>Profiler terminating...</b></span>"
+        )
         dispatch(stop_profiling())
 
     def on_start_clicked(self, *args):
@@ -251,7 +266,9 @@ class ProfilerPage(UIConnectedWidget, UIPage, Events):
             self.terminating = False
             self.refresh_toolbar()
 
-            self.set_output_text("<span size='large'><b>Profiler starting...</b></span>")
+            self.set_output_text(
+                "<span size='large'><b>Profiler starting...</b></span>"
+            )
 
             profiling_args = self.make_profiling_args()
 

--- a/fapolicy_analyzer/ui/reducers/profiler_reducer.py
+++ b/fapolicy_analyzer/ui/reducers/profiler_reducer.py
@@ -41,6 +41,7 @@ class ProfilerState(NamedTuple):
     stdout_log: Optional[str]
     stderr_log: Optional[str]
 
+
 #
 # About these state subtypes:
 #
@@ -79,20 +80,24 @@ class ProfilerDone(ProfilerState):
 
 
 def empty_profiler_state():
-    return ProfilerState(cmd=None,
-                         pwd=None,
-                         env=None,
-                         uid=None,
-                         pid=None,
-                         duration=None,
-                         running=False,
-                         killing=False,
-                         events_log=None,
-                         stdout_log=None,
-                         stderr_log=None, )
+    return ProfilerState(
+        cmd=None,
+        pwd=None,
+        env=None,
+        uid=None,
+        pid=None,
+        duration=None,
+        running=False,
+        killing=False,
+        events_log=None,
+        stdout_log=None,
+        stderr_log=None,
+    )
 
 
-def derive_profiler_state(target, source: ProfilerState, **kwargs: Optional[Any]) -> ProfilerState:
+def derive_profiler_state(
+    target, source: ProfilerState, **kwargs: Optional[Any]
+) -> ProfilerState:
     return target(**{**source._asdict(), **kwargs})
 
 
@@ -100,7 +105,9 @@ def profiler_state(target, **kwargs: Optional[Any]) -> ProfilerState:
     return target(**{**empty_profiler_state()._asdict(), **kwargs})
 
 
-def handle_start_profiling_request(state: ProfilerState, action: Action) -> ProfilerState:
+def handle_start_profiling_request(
+    state: ProfilerState, action: Action
+) -> ProfilerState:
     args: Dict[str, str] = action.payload
     uid = args.get("uid", None)
     pwd = args.get("pwd", None)
@@ -108,18 +115,24 @@ def handle_start_profiling_request(state: ProfilerState, action: Action) -> Prof
     return derive_profiler_state(ProfilerState, state, uid=uid, pwd=pwd, env=env)
 
 
-def handle_start_profiling_response(state: ProfilerState, action: Action) -> ProfilerState:
+def handle_start_profiling_response(
+    state: ProfilerState, action: Action
+) -> ProfilerState:
     cmd = action.payload
     return derive_profiler_state(ProfilerState, state, cmd=cmd, running=True)
 
 
 def handle_set_profiler_output(state: ProfilerState, action: Action) -> ProfilerState:
     (ev, so, se) = action.payload
-    return derive_profiler_state(ProfilerState, state, events_log=ev, stdout_log=so, stderr_log=se)
+    return derive_profiler_state(
+        ProfilerState, state, events_log=ev, stdout_log=so, stderr_log=se
+    )
 
 
 def handle_clear_profiler_state(state: ProfilerState, action: Action) -> ProfilerState:
-    return derive_profiler_state(ProfilerState, state, cmd=None, pwd=None, env=None, uid=None)
+    return derive_profiler_state(
+        ProfilerState, state, cmd=None, pwd=None, env=None, uid=None
+    )
 
 
 def handle_profiler_exec(state: ProfilerState, action: Action) -> ProfilerState:
@@ -151,5 +164,5 @@ profiler_reducer: Reducer = handle_actions(
         PROFILING_DONE_EVENT: handle_profiler_done,
         PROFILING_KILL_RESPONSE: handle_profiler_kill,
     },
-    empty_profiler_state()
+    empty_profiler_state(),
 )

--- a/fapolicy_analyzer/ui/rules/rules_difference_dialog.py
+++ b/fapolicy_analyzer/ui/rules/rules_difference_dialog.py
@@ -26,19 +26,23 @@ def filter_rule_diff(previous_system, current_system):
     diffs = rules_difference(previous_system, current_system).split("\n")
     for d in diffs:
         if (
-           (d.startswith("+") and d.split("+")[-1] + "\n" in previous_system.rules_text())
-           or (d.startswith("-") and d.split("-")[-1].split("\n")[0] in current_system.rules_text())
-           ):
+            d.startswith("+")
+            and d.split("+")[-1] + "\n" in previous_system.rules_text()
+        ) or (
+            d.startswith("-")
+            and d.split("-")[-1].split("\n")[0] in current_system.rules_text()
+        ):
             diffs.remove(d)
     return diffs
 
 
 class RulesDifferenceDialog(UIBuilderWidget):
-    def __init__(self,
-                 current_system: System,
-                 previous_system: System,
-                 parent=None,
-                 ):
+    def __init__(
+        self,
+        current_system: System,
+        previous_system: System,
+        parent=None,
+    ):
         super().__init__()
         if parent:
             self.get_ref().set_transient_for(parent)

--- a/fapolicy_analyzer/ui/rules/rules_list_view.py
+++ b/fapolicy_analyzer/ui/rules/rules_list_view.py
@@ -151,7 +151,10 @@ class RulesListView(SearchableList):
 
     def restore_row_collapse(self):
         def toggle_collapse(store, treepath, treeiter):
-            self.treeView.collapse_row(treepath) if store[treeiter][7] else self.treeView.expand_row(treepath, False)
+            self.treeView.collapse_row(treepath) if store[treeiter][
+                7
+            ] else self.treeView.expand_row(treepath, False)
+
         if self.model is not None:
             self.model.foreach(toggle_collapse)
 
@@ -190,4 +193,6 @@ class RulesListView(SearchableList):
                         self.__append_info(store, rule, info, rule_row)
 
         self.load_store(store)
-        self.__set_default_view(store) if self.reset_default_view else self.restore_row_collapse()
+        self.__set_default_view(
+            store
+        ) if self.reset_default_view else self.restore_row_collapse()

--- a/fapolicy_analyzer/ui/rules/rules_status_info.py
+++ b/fapolicy_analyzer/ui/rules/rules_status_info.py
@@ -76,7 +76,10 @@ class RulesStatusInfo(UIBuilderWidget):
 
     def restore_row_collapse(self):
         def toggle_collapse(store, path, treeiter):
-            self.__status_list.collapse_row(path) if store[treeiter][3] else self.__status_list.expand_row(path, False)
+            self.__status_list.collapse_row(path) if store[treeiter][
+                3
+            ] else self.__status_list.expand_row(path, False)
+
         if self.__model is not None:
             self.__model.foreach(toggle_collapse)
 
@@ -91,7 +94,14 @@ class RulesStatusInfo(UIBuilderWidget):
         for cat, messages in stats.items():
             count = len(messages)
             style = self.__status_text_style(count, cat)
-            parent = store.append(None, [f"{count} {_STATUS_HEADERS[cat]}", *style, self.get_row_collapsed(cat)])
+            parent = store.append(
+                None,
+                [
+                    f"{count} {_STATUS_HEADERS[cat]}",
+                    *style,
+                    self.get_row_collapsed(cat),
+                ],
+            )
             for m in messages:
                 store.append(parent, [m, *style, True])
 

--- a/fapolicy_analyzer/ui/time_select_dialog.py
+++ b/fapolicy_analyzer/ui/time_select_dialog.py
@@ -17,7 +17,6 @@ from fapolicy_analyzer.ui.ui_widget import UIBuilderWidget
 
 
 class TimeSelectDialog(UIBuilderWidget):
-
     def __init__(self, parent=None):
         super().__init__()
         if parent:


### PR DESCRIPTION
I turned on black formatting with the `--check` option in the CI process and added the module `flake8-black`. Linting will now report out black formatting changes too. I also formatted the python code with black and committed the changes. I get the same results from the tests before and after the changes, and a quick 👀 check looks good.

Side note you can run linting and formatting locally with `pipenv run lint` and `pipenv run format`. This part was always there.

closes #798 