### PR TITLE
Move rawhide to fc39

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,4 +1,4 @@
-ARG image=registry.fedoraproject.org/fedora:38
+ARG image=registry.fedoraproject.org/fedora:39
 FROM $image AS build-stage
 
 RUN dnf install -y rpm-build rpmdevtools dnf-plugins-core python3-pip nano

--- a/Makefile
+++ b/Makefile
@@ -135,8 +135,8 @@ check: header-check format lint test
 fc-rpm:
 	@echo -e "${GRN}--- Fedora RPM generation...${NC}"
 	make -f .copr/Makefile vendor OS_ID=fedora
-	podman build -t fapolicy-analyzer:38 -f Containerfile .
-	podman run --rm -it --network=none -v /tmp:/v fapolicy-analyzer:38 /v
+	podman build -t fapolicy-analyzer:39 -f Containerfile .
+	podman run --rm -it --network=none -v /tmp:/v fapolicy-analyzer:39 /v
 
 # Generate RHEL 8 rpms
 el8-rpm:

--- a/scripts/vagrant/fc38/Vagrantfile
+++ b/scripts/vagrant/fc38/Vagrantfile
@@ -26,8 +26,8 @@ if not plugins_to_install.empty?
 end
 
 Vagrant.configure("2") do |config|
-  config.vm.box = "alvistack/fedora-rawhide"
-  config.vm.box_version = "20230618.1.1"
+  config.vm.box = "alvistack/fedora-38"
+  config.vm.box_version = "20230625.0.0"
 
   config.ssh.forward_agent = true
   config.ssh.forward_x11 = true


### PR DESCRIPTION
Updates containers and ansible to properly consider fc39 as rawhide.

Adds fc38 as a separate vagrant configuration.