### PR TITLE
Replace CI usage of rawhide image

### DIFF
--- a/.github/workflows/rpm.yml
+++ b/.github/workflows/rpm.yml
@@ -40,7 +40,7 @@ jobs:
 
   source0:
     name: Vendor Source0
-    container: registry.fedoraproject.org/fedora:rawhide
+    container: registry.fedoraproject.org/fedora:38
     runs-on: ubuntu-20.04
     steps:
       - name: Install deps


### PR DESCRIPTION
Replaces usage of fedora:rawhide image with a stable release to avoid issues around branch time.

Closes #898 