### PR TITLE
Fix profiler page navigation

### DIFF
--- a/fapolicy_analyzer/ui/profiler_page.py
+++ b/fapolicy_analyzer/ui/profiler_page.py
@@ -81,6 +81,8 @@ class ProfilerPage(UIConnectedWidget, UIPage, Events):
         self.__events__ = [
             "analyze_button_pushed",
             "refresh_toolbar",
+            # fixes https://github.com/ctc-oss/fapolicy-analyzer/issues/940
+            "_unsaved_changes",
         ]
         Events.__init__(self)
         actions = {


### PR DESCRIPTION
Explicitly declare the `_unsaved_changes` event on the profiler page to satisfy events.py introspection

Closes #940 