### PR TITLE
All arch support

### DIFF
--- a/crates/auparse/sys/src/event.rs
+++ b/crates/auparse/sys/src/event.rs
@@ -25,7 +25,10 @@ impl Event {
     }
 
     pub fn ts(&self) -> i64 {
-        unsafe { auparse_get_time(self.au.as_ptr()) }
+        #[allow(clippy::useless_conversion)]
+        unsafe {
+            auparse_get_time(self.au.as_ptr()).into()
+        }
     }
     pub fn int(&self, name: &str) -> Result<i32, Error> {
         unsafe { audit_get_int(self.au.as_ptr(), name) }

--- a/fapolicy-analyzer.spec
+++ b/fapolicy-analyzer.spec
@@ -58,10 +58,6 @@ Requires:      gnome-icon-theme
 Requires:      webkit2gtk3
 Requires:      mesa-dri-drivers
 
-# rust-ring-devel does not support s390x and ppc64le:
-# https://bugzilla.redhat.com/show_bug.cgi?id=1869980
-ExcludeArch:   s390x %{power64}
-
 %global module          fapolicy_analyzer
 # pep440 versions handle dev and rc differently, so we call them out explicitly here
 %global module_version  %{lua: v = string.gsub(rpm.expand("%{?version}"), "~dev", ".dev"); \

--- a/scripts/srpm/fapolicy-analyzer.el9.spec
+++ b/scripts/srpm/fapolicy-analyzer.el9.spec
@@ -131,10 +131,6 @@ Requires:      gnome-icon-theme
 Requires:      webkit2gtk3
 Requires:      mesa-dri-drivers
 
-# rust-ring-devel does not support s390x and ppc64le:
-# https://bugzilla.redhat.com/show_bug.cgi?id=1869980
-ExcludeArch:   s390x %{power64}
-
 %global module          fapolicy_analyzer
 
 %global venv_dir        %{_builddir}/vendor-py


### PR DESCRIPTION
Fixes an issue building auparse bindings for i686 and removes all excluded arches from spec

An updated Rust ring crate made it possible to build on s390 and power64 arches.  That update was present in #905 but was not enabled in the spec until now.

Closes #947
Closes #948