### PR TITLE
Redeploy Divide by 0 bug fix

### DIFF
--- a/fapolicy_analyzer/ui/reducers/trust_reducer.py
+++ b/fapolicy_analyzer/ui/reducers/trust_reducer.py
@@ -75,7 +75,7 @@ def handle_received_trust_update(state: TrustState, action: Action) -> TrustStat
 
     return _create_state(
         state,
-        percent_complete=running_count / state.trust_count * 100,
+        percent_complete=running_count / state.trust_count * 100 if not state.trust_count == 0 else 100,
         trust=[*state.trust, *update],
         last_set_completed=update,
         error=None,

--- a/fapolicy_analyzer/ui/reducers/trust_reducer.py
+++ b/fapolicy_analyzer/ui/reducers/trust_reducer.py
@@ -75,7 +75,9 @@ def handle_received_trust_update(state: TrustState, action: Action) -> TrustStat
 
     return _create_state(
         state,
-        percent_complete=running_count / state.trust_count * 100 if not state.trust_count == 0 else 100,
+        percent_complete=running_count / state.trust_count * 100
+        if not state.trust_count == 0
+        else 100,
         trust=[*state.trust, *update],
         last_set_completed=update,
         error=None,

--- a/fapolicy_analyzer/ui/reducers/trust_reducer.py
+++ b/fapolicy_analyzer/ui/reducers/trust_reducer.py
@@ -76,7 +76,7 @@ def handle_received_trust_update(state: TrustState, action: Action) -> TrustStat
     return _create_state(
         state,
         percent_complete=running_count / state.trust_count * 100
-        if not state.trust_count == 0
+        if state.trust_count != 0
         else 100,
         trust=[*state.trust, *update],
         last_set_completed=update,


### PR DESCRIPTION
Fixes a divide by zero error after deploying changes that remove all entries from the trust database.

Closes #829