### PR TITLE
Add Python 3.12 to CI

### DIFF
--- a/.github/rpm-matrix.json
+++ b/.github/rpm-matrix.json
@@ -5,7 +5,7 @@
       "dist": "fc40",
       "spec": "fapolicy-analyzer.spec",
       "image": "registry.fedoraproject.org/fedora:40",
-      "chroot": "fedora-40-x86_64",
+      "chroot": "fedora-rawhide-x86_64",
       "version": "40"
     },
     {

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -26,7 +26,6 @@ jobs:
           sudo apt-get install libgirepository1.0-dev
           sudo apt-get install xvfb
           sudo apt-get install libdbus-1-dev libaudit-dev libauparse-dev
-          sudo apt-get install python3-wheel
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
         with:

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -38,6 +38,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install pipenv==2023.7.4 || pip install pipenv
+          pip install wheel
           pipenv install --dev --keep-outdated --python ${{ matrix.python-version }}
       - name: Build
         id: build

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
     steps:
       - uses: actions/checkout@v3
       - name: Install requirements
@@ -84,7 +84,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
     steps:
       - uses: actions/checkout@v3
       - name: Install requirements

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -26,6 +26,7 @@ jobs:
           sudo apt-get install libgirepository1.0-dev
           sudo apt-get install xvfb
           sudo apt-get install libdbus-1-dev libaudit-dev libauparse-dev
+          sudo apt-get install python3-wheel
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
         with:
@@ -38,7 +39,6 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install pipenv==2023.7.4 || pip install pipenv
-          pip install wheel
           pipenv install --dev --keep-outdated --python ${{ matrix.python-version }}
       - name: Build
         id: build

--- a/.github/workflows/rpm.yml
+++ b/.github/workflows/rpm.yml
@@ -229,6 +229,7 @@ jobs:
   copr:
     needs: [ config, srpm ]
     name: Copr Build ${{ matrix.props.dist }}
+    if: needs.config.outputs.is-copr-enabled == 'true'
     container: 'rockylinux:8.6'
     runs-on: ubuntu-20.04
     strategy:

--- a/.github/workflows/rpm.yml
+++ b/.github/workflows/rpm.yml
@@ -229,7 +229,6 @@ jobs:
   copr:
     needs: [ config, srpm ]
     name: Copr Build ${{ matrix.props.dist }}
-    if: needs.config.outputs.is-copr-enabled == 'true'
     container: 'rockylinux:8.6'
     runs-on: ubuntu-20.04
     strategy:

--- a/Pipfile
+++ b/Pipfile
@@ -26,6 +26,7 @@ autoflake = "*"
 markdown2 = "*"
 beautifulsoup4 = "*"
 flake8-black = "*"
+wheel = "*"
 
 [packages]
 pycairo = "1.20.0"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "c33d1bd8e1ddb50951e9adac589d1d688e7c18ad332528529ae5ad5f1059bacc"
+            "sha256": "c8c9a0d6fd9e9cb935ab29b8bbee01bd757508e57a850aba65d6e7c2bcc616ec"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -507,6 +507,14 @@
             ],
             "markers": "python_version >= '3.7'",
             "version": "==3.0.0"
+        },
+        "wheel": {
+            "hashes": [
+                "sha256:177f9c9b0d45c47873b619f5b650346d632cdc35fb5e4d25058e09c9e581433d",
+                "sha256:c45be39f7882c9d34243236f2d63cbd58039e360f85d0913425fbd7ceea617a8"
+            ],
+            "index": "pypi",
+            "version": "==0.42.0"
         }
     }
 }


### PR DESCRIPTION
Adds 3.12 to the list of Python versions tested in CI

This also addresses a lingering issue from #955 in the Copr CI by syncing up the rawhide chroot name with mock.

Closes #950 