### PR TITLE
Allow force save with syntax error

### DIFF
--- a/fapolicy_analyzer/glade/config_admin_page.glade
+++ b/fapolicy_analyzer/glade/config_admin_page.glade
@@ -70,4 +70,74 @@
       </packing>
     </child>
   </object>
+    <object class="GtkDialog" id="saveOverrideDialog">
+      <property name="can-focus">False</property>
+      <property name="icon-name">dialog-warning</property>
+      <property name="title" translatable="yes">Confirm Config Save</property>
+      <property name="type-hint">dialog</property>
+      <child internal-child="vbox">
+        <object class="GtkBox">
+          <property name="can-focus">False</property>
+          <property name="orientation">vertical</property>
+          <property name="spacing">2</property>
+          <child internal-child="action_area">
+            <object class="GtkButtonBox">
+              <property name="can-focus">False</property>
+              <property name="layout-style">center</property>
+              <child>
+                <object class="GtkButton" id="button1">
+                  <property name="label" translatable="yes">Proceed</property>
+                  <property name="visible">True</property>
+                  <property name="can-focus">True</property>
+                  <property name="receives-default">True</property>
+                </object>
+                <packing>
+                  <property name="expand">True</property>
+                  <property name="fill">True</property>
+                  <property name="position">0</property>
+                </packing>
+              </child>
+              <child>
+                <object class="GtkButton" id="button2">
+                  <property name="label" translatable="yes">Cancel</property>
+                  <property name="visible">True</property>
+                  <property name="can-focus">True</property>
+                  <property name="receives-default">True</property>
+                </object>
+                <packing>
+                  <property name="expand">True</property>
+                  <property name="fill">True</property>
+                  <property name="position">1</property>
+                </packing>
+              </child>
+            </object>
+            <packing>
+              <property name="expand">False</property>
+              <property name="fill">False</property>
+              <property name="position">0</property>
+            </packing>
+          </child>
+          <child>
+            <object class="GtkLabel" id="overrideText">
+              <property name="visible">True</property>
+              <property name="can-focus">False</property>
+              <property name="margin-bottom">20</property>
+              <property name="justify">center</property>
+            </object>
+            <packing>
+              <property name="expand">False</property>
+              <property name="fill">True</property>
+              <property name="position">1</property>
+            </packing>
+          </child>
+        </object>
+      </child>
+      <action-widgets>
+        <action-widget response="-5">button1</action-widget>
+        <action-widget response="-6">button2</action-widget>
+      </action-widgets>
+      <child type="titlebar">
+        <placeholder/>
+      </child>
+    </object>
 </interface>

--- a/fapolicy_analyzer/tests/config/test_config_admin_page.py
+++ b/fapolicy_analyzer/tests/config/test_config_admin_page.py
@@ -125,5 +125,7 @@ def test_save_click_valid(widget, mock_dispatch):
 
 def test_save_click_invalid(widget, mock_dispatch, mocker):
     widget._text_view.config_changed("permissive = foo")
+    overrideDialog = widget.get_object("saveOverrideDialog")
+    mocker.patch.object(overrideDialog, "run", return_value=Gtk.ResponseType.CANCEL)
     widget.on_save_clicked()
     mock_dispatch.assert_not_any_call(InstanceOf(Action) & Attrs(type=APPLY_CHANGESETS))

--- a/fapolicy_analyzer/ui/config/config_admin_page.py
+++ b/fapolicy_analyzer/ui/config/config_admin_page.py
@@ -13,6 +13,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+import gi
 import logging
 
 
@@ -31,6 +32,7 @@ from fapolicy_analyzer.ui.strings import (
     APPLY_CHANGESETS_ERROR_MESSAGE,
     CONFIG_CHANGESET_PARSE_ERROR,
     CONFIG_TEXT_LOAD_ERROR,
+    RULES_OVERRIDE_MESSAGE,
 )
 from fapolicy_analyzer.ui.ui_page import UIPage, UIAction
 from fapolicy_analyzer.ui.ui_widget import UIConnectedWidget
@@ -40,6 +42,9 @@ from fapolicy_analyzer.ui.store import (
     dispatch,
     get_system_feature,
 )
+
+gi.require_version("Gtk", "3.0")
+from gi.repository import Gtk  # isort: skip
 
 
 class ConfigAdminPage(UIConnectedWidget):
@@ -95,7 +100,15 @@ class ConfigAdminPage(UIConnectedWidget):
             dispatch(apply_changesets(changeset))
             self._unsaved_changes = False
         else:
-            self.__status_info.render_config_status(changeset.info())
+            overrideDialog = self.get_object("saveOverrideDialog")
+            self.get_object("overrideText").set_text(RULES_OVERRIDE_MESSAGE)
+            resp = overrideDialog.run()
+            if resp == Gtk.ResponseType.OK:
+                self.__saving = True
+                dispatch(apply_changesets(changeset))
+            else:
+                self.__status_info.render_config_status(changeset.info())
+            overrideDialog.hide()
 
     def __config_dirty(self) -> bool:
         return (

--- a/fapolicy_analyzer/ui/config/config_admin_page.py
+++ b/fapolicy_analyzer/ui/config/config_admin_page.py
@@ -106,6 +106,7 @@ class ConfigAdminPage(UIConnectedWidget):
             if resp == Gtk.ResponseType.OK:
                 self.__saving = True
                 dispatch(apply_changesets(changeset))
+                self._unsaved_changes = False
             else:
                 self.__status_info.render_config_status(changeset.info())
             overrideDialog.hide()
@@ -179,7 +180,7 @@ class ConfigAdminPage(UIConnectedWidget):
         self.__modified_config_text = config
         self.__config_validated = False
         # print(self._unsaved_changes, self._first_pass)
-        self._unsaved_changes = True  # if not self._first_pass else False
+        self._unsaved_changes = True if not self._first_pass else False
         if self._first_pass:
             self._first_pass = False
         dispatch(modify_config_text(config))

--- a/fapolicy_analyzer/ui/strings.py
+++ b/fapolicy_analyzer/ui/strings.py
@@ -241,7 +241,9 @@ regexp: "RSYSLOG_TraditionalFileFormat"
 replace: "RSYSLOG_FileFormat"
     """
 )
-RULES_OVERRIDE_MESSAGE = _("""There are syntax errors in the rule editor.""")
+RULES_OVERRIDE_MESSAGE = _(
+    """There are syntax errors in the text editor.\n\nProceed only if you are sure you know what you are doing."""
+)
 CONFIG_TEXT_LOAD_ERROR = _("Error loading Config text")
 CONFIG_CHANGESET_PARSE_ERROR = _(
     "Error parsing the config text. See log for more details."

--- a/locale/fapolicy-analyzer.pot
+++ b/locale/fapolicy-analyzer.pot
@@ -7,9 +7,9 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: fapolicy-analyzer 0.0.0+401.g679ca23.dirty\n"
+"Project-Id-Version: fapolicy-analyzer 1.1.0+20.g33c5321.dirty\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-10-09 11:20-0700\n"
+"POT-Creation-Date: 2023-10-19 08:06-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -548,14 +548,17 @@ msgid ""
 msgstr ""
 
 #: fapolicy_analyzer/ui/strings.py:244
-msgid "There are syntax errors in the rule editor."
+msgid ""
+"There are syntax errors in the text editor.\n"
+"\n"
+"Proceed only if you are sure you know what you are doing."
 msgstr ""
 
-#: fapolicy_analyzer/ui/strings.py:245
+#: fapolicy_analyzer/ui/strings.py:247
 msgid "Error loading Config text"
 msgstr ""
 
-#: fapolicy_analyzer/ui/strings.py:246
+#: fapolicy_analyzer/ui/strings.py:248
 msgid "Error parsing the config text. See log for more details."
 msgstr ""
 
@@ -591,6 +594,23 @@ msgstr ""
 msgid "Untrust"
 msgstr ""
 
+#: fapolicy_analyzer/glade/config_admin_page.glade:76
+msgid "Confirm Config Save"
+msgstr ""
+
+#: fapolicy_analyzer/glade/config_admin_page.glade:89
+#: fapolicy_analyzer/glade/rules_admin_page.glade:128
+msgid "Proceed"
+msgstr ""
+
+#: fapolicy_analyzer/glade/config_admin_page.glade:102
+#: fapolicy_analyzer/glade/confirm_change_dialog.glade:63
+#: fapolicy_analyzer/glade/rules_admin_page.glade:141
+#: fapolicy_analyzer/glade/time_select_dialog.glade:57
+#: fapolicy_analyzer/glade/trust_reconciliation_dialog.glade:67
+msgid "Cancel"
+msgstr ""
+
 #: fapolicy_analyzer/glade/config_difference_dialog.glade:23
 msgid "Config Differences"
 msgstr ""
@@ -613,13 +633,6 @@ msgstr ""
 
 #: fapolicy_analyzer/glade/confirm_change_dialog.glade:50
 msgid "No"
-msgstr ""
-
-#: fapolicy_analyzer/glade/confirm_change_dialog.glade:63
-#: fapolicy_analyzer/glade/rules_admin_page.glade:141
-#: fapolicy_analyzer/glade/time_select_dialog.glade:57
-#: fapolicy_analyzer/glade/trust_reconciliation_dialog.glade:67
-msgid "Cancel"
 msgstr ""
 
 #: fapolicy_analyzer/glade/confirm_deployment_dialog.glade:23
@@ -766,10 +779,6 @@ msgstr ""
 
 #: fapolicy_analyzer/glade/rules_admin_page.glade:115
 msgid "Confirm Rule Save"
-msgstr ""
-
-#: fapolicy_analyzer/glade/rules_admin_page.glade:128
-msgid "Proceed"
 msgstr ""
 
 #: fapolicy_analyzer/glade/rules_difference_dialog.glade:23


### PR DESCRIPTION
Allows config to be saved even if there is a syntax error.

The UI displays a message indicating there is a syntax error and to proceed only if sure, as is already done in the rule editor. This also updates the text used in the message to be generic enough to use across rules and config.

Closes #931