### PR TITLE
Update fapolicyd pipe commands

### DIFF
--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -9,6 +9,7 @@
 pub mod conf;
 pub mod error;
 pub mod fapolicyd;
+pub mod pipe;
 pub mod profiler;
 pub mod svc;
 pub mod version;

--- a/crates/daemon/src/pipe.rs
+++ b/crates/daemon/src/pipe.rs
@@ -43,7 +43,7 @@ impl Commands {
             .open(FIFO_PIPE)?;
 
         // the new line char is required here
-        fifo.write_all(&format!("{}\n", self as u8).as_bytes())?;
+        fifo.write_all(format!("{}\n", self as u8).as_bytes())?;
 
         Ok(())
     }

--- a/crates/daemon/src/pipe.rs
+++ b/crates/daemon/src/pipe.rs
@@ -1,0 +1,50 @@
+/*
+ * Copyright Concurrent Technologies Corporation 2023
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+use crate::error::Error;
+use crate::fapolicyd::FIFO_PIPE;
+use crate::pipe::Commands::{FlushCache, ReloadRules, ReloadTrust};
+use std::io::Write;
+
+#[repr(u8)]
+enum Commands {
+    ReloadTrust = 1,
+    FlushCache = 2,
+    ReloadRules = 3,
+}
+
+type CmdResult = Result<(), Error>;
+
+// 3
+pub fn reload_rules() -> CmdResult {
+    ReloadRules.send()
+}
+
+// 2
+pub fn flush_cache() -> CmdResult {
+    FlushCache.send()
+}
+
+// 1
+pub fn reload_trust() -> CmdResult {
+    ReloadTrust.send()
+}
+
+impl Commands {
+    fn send(self) -> CmdResult {
+        let mut fifo = std::fs::OpenOptions::new()
+            .write(true)
+            .read(false)
+            .open(FIFO_PIPE)?;
+
+        // the new line char is required here
+        fifo.write_all(&format!("{}\n", self as u8).as_bytes())?;
+
+        Ok(())
+    }
+}

--- a/crates/pyo3/src/trust.rs
+++ b/crates/pyo3/src/trust.rs
@@ -193,9 +193,15 @@ impl PyChangeset {
 /// send signal to fapolicyd FIFO pipe to reload the trust database
 #[pyfunction]
 fn signal_trust_reload() -> PyResult<()> {
-    pipe::reload_trust().map_err(|e| {
-        PyRuntimeError::new_err(format!("failed to write reload byte to pipe: {:?}", e))
-    })
+    pipe::reload_trust()
+        .map_err(|e| PyRuntimeError::new_err(format!("failed to signal trust reload: {:?}", e)))
+}
+
+/// send signal to fapolicyd FIFO pipe to reload rules
+#[pyfunction]
+fn signal_rule_reload() -> PyResult<()> {
+    pipe::reload_rules()
+        .map_err(|e| PyRuntimeError::new_err(format!("failed to signal rules reload: {:?}", e)))
 }
 
 pub fn init_module(_py: Python, m: &PyModule) -> PyResult<()> {
@@ -203,5 +209,6 @@ pub fn init_module(_py: Python, m: &PyModule) -> PyResult<()> {
     m.add_class::<PyTrust>()?;
     m.add_class::<PyActual>()?;
     m.add_function(wrap_pyfunction!(signal_trust_reload, m)?)?;
+    m.add_function(wrap_pyfunction!(signal_rule_reload, m)?)?;
     Ok(())
 }

--- a/crates/pyo3/src/trust.rs
+++ b/crates/pyo3/src/trust.rs
@@ -11,6 +11,7 @@ use std::collections::HashMap;
 use std::io::Write;
 
 use fapolicy_daemon::fapolicyd::FIFO_PIPE;
+use fapolicy_daemon::pipe;
 use pyo3::prelude::*;
 
 use fapolicy_trust::ops::{get_path_action_map, Changeset};
@@ -192,17 +193,9 @@ impl PyChangeset {
 /// send signal to fapolicyd FIFO pipe to reload the trust database
 #[pyfunction]
 fn signal_trust_reload() -> PyResult<()> {
-    let mut fifo = std::fs::OpenOptions::new()
-        .write(true)
-        .read(false)
-        .open(FIFO_PIPE)
-        .map_err(|e| PyRuntimeError::new_err(format!("failed to open fifo pipe: {}", e)))?;
-
-    fifo.write_all("1".as_bytes()).map_err(|e| {
+    pipe::reload_trust().map_err(|e| {
         PyRuntimeError::new_err(format!("failed to write reload byte to pipe: {:?}", e))
-    })?;
-
-    Ok(())
+    })
 }
 
 pub fn init_module(_py: Python, m: &PyModule) -> PyResult<()> {


### PR DESCRIPTION
Expands the fapolicyd fifo pipe signaling machinery to include cache flush and rule reload.

This also fixes a bug from #672 where the trust reload was not including a new line character.

This supports work that will take place for #877 to integrate the rule reload with the profiler execution.

Closes #964 