### PR TITLE
Apt update prior to install in GHA

### DIFF
--- a/.github/workflows/pdf.yml
+++ b/.github/workflows/pdf.yml
@@ -11,6 +11,7 @@ jobs:
     steps:
       - name: install deps
         run: |
+          sudo apt update
           sudo apt install git pandoc texlive-latex-recommended texlive-latex-extra
 
       - uses: actions/checkout@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,7 @@ jobs:
     steps:
     - name: Install git
       run: |
+        sudo apt update
         sudo apt install -y git
 
     - uses: actions/checkout@v3


### PR DESCRIPTION
There were a couple spots in the GHA workflows that were not performing an `apt update` prior to installing packages. Recent workflow failures brought these to light.