### PR TITLE
Pin pipenv to 2023.7.4

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install pipenv==2023.7.4
+          pip install pipenv==2023.7.4 || pip install pipenv
           pipenv install --dev --keep-outdated --python ${{ matrix.python-version }}
       - name: Build
         id: build
@@ -109,7 +109,7 @@ jobs:
         id: install_deps
         run: |
           python -m pip install --upgrade pip
-          pip install pipenv==2023.7.4
+          pip install pipenv==2023.7.4 || pip install pipenv
           pipenv install --dev --python ${{ matrix.python-version }}
           echo ::set-output name=virt_env::$(pipenv --venv)
       - name: Setup Bindings

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install pipenv
+          pip install pipenv==2023.7.4
           pipenv install --dev --keep-outdated --python ${{ matrix.python-version }}
       - name: Build
         id: build
@@ -109,7 +109,7 @@ jobs:
         id: install_deps
         run: |
           python -m pip install --upgrade pip
-          pip install pipenv
+          pip install pipenv==2023.7.4
           pipenv install --dev --python ${{ matrix.python-version }}
           echo ::set-output name=virt_env::$(pipenv --venv)
       - name: Setup Bindings


### PR DESCRIPTION
This avoids CI breakage due to removal of the deprecated `keep-outdated` cli flag.

This will be revisited, the issue will remain open.

See #891