### PR TITLE
Allow editors to specify syntax rules

### DIFF
--- a/fapolicy_analyzer/ui/config/config_text_view.py
+++ b/fapolicy_analyzer/ui/config/config_text_view.py
@@ -12,6 +12,8 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
+from typing import Optional
+
 from fapolicy_analyzer.ui.editable_text_view import EditableTextView
 
 
@@ -24,3 +26,6 @@ class ConfigTextView(EditableTextView):
 
     def on_config_changed(self, buffer):
         self.config_changed(self._get_text())
+
+    def _get_view_lang_id(self) -> Optional[str]:
+        return None

--- a/fapolicy_analyzer/ui/editable_text_view.py
+++ b/fapolicy_analyzer/ui/editable_text_view.py
@@ -16,6 +16,8 @@
 
 import logging
 import os
+from abc import abstractmethod
+from typing import Optional
 
 import gi
 
@@ -47,30 +49,36 @@ class EditableTextView(UIBuilderWidget, Events):
         # self.__buffer.connect("changed", self.on_rules_changed)
         self._text_view.set_buffer(self._buffer)
 
-    def _get_view_lang(self):
-        lang_manager = GtkSource.LanguageManager.get_default()
-        try:
-            with resources.path(
-                "fapolicy_analyzer.resources.sourceview.language-specs",
-                "fapolicyd-rules.lang",
-            ) as path:
-                if (
-                    os.path.dirname(path.as_posix())
-                    not in lang_manager.get_search_path()
-                ):
-                    lang_manager.set_search_path(
-                        [
-                            *lang_manager.get_search_path(),
-                            os.path.dirname(path.as_posix()),
-                        ]
-                    )
-        except Exception as ex:
-            logging.warning("Could not load the rules language file")
-            logging.debug(
-                "Error loading GtkSource language file fapolicyd-rules.lang", ex
-            )
+    @abstractmethod
+    def _get_view_lang_id(self) -> Optional[str]:
+        pass
 
-        return lang_manager.get_language("fapolicyd-rules")
+    def _get_view_lang(self):
+        lang_id = self._get_view_lang_id()
+        if lang_id:
+            lang_manager = GtkSource.LanguageManager.get_default()
+            try:
+                with resources.path(
+                    "fapolicy_analyzer.resources.sourceview.language-specs",
+                    lang_id,
+                ) as path:
+                    if (
+                        os.path.dirname(path.as_posix())
+                        not in lang_manager.get_search_path()
+                    ):
+                        lang_manager.set_search_path(
+                            [
+                                *lang_manager.get_search_path(),
+                                os.path.dirname(path.as_posix()),
+                            ]
+                        )
+            except Exception as ex:
+                logging.warning("Could not load the rules language file")
+                logging.debug(
+                    "Error loading GtkSource language file fapolicyd-rules.lang", ex
+                )
+
+            return lang_manager.get_language("fapolicyd-rules")
 
     def _get_view_style(self):
         style_manager = GtkSource.StyleSchemeManager.get_default()

--- a/fapolicy_analyzer/ui/rules/rules_text_view.py
+++ b/fapolicy_analyzer/ui/rules/rules_text_view.py
@@ -12,7 +12,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
-
+from typing import Optional
 
 from fapolicy_analyzer.ui.editable_text_view import EditableTextView
 
@@ -26,3 +26,6 @@ class RulesTextView(EditableTextView):
 
     def on_rules_changed(self, buffer):
         self.rules_changed(self._get_text())
+
+    def _get_view_lang_id(self) -> Optional[str]:
+        return "fapolicyd-rules.lang"


### PR DESCRIPTION
Allow text views to specify the syntax highlighting rules to apply.

Currently the rules view has their own rules and the config editor has no style applied.  This change fixes the case where the rule syntax was being applied to config because there was no way to specify per implementation the rules.

Closes #937 