### PR TITLE
Add type to session format

### DIFF
--- a/fapolicy_analyzer/tests/test_changeset_wrapper.py
+++ b/fapolicy_analyzer/tests/test_changeset_wrapper.py
@@ -20,25 +20,28 @@ from fapolicy_analyzer.ui.changeset_wrapper import (
     Changeset,
     RuleChangeset,
     TrustChangeset,
+    changeset_dict_to_json,
 )
 
 
 def test_deserialize_RuleChangeset():
-    result = Changeset.deserialize("rules")
-    assert type(result) == RuleChangeset
-    assert result.serialize() == "rules"
+    expected = {"type": "rules", "data": "rules"}
+    actual = Changeset.load(expected)
+    assert type(actual) == RuleChangeset
+    assert actual.serialize() == expected
 
 
 @pytest.mark.parametrize("action", ["Add", "Del"])
 def test_deserialize_TrustChangeset(action):
-    result = Changeset.deserialize({"addition": action})
-    assert type(result) == TrustChangeset
-    assert result.serialize() == {"addition": action}
+    expected = {"type": "trust", "data": changeset_dict_to_json({"addition": action})}
+    actual = Changeset.load(expected)
+    assert type(actual) == TrustChangeset
+    assert actual.serialize() == expected
 
 
 def test_bad_deserialize():
     with pytest.raises(TypeError) as ex_info:
-        Changeset.deserialize(None)
+        Changeset.load(None)
     assert str(ex_info.value) == "Invalid changeset type to deserialize"
 
 
@@ -70,7 +73,7 @@ def test_RuleChangeset_rules(mocker):
 def test_RuleChangeset_serialize():
     sut = RuleChangeset()
     sut.parse("foo")
-    assert sut.serialize() == "foo"
+    assert sut.serialize() == {"type": "rules", "data": "foo"}
 
 
 def test_TrustChangeset_apply():
@@ -102,4 +105,7 @@ def test_TrustChangeset_serialize():
     sut = TrustChangeset()
     sut.add("addition")
     sut.delete("deletion")
-    assert sut.serialize() == {"addition": "Add", "deletion": "Del"}
+    assert sut.serialize() == {
+        "type": "trust",
+        "data": changeset_dict_to_json({"addition": "Add", "deletion": "Del"}),
+    }

--- a/fapolicy_analyzer/tests/test_changeset_wrapper.py
+++ b/fapolicy_analyzer/tests/test_changeset_wrapper.py
@@ -21,6 +21,7 @@ from fapolicy_analyzer.ui.changeset_wrapper import (
     RuleChangeset,
     TrustChangeset,
     changeset_dict_to_json,
+    ConfigChangeset,
 )
 
 
@@ -36,6 +37,13 @@ def test_deserialize_TrustChangeset(action):
     expected = {"type": "trust", "data": changeset_dict_to_json({"addition": action})}
     actual = Changeset.load(expected)
     assert type(actual) == TrustChangeset
+    assert actual.serialize() == expected
+
+
+def test_deserialize_ConfigChangeset():
+    expected = {"type": "config", "data": "config"}
+    actual = Changeset.load(expected)
+    assert type(actual) == ConfigChangeset
     assert actual.serialize() == expected
 
 
@@ -109,3 +117,25 @@ def test_TrustChangeset_serialize():
         "type": "trust",
         "data": changeset_dict_to_json({"addition": "Add", "deletion": "Del"}),
     }
+
+
+def test_ConfigChangeset_apply():
+    mock_system_apply = MagicMock()
+    sut = ConfigChangeset()
+    sut.apply_to_system(MagicMock(apply_config_changes=mock_system_apply))
+    mock_system_apply.assert_called_with(sut._ConfigChangeset__wrapped)
+
+
+def test_ConfigChangeset_parse(mocker):
+    mock = mocker.patch(
+        "fapolicy_analyzer.ui.changeset_wrapper.fapolicy_analyzer.ConfigChangeset"
+    )
+    sut = ConfigChangeset()
+    sut.parse("foo")
+    mock().parse.assert_called_with("foo")
+
+
+def test_ConfigChangeset_serialize():
+    sut = ConfigChangeset()
+    sut.parse("foo")
+    assert sut.serialize() == {"type": "config", "data": "foo"}

--- a/fapolicy_analyzer/tests/test_session_manager.py
+++ b/fapolicy_analyzer/tests/test_session_manager.py
@@ -26,16 +26,23 @@ from fapolicy_analyzer.ui.actions import (
     ADD_NOTIFICATION,
     APPLY_CHANGESETS,
 )
-from fapolicy_analyzer.ui.changeset_wrapper import RuleChangeset, TrustChangeset
+from fapolicy_analyzer.ui.changeset_wrapper import (
+    RuleChangeset,
+    TrustChangeset,
+    ConfigChangeset,
+)
 from fapolicy_analyzer.ui.session_manager import SessionManager
 
 import context  # noqa: F401
 
 test_changes = [
-    "foo rules",
     {
-        "/data_space/this/is/a/longer/path/now_is_the_time.txt": "Del",
-        "/data_space/Integration.json": "Add",
+        "type": "rules",
+        "data": "foo rules",
+    },
+    {
+        "type": "trust",
+        "data": """{"/data_space/Integration.json":"Add","/data_space/this/is/a/longer/path/now_is_the_time.txt":"Del"}""",
     },
 ]
 
@@ -76,10 +83,10 @@ def uut_autosave_enabled():
 @pytest.fixture
 def autosaved_files():
     with open("/tmp/FaCurrentSession.tmp_20210803_130622_059045.json", "w") as fp0:
-        fp0.write(f"""[{json.dumps(test_changes[0], sort_keys=True, indent=4)}]""")
+        fp0.write(f"""[{json.dumps(test_changes[0], sort_keys=True)}]""")
 
     with open("/tmp/FaCurrentSession.tmp_20210803_130622_065690.json", "w") as fp1:
-        fp1.write(json.dumps(test_changes, sort_keys=True, indent=4))
+        fp1.write(json.dumps(test_changes, sort_keys=True))
 
     # yields  a list of the autosaved files
     yield [
@@ -273,6 +280,7 @@ def test_restore_previous_session(uut_autosave_enabled, autosaved_files, mock_di
     expected = test_changes
     # parse changesets to json string to compare
     args, _ = mock_dispatch.call_args
+
     actual = [
         {path: action for path, action in c.serialize().items()}
         if isinstance(c, TrustChangeset)

--- a/fapolicy_analyzer/tests/test_session_manager.py
+++ b/fapolicy_analyzer/tests/test_session_manager.py
@@ -29,7 +29,6 @@ from fapolicy_analyzer.ui.actions import (
 from fapolicy_analyzer.ui.changeset_wrapper import (
     RuleChangeset,
     TrustChangeset,
-    ConfigChangeset,
 )
 from fapolicy_analyzer.ui.session_manager import SessionManager
 
@@ -42,7 +41,7 @@ test_changes = [
     },
     {
         "type": "trust",
-        "data": """{"/data_space/Integration.json":"Add","/data_space/this/is/a/longer/path/now_is_the_time.txt":"Del"}""",
+        "data": """{"/data_space/Integration.json":"Add","/data_space/this/is/a/longer/path/now_time.txt":"Del"}""",
     },
 ]
 
@@ -55,7 +54,7 @@ test_json = json.dumps(
 
 test_changesets = [RuleChangeset(), TrustChangeset()]
 test_changesets[0].parse("foo rules")
-test_changesets[1].delete("/data_space/this/is/a/longer/path/now_is_the_time.txt")
+test_changesets[1].delete("/data_space/this/is/a/longer/path/now_time.txt")
 test_changesets[1].add("/data_space/Integration.json")
 
 

--- a/fapolicy_analyzer/ui/changeset_wrapper.py
+++ b/fapolicy_analyzer/ui/changeset_wrapper.py
@@ -132,8 +132,6 @@ class TrustChangeset(Changeset[Dict[str, str]]):
     @staticmethod
     def deserialize(d) -> "TrustChangeset":
         tcs = TrustChangeset()
-        # s = '{"/data_space/this/is/a/longer/path/now_is_the_time.txt": "Del","/data_space/Integration.json": "Add",}'
-        # json.decoder.JSONDecodeError: Expecting property name enclosed in double quotes: line 1 column 103 (char 102)
         if isinstance(d, str):
             d = json.loads(d)
         for path, action in d.items():

--- a/fapolicy_analyzer/ui/changeset_wrapper.py
+++ b/fapolicy_analyzer/ui/changeset_wrapper.py
@@ -14,7 +14,7 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 import json
 from abc import ABC, abstractmethod
-from typing import Dict, Generic, TypeVar, Union
+from typing import Dict, Generic, TypeVar
 
 import fapolicy_analyzer
 from fapolicy_analyzer import System
@@ -71,7 +71,7 @@ class ConfigChangeset(Changeset[str]):
         }
 
     @staticmethod
-    def deserialize(d) -> T:
+    def deserialize(d) -> "ConfigChangeset":
         ccs = ConfigChangeset()
         ccs.parse(d)
         return ccs

--- a/fapolicy_analyzer/ui/changeset_wrapper.py
+++ b/fapolicy_analyzer/ui/changeset_wrapper.py
@@ -71,7 +71,7 @@ class ConfigChangeset(Changeset[str]):
     def apply_to_system(self, system: System) -> System:
         return system.apply_config_changes(self.__wrapped)
 
-    def serialize(self) -> dict[str, str]:
+    def serialize(self) -> Dict[str, str]:
         return {
             "type": "config",
             "data": self.__wrapped.text(),
@@ -97,7 +97,7 @@ class RuleChangeset(Changeset[str]):
     def apply_to_system(self, system: System) -> System:
         return system.apply_rule_changes(self.__wrapped)
 
-    def serialize(self) -> dict[str, str]:
+    def serialize(self) -> Dict[str, str]:
         return {"type": "rules", "data": self.__wrapped.text()}
 
     @staticmethod
@@ -117,7 +117,7 @@ class TrustChangeset(Changeset[Dict[str, str]]):
     def delete(self, change: str):
         self.__wrapped.del_trust(change)
 
-    def action_map(self) -> dict:
+    def action_map(self) -> Dict[str, str]:
         return self.__wrapped.get_path_action_map()
 
     def apply_to_system(self, system: System) -> System:

--- a/fapolicy_analyzer/ui/confirm_deployment_dialog.py
+++ b/fapolicy_analyzer/ui/confirm_deployment_dialog.py
@@ -12,7 +12,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
-
+import json
 from locale import gettext as _
 from typing import Sequence, Tuple
 
@@ -134,7 +134,7 @@ class ConfirmDeploymentDialog(UIBuilderWidget):
                 t
                 for e in changesets
                 if isinstance(e, TrustChangeset)
-                for t in e.serialize().items()
+                for t in json.loads(e.serialize()["data"]).items()
             ]
 
         rule_messages, rule_diff = rules_changes()

--- a/fapolicy_analyzer/ui/session_manager.py
+++ b/fapolicy_analyzer/ui/session_manager.py
@@ -139,7 +139,7 @@ class SessionManager:
                 return False
 
         logging.debug(f"Loaded dict = {data}")
-        changesets = [Changeset.deserialize(d) for d in data]
+        changesets = [Changeset.load(d) for d in data]
         logging.debug("SessionManager::open_edit_session():{}".format(changesets))
 
         if changesets:


### PR DESCRIPTION
Implements a new format for changesets to include a type discriminator which assists with deserialization.

Previously the deserialization was deriving the value type by the type of the serialized data, but this has issues when scaling to support additional types. 

Closes #917 