### PR TITLE
Fix editor state after deploy

### DIFF
--- a/fapolicy_analyzer/ui/config/config_admin_page.py
+++ b/fapolicy_analyzer/ui/config/config_admin_page.py
@@ -158,6 +158,7 @@ class ConfigAdminPage(UIConnectedWidget):
             self.__changesets = changesetState.changesets
             self.__config_text = ""
             self.__load_config()
+            self._unsaved_changes = False
 
         if not text_state.loading and self.__error_text != text_state.error:
             self.__error_text = text_state.error

--- a/fapolicy_analyzer/ui/rules/rules_admin_page.py
+++ b/fapolicy_analyzer/ui/rules/rules_admin_page.py
@@ -270,6 +270,7 @@ class RulesAdminPage(UIConnectedWidget, UIPage):
             self.__rules_text = ""
             self.__rules = []
             self.__load_rules()
+            self._unsaved_changes = False
 
         # Handle return from loading parsed rules object
         if not rules_state.loading and self.__error_rules != rules_state.error:


### PR DESCRIPTION
This fixes an issue where the text editors were erroneously notifying of existing changes after a deployment.

For reference see the changes in #727 and #921.  The text clearing in the former is clashing with the flagging in the latter.  This PR addressed it by flipping a flag right after the point where the text is cleared.

Closes #934 