### PR TITLE
Parse dir object keywords

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -307,7 +307,7 @@ dependencies = [
 
 [[package]]
 name = "fapolicy-rules"
-version = "0.4.5"
+version = "0.4.6"
 dependencies = [
  "assert_matches",
  "is_executable",

--- a/crates/rules/Cargo.toml
+++ b/crates/rules/Cargo.toml
@@ -2,7 +2,7 @@
 name = "fapolicy-rules"
 description = "Rule support for fapolicyd"
 license = "MPL-2.0"
-version = "0.4.5"
+version = "0.4.6"
 edition = "2018"
 
 [lib]

--- a/crates/rules/src/dir_type.rs
+++ b/crates/rules/src/dir_type.rs
@@ -1,0 +1,50 @@
+/*
+ * Copyright Concurrent Technologies Corporation 2023
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+use std::fmt::{Display, Formatter};
+
+#[derive(Clone, Debug, Eq, PartialEq, Hash)]
+pub enum DirType {
+    /// Match a directory using the full path to the directory. Its recommended to end with the /
+    /// to ensure it matches a directory.
+    Path(String),
+    /// The execdirs option will match against the following list of directories:
+    /// /usr/, /bin/, /sbin/, /lib/, /lib64/, /usr/libexec/
+    ExecDirs,
+    /// The systemdirs option will match against the same list as execdirs but also includes /etc/.
+    SystemDirs,
+    /// The  untrusted option will look up the current executable's full path in the rpm database to see
+    /// if the executable is known to the system. The rule will trigger if the file in question  is  not
+    /// in  the  trust database. This option is deprecated in favor of using obj_trust with execute per‐
+    /// mission when writing rules.
+    Untrusted,
+}
+
+impl Display for DirType {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            DirType::Path(v) => f.write_str(v),
+            DirType::ExecDirs => f.write_str("execdirs"),
+            DirType::SystemDirs => f.write_str("systemdirs"),
+            DirType::Untrusted => f.write_str("untrusted"),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn display() {
+        assert_eq!(format!("{}", DirType::Path("/foo/".to_string())), "/foo/");
+        assert_eq!(format!("{}", DirType::ExecDirs), "execdirs");
+        assert_eq!(format!("{}", DirType::SystemDirs), "systemdirs");
+        assert_eq!(format!("{}", DirType::Untrusted), "untrusted");
+    }
+}

--- a/crates/rules/src/lib.rs
+++ b/crates/rules/src/lib.rs
@@ -22,6 +22,7 @@ pub mod ops;
 pub mod parser;
 
 mod decision;
+mod dir_type;
 mod file_type;
 mod linter;
 mod object;

--- a/crates/rules/src/linter/findings.rs
+++ b/crates/rules/src/linter/findings.rs
@@ -7,6 +7,7 @@
  */
 
 use crate::db::{Entry, DB};
+use crate::dir_type::DirType;
 use crate::Rule;
 use is_executable::IsExecutable;
 use std::path::PathBuf;
@@ -86,8 +87,10 @@ pub fn l003_object_path_missing(_: usize, r: &Rule, _db: &DB) -> Option<String> 
         .filter_map(|p| match p {
             Part::Device(p) if is_missing(p) => Some(path_does_not_exist_message("device", p)),
             Part::Path(p) if is_missing(p) => Some(path_does_not_exist_message("file", p)),
-            Part::Dir(p) if is_missing(p) => Some(path_does_not_exist_message("dir", p)),
-            Part::Dir(p) if !is_dir(p) => Some(wrong_type_message("dir")),
+            Part::Dir(DirType::Path(p)) if is_missing(p) => {
+                Some(path_does_not_exist_message("dir", p))
+            }
+            Part::Dir(DirType::Path(p)) if !is_dir(p) => Some(wrong_type_message("dir")),
             Part::Device(p) | Part::Path(p) if !is_file(p) => Some(wrong_type_message("file")),
             _ => None,
         })
@@ -117,7 +120,7 @@ pub fn l005_object_dir_missing_trailing_slash(_: usize, r: &Rule, _db: &DB) -> O
         .parts
         .iter()
         .filter_map(|p| match p {
-            Part::Dir(p) if !p.ends_with('/') => Some(L005_MESSAGE.to_string()),
+            Part::Dir(DirType::Path(p)) if !p.ends_with('/') => Some(L005_MESSAGE.to_string()),
             _ => None,
         })
         .collect::<Vec<String>>()

--- a/crates/rules/src/object.rs
+++ b/crates/rules/src/object.rs
@@ -8,6 +8,7 @@
 
 use std::fmt::{Display, Formatter};
 
+use crate::dir_type::DirType;
 use crate::{bool_to_c, ObjPart, Rvalue};
 
 /// # Object
@@ -66,7 +67,7 @@ pub enum Part {
     ///    - `untrusted`
     ///
     /// ### See the `dir` option under Subject for an explanation of these keywords.
-    Dir(String),
+    Dir(DirType),
     /// This option matches against the mime type of the file being accessed. See `ftype` under Subject for more information on determining the mime type.
     FileType(Rvalue),
     /// This is the full path to the file that will be accessed. Globbing is not supported. You may also use the special keyword `untrusted` to match on the subject not being listed in the rpm database.
@@ -122,7 +123,10 @@ mod tests {
     #[test]
     fn display() {
         assert_eq!(format!("{}", Part::All), "all");
-        assert_eq!(format!("{}", Part::Dir("/foo".into())), "dir=/foo");
+        assert_eq!(
+            format!("{}", Part::Dir(DirType::Path("/foo".into()))),
+            "dir=/foo"
+        );
         assert_eq!(
             format!("{}", Part::Device("/dev/cdrom".into())),
             "device=/dev/cdrom"
@@ -145,7 +149,10 @@ mod tests {
         assert_eq!(
             format!(
                 "{}",
-                Object::new(vec![Part::Dir("/foo".into()), Part::Trust(true)])
+                Object::new(vec![
+                    Part::Dir(DirType::Path("/foo".into())),
+                    Part::Trust(true)
+                ])
             ),
             "dir=/foo trust=1"
         );

--- a/crates/rules/src/parser/errat.rs
+++ b/crates/rules/src/parser/errat.rs
@@ -75,6 +75,7 @@ impl<'a> From<RuleParseError<StrTrace<'a>>> for ErrorAt<StrTrace<'a>> {
                 return ErrorAt::<StrTrace<'a>>::new_with_len(e, t, v.current.len())
             }
             ExpectedFileType(t) => t,
+            ExpectedAbsoluteDirPath(t) => t,
 
             Nom(t, _) => t,
         };

--- a/crates/rules/src/parser/errat.rs
+++ b/crates/rules/src/parser/errat.rs
@@ -75,8 +75,6 @@ impl<'a> From<RuleParseError<StrTrace<'a>>> for ErrorAt<StrTrace<'a>> {
                 return ErrorAt::<StrTrace<'a>>::new_with_len(e, t, v.current.len())
             }
             ExpectedFileType(t) => t,
-            ExpectedAbsoluteDirPath(t) => t,
-
             Nom(t, _) => t,
         };
         ErrorAt::<StrTrace<'a>>::new(e, t)

--- a/crates/rules/src/parser/error.rs
+++ b/crates/rules/src/parser/error.rs
@@ -39,8 +39,6 @@ pub enum RuleParseError<I> {
     ExpectedBoolean(I, I),
     ExpectedFileType(I),
 
-    ExpectedAbsoluteDirPath(I),
-
     Nom(I, ErrorKind),
 }
 
@@ -78,7 +76,6 @@ impl Display for RuleParseError<Trace<&str>> {
             ExpectedPattern(_) => f.write_str("Expected pattern"),
             ExpectedBoolean(_, _) => f.write_str("Expected boolean (0, 1) value"),
             ExpectedFileType(_) => f.write_str("Expected mime file type"),
-            ExpectedAbsoluteDirPath(_) => f.write_str("Expected absolute dir path"),
             e @ Nom(_, _) => f.write_fmt(format_args!("{:?}", e)),
         }
     }

--- a/crates/rules/src/parser/error.rs
+++ b/crates/rules/src/parser/error.rs
@@ -39,6 +39,8 @@ pub enum RuleParseError<I> {
     ExpectedBoolean(I, I),
     ExpectedFileType(I),
 
+    ExpectedAbsoluteDirPath(I),
+
     Nom(I, ErrorKind),
 }
 
@@ -76,6 +78,7 @@ impl Display for RuleParseError<Trace<&str>> {
             ExpectedPattern(_) => f.write_str("Expected pattern"),
             ExpectedBoolean(_, _) => f.write_str("Expected boolean (0, 1) value"),
             ExpectedFileType(_) => f.write_str("Expected mime file type"),
+            ExpectedAbsoluteDirPath(_) => f.write_str("Expected absolute dir path"),
             e @ Nom(_, _) => f.write_fmt(format_args!("{:?}", e)),
         }
     }

--- a/crates/rules/src/parser/object.rs
+++ b/crates/rules/src/parser/object.rs
@@ -20,7 +20,9 @@ use crate::parser::error::RuleParseError::*;
 
 use crate::Object;
 
-use crate::parser::parse::{filepath, filetype, trust_flag, StrTrace, TraceError, TraceResult};
+use crate::parser::parse::{
+    dir_type, filepath, filetype, trust_flag, StrTrace, TraceError, TraceResult,
+};
 
 fn obj_part(i: StrTrace) -> TraceResult<ObjPart> {
     let (ii, x) = alt((tag("all"), terminated(alpha1, tag("="))))(i)
@@ -33,8 +35,8 @@ fn obj_part(i: StrTrace) -> TraceResult<ObjPart> {
             .map(|(ii, d)| (ii, ObjPart::Device(d.current.to_string())))
             .map_err(|_: nom::Err<TraceError>| nom::Err::Error(ExpectedFilePath(i))),
 
-        "dir" => filepath(ii)
-            .map(|(ii, d)| (ii, ObjPart::Dir(DirType::Path(d.current.to_string()))))
+        "dir" => dir_type(ii)
+            .map(|(ii, d)| (ii, ObjPart::Dir(d)))
             .map_err(|_: nom::Err<TraceError>| nom::Err::Error(ExpectedDirPath(i))),
 
         "ftype" => filetype(ii)
@@ -109,6 +111,18 @@ mod tests {
         assert_matches!(
             obj_part("foo=/tmp".into()).err(),
             Some(nom::Err::Error(UnknownObjectPart(_)))
+        );
+    }
+
+    #[test]
+    fn dir_types() {
+        assert_matches!(
+            obj_part("dir=/tmp".into()).ok().map(|f| f.1),
+            Some(ObjPart::Dir(DirType::Path(_)))
+        );
+        assert_matches!(
+            obj_part("dir=tmp".into()).err(),
+            Some(nom::Err::Error(ExpectedDirPath(_)))
         );
     }
 }

--- a/crates/rules/src/parser/object.rs
+++ b/crates/rules/src/parser/object.rs
@@ -11,7 +11,6 @@ use nom::bytes::complete::tag;
 
 use nom::character::complete::{alpha1, multispace0};
 
-use crate::dir_type::DirType;
 use nom::sequence::{delimited, terminated};
 
 use crate::object::Part as ObjPart;
@@ -76,6 +75,7 @@ pub(crate) fn parse(i: StrTrace) -> TraceResult<Object> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::dir_type::DirType;
     use assert_matches::assert_matches;
 
     #[test]

--- a/crates/rules/src/parser/object.rs
+++ b/crates/rules/src/parser/object.rs
@@ -11,6 +11,7 @@ use nom::bytes::complete::tag;
 
 use nom::character::complete::{alpha1, multispace0};
 
+use crate::dir_type::DirType;
 use nom::sequence::{delimited, terminated};
 
 use crate::object::Part as ObjPart;
@@ -33,7 +34,7 @@ fn obj_part(i: StrTrace) -> TraceResult<ObjPart> {
             .map_err(|_: nom::Err<TraceError>| nom::Err::Error(ExpectedFilePath(i))),
 
         "dir" => filepath(ii)
-            .map(|(ii, d)| (ii, ObjPart::Dir(d.current.to_string())))
+            .map(|(ii, d)| (ii, ObjPart::Dir(DirType::Path(d.current.to_string()))))
             .map_err(|_: nom::Err<TraceError>| nom::Err::Error(ExpectedDirPath(i))),
 
         "ftype" => filetype(ii)

--- a/crates/rules/src/parser/parse.rs
+++ b/crates/rules/src/parser/parse.rs
@@ -50,7 +50,7 @@ pub(crate) fn dir_type(i: StrTrace) -> TraceResult<DirType> {
         Ok((r, v)) if v.current == "systemdirs" => Ok((r, DirType::SystemDirs)),
         Ok((r, v)) if v.current == "untrusted" => Ok((r, DirType::Untrusted)),
         Ok((r, v)) if v.current.starts_with("/") => Ok((r, DirType::Path(v.current.to_string()))),
-        Ok((_, _)) => Err(nom::Err::Error(ExpectedAbsoluteDirPath(i))),
+        Ok((_, _)) => Err(nom::Err::Error(ExpectedDirPath(i))),
         Err(e) => Err(e),
     }
 }
@@ -131,12 +131,12 @@ mod tests {
 
         assert_matches!(
             dir_type("reldir/".into()),
-            Err(nom::Err::Error(ExpectedAbsoluteDirPath(_)))
+            Err(nom::Err::Error(ExpectedDirPath(_)))
         );
 
         assert_matches!(
             dir_type("./reldir/".into()),
-            Err(nom::Err::Error(ExpectedAbsoluteDirPath(_)))
+            Err(nom::Err::Error(ExpectedDirPath(_)))
         );
     }
 }

--- a/crates/rules/src/parser/parse.rs
+++ b/crates/rules/src/parser/parse.rs
@@ -22,6 +22,7 @@ use crate::parser::object;
 use crate::parser::subject;
 use crate::parser::trace::Trace;
 
+use crate::dir_type::DirType;
 use crate::{Object, Rvalue, Subject};
 use nom::IResult;
 
@@ -41,6 +42,17 @@ pub(crate) struct SubObj {
 // todo;; this should be absolute path
 pub(crate) fn filepath(i: StrTrace) -> TraceResult<StrTrace> {
     nom::bytes::complete::is_not(" \t\n")(i)
+}
+
+pub(crate) fn dir_type(i: StrTrace) -> TraceResult<DirType> {
+    match is_not(" \t\n")(i) {
+        Ok((r, v)) if v.current == "execdirs" => Ok((r, DirType::ExecDirs)),
+        Ok((r, v)) if v.current == "systemdirs" => Ok((r, DirType::SystemDirs)),
+        Ok((r, v)) if v.current == "untrusted" => Ok((r, DirType::Untrusted)),
+        Ok((r, v)) if v.current.starts_with("/") => Ok((r, DirType::Path(v.current.to_string()))),
+        Ok((_, _)) => Err(nom::Err::Error(ExpectedAbsoluteDirPath(i))),
+        Err(e) => Err(e),
+    }
 }
 
 // todo;; this should be mimetype
@@ -93,6 +105,8 @@ pub(crate) fn end_of_rule(i: StrTrace) -> nom::IResult<StrTrace, (), RuleParseEr
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::dir_type::DirType;
+    use assert_matches::assert_matches;
 
     #[test]
     fn parse_trust_flag() {
@@ -100,5 +114,29 @@ mod tests {
         assert!(!trust_flag("0".into()).ok().unwrap().1);
         assert_eq!(None, trust_flag("2".into()).ok());
         assert_eq!(None, trust_flag("foo".into()).ok());
+    }
+
+    #[test]
+    fn parse_dir_flag() {
+        assert_eq!(
+            dir_type("systemdirs".into()).unwrap().1,
+            DirType::SystemDirs
+        );
+        assert_eq!(dir_type("execdirs".into()).unwrap().1, DirType::ExecDirs);
+        assert_eq!(dir_type("untrusted".into()).unwrap().1, DirType::Untrusted);
+        assert_eq!(
+            dir_type("/mydir/".into()).unwrap().1,
+            DirType::Path("/mydir/".to_string())
+        );
+
+        assert_matches!(
+            dir_type("reldir/".into()),
+            Err(nom::Err::Error(ExpectedAbsoluteDirPath(_)))
+        );
+
+        assert_matches!(
+            dir_type("./reldir/".into()),
+            Err(nom::Err::Error(ExpectedAbsoluteDirPath(_)))
+        );
     }
 }

--- a/crates/rules/src/parser/parse.rs
+++ b/crates/rules/src/parser/parse.rs
@@ -49,7 +49,7 @@ pub(crate) fn dir_type(i: StrTrace) -> TraceResult<DirType> {
         Ok((r, v)) if v.current == "execdirs" => Ok((r, DirType::ExecDirs)),
         Ok((r, v)) if v.current == "systemdirs" => Ok((r, DirType::SystemDirs)),
         Ok((r, v)) if v.current == "untrusted" => Ok((r, DirType::Untrusted)),
-        Ok((r, v)) if v.current.starts_with("/") => Ok((r, DirType::Path(v.current.to_string()))),
+        Ok((r, v)) if v.current.starts_with('/') => Ok((r, DirType::Path(v.current.to_string()))),
         Ok((_, _)) => Err(nom::Err::Error(ExpectedDirPath(i))),
         Err(e) => Err(e),
     }

--- a/crates/rules/src/parser/rule.rs
+++ b/crates/rules/src/parser/rule.rs
@@ -45,6 +45,7 @@ pub fn parse_with_error_message(i: StrTrace) -> Result<Rule, String> {
 
 #[cfg(test)]
 mod tests {
+    use crate::dir_type::DirType;
     use crate::{Decision, ObjPart, Object, Permission, Rvalue, SubjPart, Subject};
 
     use super::*;
@@ -101,7 +102,10 @@ mod tests {
         assert_eq!(Decision::DenyAudit, r.dec);
         assert_eq!(Permission::Open, r.perm);
         assert_eq!(Subject::from(SubjPart::Exe("/usr/bin/ssh".into())), r.subj);
-        assert_eq!(Object::from(ObjPart::Dir("/opt".into())), r.obj);
+        assert_eq!(
+            Object::from(ObjPart::Dir(DirType::Path("/opt".into()))),
+            r.obj
+        );
         assert!(rem.is_empty());
 
         let (rem, r) = parse("deny_audit perm=any all : ftype=application/x-bad-elf".into())


### PR DESCRIPTION
In addition to the string path parsing that we currently support there are 3 keywords that need special handling:
- execdirs
- systemdirs
- untrusted

This implementes a type that wraps up these three and the string type to add support for the keywords.

Closes #588