### PR TITLE
Update Rust to 1.66.1

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@v1
         with:
-          toolchain: 1.62.1
+          toolchain: 1.66.1
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -49,6 +49,11 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
+
+      # disable lint on pyo3 due to
+      # https://github.com/rust-lang/rust-clippy/issues/8971
+      - run: sed -i '/pyo3/d' Cargo.toml
+
       - name: Install requirements
         run: |
           sudo apt-get update

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@v1
         with:
           components: rustfmt
-          toolchain: 1.62.1
+          toolchain: 1.66.1
       - run: rustup component add rustfmt
       # use a placeholder for bindgen bindings
       - run: echo "//placeholder" | tee crates/auparse/sys/src/bindings.rs
@@ -39,7 +39,7 @@ jobs:
           sudo apt-get install libdbus-1-dev libaudit-dev libauparse-dev
       - uses: dtolnay/rust-toolchain@v1
         with:
-          toolchain: 1.62.1
+          toolchain: 1.66.1
       - uses: actions-rs/cargo@v1
         with:
           command: check
@@ -56,7 +56,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@v1
         with:
           components: clippy
-          toolchain: 1.62.1
+          toolchain: 1.66.1
       - run: rustup component add clippy
       - uses: actions-rs/cargo@v1
         with:
@@ -74,7 +74,7 @@ jobs:
           sudo apt-get install libdbus-1-dev libaudit-dev libauparse-dev
       - uses: dtolnay/rust-toolchain@v1
         with:
-          toolchain: 1.62.1
+          toolchain: 1.66.1
       - uses: actions-rs/cargo@v1
         with:
           command: test

--- a/.github/workflows/tools.yml
+++ b/.github/workflows/tools.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Install toolchain
         uses: dtolnay/rust-toolchain@v1
         with:
-          toolchain: 1.62.1
+          toolchain: 1.66.1
 
       - uses: actions/checkout@v3
         with:

--- a/crates/analyzer/tests/test_analyzing.rs
+++ b/crates/analyzer/tests/test_analyzing.rs
@@ -124,10 +124,10 @@ fn simple_obj_ad_status() {
     let e1 = bash_denied("/foo/bar", uid, 1003);
     let e2 = bash_allowed("/foo/bin", uid, 1003);
 
-    let a1 = analyze_from_user(&*vec![e1], uid, &trust);
+    let a1 = analyze_from_user(&[e1], uid, &trust);
     assert_eq!(a1.object.access, "D");
 
-    let a2 = analyze_from_user(&*vec![e2], uid, &trust);
+    let a2 = analyze_from_user(&[e2], uid, &trust);
     assert_eq!(a2.object.access, "A");
 }
 
@@ -140,7 +140,7 @@ fn user_subj_apd_status() {
     let e2 = bash_allowed("/foo/bin", uid, 1003);
     let e3 = bash_allowed("/foo/baz", uid, 1003);
 
-    let a1 = analyze_from_user(&*vec![e1.clone()], uid, &trust);
+    let a1 = analyze_from_user(&[e1.clone()], uid, &trust);
 
     assert_eq!(a1.subject.access, "D");
 
@@ -163,10 +163,10 @@ fn user_obj_ad_status() {
     let e1 = bash_denied("/foo/bar", uid, 1003);
     let e2 = bash_allowed("/foo/bin", uid, 1003);
 
-    let a1 = analyze_from_user(&*vec![e1], uid, &trust);
+    let a1 = analyze_from_user(&[e1], uid, &trust);
     assert_eq!(a1.object.access, "D");
 
-    let a2 = analyze_from_user(&*vec![e2], uid, &trust);
+    let a2 = analyze_from_user(&[e2], uid, &trust);
     assert_eq!(a2.object.access, "A");
 }
 

--- a/crates/auparse/sys/src/event.rs
+++ b/crates/auparse/sys/src/event.rs
@@ -25,7 +25,7 @@ impl Event {
     }
 
     pub fn ts(&self) -> i64 {
-        unsafe { auparse_get_time(self.au.as_ptr()) as i64 }
+        unsafe { auparse_get_time(self.au.as_ptr()) }
     }
     pub fn int(&self, name: &str) -> Result<i32, Error> {
         unsafe { audit_get_int(self.au.as_ptr(), name) }

--- a/crates/auparse/sys/src/util.rs
+++ b/crates/auparse/sys/src/util.rs
@@ -20,7 +20,7 @@ pub unsafe fn audit_get_int(au: *mut auparse_state_t, field: &str) -> Result<i32
     if let Ok((rec, field)) = find_last_field(au, field) {
         auparse_goto_record_num(au, rec);
         auparse_goto_field_num(au, field);
-        let res = auparse_get_field_int(au) as i32;
+        let res = auparse_get_field_int(au);
         auparse_first_record(au);
         Ok(res)
     } else {

--- a/crates/pyo3/src/analysis.rs
+++ b/crates/pyo3/src/analysis.rs
@@ -61,8 +61,7 @@ impl PyEvent {
     /// The group id parsed from the log event
     #[getter]
     fn gid(&self) -> i32 {
-        // todo;; unhack this
-        *self.rs.event.gid.get(0).unwrap()
+        *self.rs.event.gid.first().unwrap_or(&-1)
     }
 
     /// The fapolicyd subject parsed from the log event

--- a/crates/rules/tests/write.rs
+++ b/crates/rules/tests/write.rs
@@ -138,7 +138,7 @@ fn test_dir_multi_file_multi_rule() -> Result<(), Box<dyn Error>> {
 }
 
 fn read_string(from: &Path) -> Result<String, io::Error> {
-    let mut reader = File::open(&from).map(BufReader::new)?;
+    let mut reader = File::open(from).map(BufReader::new)?;
     let mut actual = String::new();
     reader.read_to_string(&mut actual)?;
     Ok(actual)

--- a/crates/tools/src/trust_db_util.rs
+++ b/crates/tools/src/trust_db_util.rs
@@ -348,7 +348,7 @@ fn dump(opts: DumpDbOpts, cfg: &cfg::All) -> Result<(), Error> {
             }
         }
         Some(path) => {
-            let mut f = File::create(&path)?;
+            let mut f = File::create(path)?;
             for (_, v) in db.iter() {
                 f.write_all(format!("{}\n", v.trusted).as_bytes())?;
             }

--- a/crates/trust/src/ops.rs
+++ b/crates/trust/src/ops.rs
@@ -157,7 +157,7 @@ mod tests {
         let expected = make_default_trust();
 
         let mut xs = Changeset::new();
-        xs.ins(&*expected.path, expected.size, &*expected.hash);
+        xs.ins(&expected.path, expected.size, &expected.hash);
         assert_eq!(xs.len(), 1);
 
         let store = xs.apply(DB::default());
@@ -215,9 +215,9 @@ mod tests {
         let expected = make_default_trust();
 
         let mut xs = Changeset::new();
-        xs.ins(&*expected.path, 1000, "12345");
+        xs.ins(&expected.path, 1000, "12345");
         assert_eq!(xs.len(), 1);
-        xs.ins(&*expected.path, expected.size, &*expected.hash);
+        xs.ins(&expected.path, expected.size, &expected.hash);
 
         let store = xs.apply(DB::default());
         assert_eq!(store.len(), 1);

--- a/crates/trust/src/read.rs
+++ b/crates/trust/src/read.rs
@@ -21,7 +21,7 @@ use crate::source::{TrustSource, TrustSourceEntry};
 use crate::{parse, Trust};
 
 pub fn from_file(from: &Path) -> Result<Vec<TrustSourceEntry>, io::Error> {
-    let r = BufReader::new(File::open(&from)?);
+    let r = BufReader::new(File::open(from)?);
     let lines: Result<Vec<String>, io::Error> = r.lines().collect();
     Ok(lines?
         .iter()

--- a/crates/trust/src/write.rs
+++ b/crates/trust/src/write.rs
@@ -80,7 +80,7 @@ fn dir(db: &DB, dir: &Path) -> Result<(), io::Error> {
 
 fn file(db: &DB, to: &Path) -> Result<(), io::Error> {
     // write file trust db
-    let mut tf = File::create(&to)?;
+    let mut tf = File::create(to)?;
     for (_, rec) in db.iter() {
         match rec.source {
             None | Some(TrustSource::Ancillary) => {

--- a/crates/trust/tests/write.rs
+++ b/crates/trust/tests/write.rs
@@ -159,7 +159,7 @@ fn test_dir_and_file_overwrite_2() -> Result<(), Box<dyn Error>> {
 }
 
 fn read_string(from: &Path) -> Result<String, io::Error> {
-    let mut reader = File::open(&from).map(BufReader::new)?;
+    let mut reader = File::open(from).map(BufReader::new)?;
     let mut actual = String::new();
     reader.read_to_string(&mut actual)?;
     Ok(actual)


### PR DESCRIPTION
Update Rust and address clippy findings

Clippy failing on pyo3 generated functions with `borrow_deref_ref` https://github.com/rust-lang/rust-clippy/issues/8971. Disabling checking on pyo3 for now until better solution is available. 

Closes #884