### PR TITLE
Fix required gtk version in config editor glade files

### DIFF
--- a/fapolicy_analyzer/glade/config_admin_page.glade
+++ b/fapolicy_analyzer/glade/config_admin_page.glade
@@ -17,7 +17,7 @@
   along with this program.  If not, see <https://www.gnu.org/licenses/>.
 -->
 <interface>
-  <requires lib="gtk+" version="3.24"/>
+  <requires lib="gtk+" version="3.22"/>
   <object class="GtkPaned" id="configAdminPage">
     <property name="visible">True</property>
     <property name="can_focus">True</property>

--- a/fapolicy_analyzer/glade/config_text_view.glade
+++ b/fapolicy_analyzer/glade/config_text_view.glade
@@ -17,7 +17,7 @@
   along with this program.  If not, see <https://www.gnu.org/licenses/>.
 -->
 <interface>
-  <requires lib="gtk+" version="3.24"/>
+  <requires lib="gtk+" version="3.22"/>
   <object class="GtkScrolledWindow" id="configTextView">
     <property name="visible">True</property>
     <property name="can_focus">True</property>


### PR DESCRIPTION
This fix pins the gtk version to 3.22 in the `fapolicyd` config editor glade files.

The config file editor was broken on RHEL8 at the 3.24 version of Gtk.

Closes #923 