### PR TITLE
Fix spec version patching

### DIFF
--- a/.github/workflows/rpm.yml
+++ b/.github/workflows/rpm.yml
@@ -60,7 +60,7 @@ jobs:
           make -f .copr/Makefile vendor-app spec=fapolicy-analyzer.spec
 
       - name: Rename source0 with prerelease version
-        if: endsWith(github.ref, '/master') && github.event_name != 'pull_request_target'
+        if: endsWith(github.ref, '/master')
         run: |
           spec_version=$(grep "Version:" ${{ matrix.props.spec }} | tr -s ' ' | cut -d' ' -f2)
           commit_number=$(git rev-list HEAD --count)
@@ -68,7 +68,7 @@ jobs:
           mv fapolicy-analyzer-${spec_version}.tar.gz fapolicy-analyzer-${patched_version}.tar.gz
 
       - name: Rename source0 with pull request version
-        if: github.event_name == 'pull_request_target'
+        if: github.event_name == 'pull_request'
         run: |
           spec_version=$(grep "Version:" ${{ matrix.props.spec }} | tr -s ' ' | cut -d' ' -f2)
           pr_number=${{ github.event.pull_request.number }}
@@ -138,7 +138,7 @@ jobs:
           echo "The spec version $spec_version is correct based on git tag $tag"
 
       - name: Patch spec with prerelease version
-        if: endsWith(github.ref, '/master') && github.event_name != 'pull_request_target'
+        if: endsWith(github.ref, '/master')
         run: |
           spec_version=$(grep "Version:" ${{ matrix.props.spec }} | tr -s ' ' | cut -d' ' -f2)
           commit_number=$(git rev-list HEAD --count)
@@ -147,7 +147,7 @@ jobs:
           grep Version ${{ matrix.props.spec }}
 
       - name: Patch spec with pull request version
-        if: github.event_name == 'pull_request_target'
+        if: github.event_name == 'pull_request'
         run: |
           spec_version=$(grep "Version:" ${{ matrix.props.spec }} | tr -s ' ' | cut -d' ' -f2)
           pr_number=${{ github.event.pull_request.number }}

--- a/.github/workflows/rpm.yml
+++ b/.github/workflows/rpm.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Rename source0 with prerelease version
         if: endsWith(github.ref, '/master')
         run: |
-          spec_version=$(grep "Version:" ${{ matrix.props.spec }} | tr -s ' ' | cut -d' ' -f2)
+          spec_version=$(grep "Version:" fapolicy-analyzer.spec | tr -s ' ' | cut -d' ' -f2)
           commit_number=$(git rev-list HEAD --count)
           patched_version="$spec_version~dev${commit_number}"
           mv fapolicy-analyzer-${spec_version}.tar.gz fapolicy-analyzer-${patched_version}.tar.gz
@@ -70,7 +70,7 @@ jobs:
       - name: Rename source0 with pull request version
         if: github.event_name == 'pull_request'
         run: |
-          spec_version=$(grep "Version:" ${{ matrix.props.spec }} | tr -s ' ' | cut -d' ' -f2)
+          spec_version=$(grep "Version:" fapolicy-analyzer.spec | tr -s ' ' | cut -d' ' -f2)
           pr_number=${{ github.event.pull_request.number }}
           patched_version="0.0.${pr_number}"
           mv fapolicy-analyzer-${spec_version}.tar.gz fapolicy-analyzer-${patched_version}.tar.gz

--- a/.github/workflows/rpm.yml
+++ b/.github/workflows/rpm.yml
@@ -59,6 +59,22 @@ jobs:
         run: |
           make -f .copr/Makefile vendor-app spec=fapolicy-analyzer.spec
 
+      - name: Rename source0 with prerelease version
+        if: endsWith(github.ref, '/master') && github.event_name != 'pull_request_target'
+        run: |
+          spec_version=$(grep "Version:" ${{ matrix.props.spec }} | tr -s ' ' | cut -d' ' -f2)
+          commit_number=$(git rev-list HEAD --count)
+          patched_version="$spec_version~dev${commit_number}"
+          mv fapolicy-analyzer-${spec_version}.tar.gz fapolicy-analyzer-${patched_version}.tar.gz
+
+      - name: Rename source0 with pull request version
+        if: github.event_name == 'pull_request_target'
+        run: |
+          spec_version=$(grep "Version:" ${{ matrix.props.spec }} | tr -s ' ' | cut -d' ' -f2)
+          pr_number=${{ github.event.pull_request.number }}
+          patched_version="0.0.${pr_number}"
+          mv fapolicy-analyzer-${spec_version}.tar.gz fapolicy-analyzer-${patched_version}.tar.gz
+
       - name: Upload
         uses: actions/upload-artifact@v3
         with:

--- a/scripts/srpm/fapolicy-analyzer.el9.spec
+++ b/scripts/srpm/fapolicy-analyzer.el9.spec
@@ -25,6 +25,7 @@ Source19:      %{pypi_source flit_core 3.7.1}
 Source20:      %{pypi_source typing_extensions 3.7.4.3}
 
 BuildRequires: python3-devel
+BuildRequires: python3dist(pip)
 BuildRequires: python3dist(babel)
 BuildRequires: python3dist(packaging)
 BuildRequires: python3dist(pyparsing)


### PR DESCRIPTION
Some previously undetected regressions were brought to light after merging the implementation of #821 in #864.

The background here is that the version defined in the spec files can be patched in CI builds on master or a PR branch.  This is done to allow these builds to be versioned with qualifiers that identify them as special, as development builds.

The spec version patching had a couple issues that were introduced back when removing the pull-request-target support. This PR fixes those and some other other issues causing the work from #865 not to succeed on master.