### PR TITLE
Config deployment

### DIFF
--- a/crates/app/src/app.rs
+++ b/crates/app/src/app.rs
@@ -11,6 +11,7 @@ use serde::Serialize;
 use std::path::PathBuf;
 
 use fapolicy_analyzer::users::{read_groups, read_users, Group, User};
+use fapolicy_daemon::conf::ops::Changeset as ConfigChanges;
 use fapolicy_daemon::conf::DB as ConfDB;
 use fapolicy_daemon::fapolicyd::Version;
 use fapolicy_rules::db::DB as RulesDB;
@@ -97,6 +98,20 @@ impl State {
             users: self.users.clone(),
             groups: self.groups.clone(),
             daemon_config: self.daemon_config.clone(),
+            daemon_version: self.daemon_version.clone(),
+        }
+    }
+
+    /// Apply a config changeset to this state, results in a new immutable state
+    pub fn apply_config_changes(&self, changes: ConfigChanges) -> Self {
+        let modified = changes.apply();
+        Self {
+            config: self.config.clone(),
+            trust_db: self.trust_db.clone(),
+            rules_db: self.rules_db.clone(),
+            users: self.users.clone(),
+            groups: self.groups.clone(),
+            daemon_config: modified.clone(),
             daemon_version: self.daemon_version.clone(),
         }
     }

--- a/crates/daemon/src/conf/config.rs
+++ b/crates/daemon/src/conf/config.rs
@@ -76,7 +76,7 @@ impl From<&DB> for Config {
         for line in value.iter() {
             match line {
                 Line::Valid(tok) => cfg.apply_ok(tok.clone()),
-                Line::Invalid(tok, txt) => cfg.apply_err(tok, txt),
+                Line::Invalid { k, v } => cfg.apply_err(k, v),
                 Line::Duplicate(tok) => cfg.apply_ok(tok.clone()),
                 _ => {}
             }
@@ -131,25 +131,25 @@ impl Config {
         }
     }
 
-    pub fn apply_err(&mut self, tok: &str, txt: &str) {
+    pub fn apply_err(&mut self, k: &str, v: &str) {
         use Entry::Invalid;
-        match tok {
-            "permissive" => self.permissive = Invalid(txt.to_string()),
-            "nice_val" => self.nice_val = Invalid(txt.to_string()),
-            "q_size" => self.q_size = Invalid(txt.to_string()),
-            "uid" => self.uid = Invalid(txt.to_string()),
-            "gid" => self.gid = Invalid(txt.to_string()),
-            "do_stat_report" => self.do_stat_report = Invalid(txt.to_string()),
-            "detailed_report" => self.detailed_report = Invalid(txt.to_string()),
-            "db_max_size" => self.db_max_size = Invalid(txt.to_string()),
-            "subj_cache_size" => self.subj_cache_size = Invalid(txt.to_string()),
-            "obj_cache_size" => self.obj_cache_size = Invalid(txt.to_string()),
-            "watch_fs" => self.watch_fs = Invalid(txt.to_string()),
-            "trust" => self.trust = Invalid(txt.to_string()),
-            "integrity" => self.integrity = Invalid(txt.to_string()),
-            "syslog_format" => self.syslog_format = Invalid(txt.to_string()),
-            "rpm_sha256_only" => self.rpm_sha256_only = Invalid(txt.to_string()),
-            "allow_filesystem_mark" => self.allow_filesystem_mark = Invalid(txt.to_string()),
+        match k {
+            "permissive" => self.permissive = Invalid(v.to_string()),
+            "nice_val" => self.nice_val = Invalid(v.to_string()),
+            "q_size" => self.q_size = Invalid(v.to_string()),
+            "uid" => self.uid = Invalid(v.to_string()),
+            "gid" => self.gid = Invalid(v.to_string()),
+            "do_stat_report" => self.do_stat_report = Invalid(v.to_string()),
+            "detailed_report" => self.detailed_report = Invalid(v.to_string()),
+            "db_max_size" => self.db_max_size = Invalid(v.to_string()),
+            "subj_cache_size" => self.subj_cache_size = Invalid(v.to_string()),
+            "obj_cache_size" => self.obj_cache_size = Invalid(v.to_string()),
+            "watch_fs" => self.watch_fs = Invalid(v.to_string()),
+            "trust" => self.trust = Invalid(v.to_string()),
+            "integrity" => self.integrity = Invalid(v.to_string()),
+            "syslog_format" => self.syslog_format = Invalid(v.to_string()),
+            "rpm_sha256_only" => self.rpm_sha256_only = Invalid(v.to_string()),
+            "allow_filesystem_mark" => self.allow_filesystem_mark = Invalid(v.to_string()),
             _unsupported => {}
         }
     }

--- a/crates/daemon/src/conf/db.rs
+++ b/crates/daemon/src/conf/db.rs
@@ -7,12 +7,13 @@
  */
 
 use crate::conf::config::ConfigToken;
+use std::fmt::{Display, Formatter};
 use std::slice::Iter;
 
 #[derive(Clone, Debug)]
 pub enum Line {
     Valid(ConfigToken),
-    Invalid(String, String),
+    Invalid { k: String, v: String },
     Malformed(String),
     Duplicate(ConfigToken),
     Comment(String),
@@ -37,5 +38,18 @@ impl DB {
 impl From<Vec<Line>> for DB {
     fn from(lines: Vec<Line>) -> Self {
         Self { lines }
+    }
+}
+
+impl Display for Line {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Line::Valid(tok) => f.write_fmt(format_args!("{tok}")),
+            Line::Invalid { k, v } => f.write_fmt(format_args!("{k}={v}")),
+            Line::Malformed(txt) => f.write_str(txt),
+            Line::Duplicate(tok) => f.write_fmt(format_args!("{tok}")),
+            Line::Comment(txt) => f.write_str(txt),
+            Line::BlankLine => f.write_str(""),
+        }
     }
 }

--- a/crates/daemon/src/conf/load.rs
+++ b/crates/daemon/src/conf/load.rs
@@ -9,20 +9,6 @@
 use crate::conf::db::DB;
 use crate::conf::error::Error;
 use crate::conf::read;
-use std::path::PathBuf;
-
-pub(crate) enum ConfFrom {
-    Disk(PathBuf),
-    Mem(String),
-}
-
-pub(crate) fn conf_from(src: ConfFrom) -> Result<DB, Error> {
-    let r = match src {
-        ConfFrom::Disk(path) => read::file(path)?,
-        ConfFrom::Mem(txt) => read::mem(&txt)?,
-    };
-    Ok(r)
-}
 
 pub fn file(path: &str) -> Result<DB, Error> {
     read::file(path.into())

--- a/crates/daemon/src/conf/load.rs
+++ b/crates/daemon/src/conf/load.rs
@@ -18,6 +18,10 @@ pub fn mem(txt: &str) -> Result<DB, Error> {
     read::mem(txt)
 }
 
+pub fn with_error_message(txt: &str) -> Result<DB, String> {
+    mem(txt).map_err(|e| e.to_string())
+}
+
 #[cfg(test)]
 mod test {
     use super::*;

--- a/crates/daemon/src/conf/load.rs
+++ b/crates/daemon/src/conf/load.rs
@@ -6,10 +6,55 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use crate::conf;
+use crate::conf::db::DB;
 use crate::conf::error::Error;
 use crate::conf::read;
+use std::path::PathBuf;
 
-pub fn file(path: &str) -> Result<conf::db::DB, Error> {
+pub(crate) enum ConfFrom {
+    Disk(PathBuf),
+    Mem(String),
+}
+
+pub(crate) fn conf_from(src: ConfFrom) -> Result<DB, Error> {
+    let r = match src {
+        ConfFrom::Disk(path) => read::file(path)?,
+        ConfFrom::Mem(txt) => read::mem(&txt)?,
+    };
+    Ok(r)
+}
+
+pub fn file(path: &str) -> Result<DB, Error> {
     read::file(path.into())
+}
+
+pub fn mem(txt: &str) -> Result<DB, Error> {
+    read::mem(txt)
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::conf::config::Entry;
+    use crate::Config;
+    use assert_matches::assert_matches;
+
+    #[test]
+    fn parse_good_txt_config() {
+        let db = &mem("permissive=0\nuid=fapolicyd").expect("parse");
+        let x: Config = db.into();
+        assert_matches!(x.permissive, Entry::Valid(false));
+        assert_matches!(x.uid, Entry::Valid(uid) if uid == "fapolicyd");
+        assert_matches!(x.gid, Entry::Missing);
+    }
+
+    #[test]
+    fn parse_bad_txt_config() -> Result<(), Box<dyn std::error::Error>> {
+        let db = &mem("permissive=true")?;
+        let x: Config = db.into();
+        assert_matches!(x.permissive, Entry::Invalid(p) if p == "true");
+        assert_matches!(x.gid, Entry::Missing);
+
+        Ok(())
+    }
 }

--- a/crates/daemon/src/conf/mod.rs
+++ b/crates/daemon/src/conf/mod.rs
@@ -11,9 +11,11 @@ mod db;
 pub mod error;
 pub mod key;
 mod load;
+pub mod ops;
 mod parse;
 mod read;
 pub mod write;
 
 pub use db::*;
 pub use load::file as from_file;
+pub use load::with_error_message;

--- a/crates/daemon/src/conf/mod.rs
+++ b/crates/daemon/src/conf/mod.rs
@@ -13,6 +13,7 @@ pub mod key;
 mod load;
 mod parse;
 mod read;
+pub mod write;
 
 pub use db::*;
 pub use load::file as from_file;

--- a/crates/daemon/src/conf/ops.rs
+++ b/crates/daemon/src/conf/ops.rs
@@ -1,3 +1,11 @@
+/*
+ * Copyright Concurrent Technologies Corporation 2023
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
 use crate::conf::error::Error;
 use crate::conf::{load, DB};
 

--- a/crates/daemon/src/conf/ops.rs
+++ b/crates/daemon/src/conf/ops.rs
@@ -1,0 +1,59 @@
+use crate::conf::error::Error;
+use crate::conf::{load, DB};
+
+// Mutable
+#[derive(Default, Clone, Debug)]
+pub struct Changeset {
+    db: DB,
+    src: Option<String>,
+}
+
+impl Changeset {
+    pub fn get(&self) -> &DB {
+        &self.db
+    }
+
+    pub fn src(&self) -> Option<&String> {
+        self.src.as_ref()
+    }
+
+    pub fn set(&mut self, text: &str) -> Result<&DB, Error> {
+        match load::mem(text) {
+            Ok(r) => {
+                self.db = r;
+                self.src = Some(text.to_string());
+                Ok(&self.db)
+            }
+            Err(e) => Err(e),
+        }
+    }
+
+    pub fn apply(&self) -> &DB {
+        &self.db
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::conf::config::Entry;
+    use crate::Config;
+    use assert_matches::assert_matches;
+    use std::error::Error;
+
+    #[test]
+    fn deserialize() -> Result<(), Box<dyn Error>> {
+        let mut cs = Changeset::default();
+        let txt = "permissive=0";
+        let _x1 = cs.set(txt)?;
+        let cfg: Config = _x1.into();
+        assert_matches!(cfg.permissive, Entry::Valid(false));
+
+        let txt = "permissive=1";
+        let _x2 = cs.set(txt)?;
+        let cfg: Config = _x2.into();
+        assert_matches!(cfg.permissive, Entry::Valid(true));
+
+        Ok(())
+    }
+}

--- a/crates/daemon/src/conf/read.rs
+++ b/crates/daemon/src/conf/read.rs
@@ -6,10 +6,9 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use crate::conf;
 use crate::conf::db::Line;
 use crate::conf::error::Error;
-use crate::conf::parse;
+use crate::conf::{parse, DB};
 use std::fs::File;
 use std::io::{BufRead, BufReader};
 use std::path::PathBuf;
@@ -22,11 +21,19 @@ fn lines_in_file(path: PathBuf) -> Result<Vec<String>, Error> {
     Ok(lines)
 }
 
-pub fn file(path: PathBuf) -> Result<conf::db::DB, Error> {
+pub fn file(path: PathBuf) -> Result<DB, Error> {
+    lines(lines_in_file(path)?)
+}
+
+pub fn mem(txt: &str) -> Result<DB, Error> {
+    lines(txt.split("\n").map(|s| s.to_string()).collect())
+}
+
+fn lines(src: Vec<String>) -> Result<DB, Error> {
     let mut lines = vec![];
     let mut skip_blank = true;
 
-    for s in lines_in_file(path)? {
+    for s in src {
         let s = s.trim();
         if s.is_empty() {
             if skip_blank {

--- a/crates/daemon/src/conf/read.rs
+++ b/crates/daemon/src/conf/read.rs
@@ -26,7 +26,7 @@ pub fn file(path: PathBuf) -> Result<DB, Error> {
 }
 
 pub fn mem(txt: &str) -> Result<DB, Error> {
-    lines(txt.split("\n").map(|s| s.to_string()).collect())
+    lines(txt.split('\n').map(|s| s.to_string()).collect())
 }
 
 fn lines(src: Vec<String>) -> Result<DB, Error> {

--- a/crates/daemon/src/conf/read.rs
+++ b/crates/daemon/src/conf/read.rs
@@ -47,11 +47,15 @@ fn lines(src: Vec<String>) -> Result<DB, Error> {
         } else {
             match parse::token(s) {
                 Ok(v) => lines.push(Line::Valid(v)),
-                Err((lhs, rhs, Error::InvalidLhs(_))) => {
-                    lines.push(Line::Invalid(lhs.to_string(), rhs.to_string()))
-                }
+                Err((lhs, rhs, Error::InvalidLhs(_))) => lines.push(Line::Invalid {
+                    k: lhs.to_string(),
+                    v: rhs.to_string(),
+                }),
                 Err((v, _, Error::MalformedConfig)) => lines.push(Line::Malformed(v.to_string())),
-                Err((lhs, rhs, _)) => lines.push(Line::Invalid(lhs.to_string(), rhs.to_string())),
+                Err((lhs, rhs, _)) => lines.push(Line::Invalid {
+                    k: lhs.to_string(),
+                    v: rhs.to_string(),
+                }),
             };
             skip_blank = false;
         }

--- a/crates/daemon/src/conf/write.rs
+++ b/crates/daemon/src/conf/write.rs
@@ -1,0 +1,21 @@
+/*
+ * Copyright Concurrent Technologies Corporation 2023
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+use crate::conf::DB;
+use std::fs::File;
+use std::io;
+use std::io::Write;
+use std::path::Path;
+
+pub fn db(db: &DB, to: &Path) -> Result<(), io::Error> {
+    let mut conf_file = File::create(to)?;
+    for line in db.iter() {
+        conf_file.write_all(format!("{}\n", line).as_bytes())?;
+    }
+    Ok(())
+}

--- a/crates/daemon/tests/load_config.rs
+++ b/crates/daemon/tests/load_config.rs
@@ -71,7 +71,10 @@ fn parse_empty_config() {
 fn parse_bad_config() {
     let db = &from_file("tests/data/bad-values.conf").expect("load");
     let x: Config = db.into();
-    assert_matches!(x.permissive, Entry::Invalid(str) if str == "true")
+    assert_matches!(x.permissive, Entry::Invalid(str) if str == "true");
+
+    // valid values will be parsed even with bad data present
+    assert_matches!(x.db_max_size, Entry::Valid(50));
 }
 
 fn splits(s: &str) -> Vec<String> {

--- a/crates/pyo3/src/daemon.rs
+++ b/crates/pyo3/src/daemon.rs
@@ -8,13 +8,11 @@
 
 use crate::system::PySystem;
 use fapolicy_daemon::conf;
-use fapolicy_daemon::conf::Line;
 use fapolicy_daemon::fapolicyd::Version;
 use fapolicy_daemon::svc::State::{Active, Inactive};
 use fapolicy_daemon::svc::{wait_for_service, Handle};
 use pyo3::exceptions::PyRuntimeError;
 use pyo3::prelude::*;
-use std::fmt::Display;
 
 #[pyclass(module = "svc", name = "Handle")]
 #[derive(Clone, Default)]
@@ -138,22 +136,11 @@ fn is_fapolicyd_active() -> PyResult<bool> {
 }
 
 pub(crate) fn conf_to_text(db: &conf::DB) -> String {
-    let empty = "".to_string();
-    db.iter().fold(String::new(), |x, y| {
-        let txt: &dyn Display = match y {
-            Line::Valid(tok) => tok,
-            Line::Invalid(_, txt) => txt,
-            Line::Malformed(txt) => txt,
-            Line::Duplicate(tok) => tok,
-            Line::Comment(txt) => txt,
-            Line::BlankLine => &empty,
-        };
-        if x.is_empty() {
-            format!("{}", txt)
-        } else {
-            format!("{}\n{}", x, txt)
-        }
-    })
+    db.iter()
+        .fold(String::new(), |acc, line| match acc.as_str() {
+            "" => format!("{line}"),
+            _ => format!("{acc}\n{line}"),
+        })
 }
 
 pub fn init_module(_py: Python, m: &PyModule) -> PyResult<()> {

--- a/crates/pyo3/src/system.rs
+++ b/crates/pyo3/src/system.rs
@@ -101,6 +101,12 @@ impl PySystem {
         self.rs.apply_rule_changes(change.into()).into()
     }
 
+    /// Apply the changeset to the state of this System, produces a new System
+    fn apply_config_changes(&self, change: daemon::PyChangeset) -> PySystem {
+        log::debug!("apply_rule_changes");
+        self.rs.apply_config_changes(change.into()).into()
+    }
+
     /// Update the host system with this state of this System and signal fapolicyd to reload trust
     pub fn deploy(&self) -> PyResult<()> {
         log::debug!("deploy");
@@ -167,6 +173,7 @@ impl PySystem {
     }
 
     fn config_text(&self) -> String {
+        log::debug!("config_text");
         daemon::conf_to_text(&self.rs.daemon_config)
     }
 


### PR DESCRIPTION
Integrate configuration backend with deployment machinery

The configuration backend now supports changesets and is wired into the system deployment bindings.  There are bindings for error checking conf text similar to how it is done for rule text.

Closes #907 