### PR TITLE
Update el8 to 1.2.2

### DIFF
--- a/.copr/Makefile
+++ b/.copr/Makefile
@@ -26,7 +26,7 @@ dnf: dnf-common
 dnf-common:
 	dnf install -y git which openssl-devel dbus-devel audit-libs-devel clang python3-devel python3-pip python3-toml python3-beautifulsoup4 python3-requests python3-babel itstool
 	dnf install -y python3-markdown2 || python3 -m pip install markdown2
-	dnf install -y rust-packaging
+	dnf install -y rust-toolset
 
 ifeq ($(OS_ID),rhel)
 # we only need to vendor rust and python on rhel

--- a/.copr/Makefile
+++ b/.copr/Makefile
@@ -21,28 +21,16 @@ clean:
 	rm -f fapolicy-analyzer-${VERSION}.tar.gz
 	rm -f vendor-rs-${VERSION}.tar.gz
 
-ifeq ($(OS_ID),rhel)
-dnf: dnf-common dnf-el
-else
-dnf: dnf-common dnf-fc
-endif
+dnf: dnf-common
 
 dnf-common:
 	dnf install -y git which openssl-devel dbus-devel audit-libs-devel clang python3-devel python3-pip python3-toml python3-beautifulsoup4 python3-requests python3-babel itstool
 	dnf install -y python3-markdown2 || python3 -m pip install markdown2
-
-dnf-fc:
 	dnf install -y rust-packaging
-
-dnf-el:
-	dnf install -y rpmdevtools
-	dnf install -y rust-toolset
-	# v0.5.9 requires rust 1.64
-	cargo install cargo-vendor-filterer@0.5.8
 
 ifeq ($(OS_ID),rhel)
 # we only need to vendor rust and python on rhel
-vendor: prep_rpmbuild_dir vendor-app vendor-doc vendor-rs vendor-py
+vendor: prep_rpmbuild_dir vendor-app vendor-doc vendor-py
 else
 vendor: prep_rpmbuild_dir vendor-app vendor-doc
 endif
@@ -54,7 +42,6 @@ vendor-py:
 	which spectool && spectool -g -C /tmp/rpmbuild/SOURCES/ \$(spec) || true
 
 vendor-rs:
-	cargo check
 	./scripts/srpm/vendor-rs.sh ${VERSION}
 	cp vendor-rs-${VERSION}.tar.gz /tmp/rpmbuild/SOURCES/vendor-rs-${VERSION}.tar.gz
 

--- a/.github/rpm-matrix.json
+++ b/.github/rpm-matrix.json
@@ -5,7 +5,7 @@
       "dist": "el8",
       "spec": "scripts/srpm/fapolicy-analyzer.el8.spec",
       "image": "rockylinux:8",
-      "chroot": "rocky+epel-9-x86_64",
+      "chroot": "rocky+epel-8-x86_64",
       "version": "8"
     }
   ]

--- a/.github/rpm-matrix.json
+++ b/.github/rpm-matrix.json
@@ -5,7 +5,7 @@
       "dist": "el8",
       "spec": "scripts/srpm/fapolicy-analyzer.el8.spec",
       "image": "rockylinux:8",
-      "chroot": "epel-8-x86_64",
+      "chroot": "rocky+epel-9-x86_64",
       "version": "8"
     }
   ]

--- a/.github/rpm-matrix.json
+++ b/.github/rpm-matrix.json
@@ -37,7 +37,7 @@
       "dist": "el9",
       "spec": "scripts/srpm/fapolicy-analyzer.el9.spec",
       "image": "rockylinux:9",
-      "chroot": "epel-9-x86_64",
+      "chroot": "rocky+epel-9-x86_64",
       "version": "9"
     }
   ]

--- a/.github/rpm-matrix.json
+++ b/.github/rpm-matrix.json
@@ -1,44 +1,12 @@
 {
   "props": [
     {
-      "platform": "fedora",
-      "dist": "fc40",
-      "spec": "fapolicy-analyzer.spec",
-      "image": "registry.fedoraproject.org/fedora:40",
-      "chroot": "fedora-40-x86_64",
-      "version": "40"
-    },
-    {
-      "platform": "fedora",
-      "dist": "fc39",
-      "spec": "fapolicy-analyzer.spec",
-      "image": "registry.fedoraproject.org/fedora:39",
-      "chroot": "fedora-39-x86_64",
-      "version": "39"
-    },
-    {
-      "platform": "fedora",
-      "dist": "fc38",
-      "spec": "fapolicy-analyzer.spec",
-      "image": "registry.fedoraproject.org/fedora:38",
-      "chroot": "fedora-38-x86_64",
-      "version": "38"
-    },
-    {
       "platform": "rhel",
       "dist": "el8",
       "spec": "scripts/srpm/fapolicy-analyzer.el8.spec",
       "image": "rockylinux:8",
       "chroot": "epel-8-x86_64",
       "version": "8"
-    },
-    {
-      "platform": "rhel",
-      "dist": "el9",
-      "spec": "scripts/srpm/fapolicy-analyzer.el9.spec",
-      "image": "rockylinux:9",
-      "chroot": "rocky+epel-9-x86_64",
-      "version": "9"
     }
   ]
 }

--- a/.github/workflows/rpm.yml
+++ b/.github/workflows/rpm.yml
@@ -113,7 +113,7 @@ jobs:
           # disable dev-tools crate
           sed -i '/tools/d' Cargo.toml
           # generate build deps with cargo2rpm
-          cargo2rpm -p Cargo.toml buildrequires | while read line; do
+          cargo2rpm -p Cargo.toml buildrequires -t | while read line; do
             grep -n "BuildRequires:" fapolicy-analyzer.spec | head -n1 | cut -d: -f1 | xargs -I{} sed -i "{}iBuildRequires: $line" fapolicy-analyzer.spec
           done
 

--- a/.github/workflows/rpm.yml
+++ b/.github/workflows/rpm.yml
@@ -96,7 +96,7 @@ jobs:
 
   crates0:
     name: Vendor Crates0
-    container: registry.fedoraproject.org/fedora:rawhide
+    container: registry.fedoraproject.org/fedora:37
     runs-on: ubuntu-20.04
     steps:
       - name: Install RPM build dependencies

--- a/.github/workflows/rpm.yml
+++ b/.github/workflows/rpm.yml
@@ -10,6 +10,7 @@ on:
     branches:
       - 'master'
       - 'release/*'
+      - 'el8'
 
 name: RPM
 

--- a/.github/workflows/rpm.yml
+++ b/.github/workflows/rpm.yml
@@ -265,12 +265,12 @@ jobs:
 
       - name: build
         run: |
-          copr-cli build --chroot ${{ matrix.props.chroot }} fapolicy-analyzer /tmp/fapolicy-analyzer-*.${{ matrix.props.dist }}.src.rpm
+          chroot=$(echo ${{ matrix.props.chroot }} | cut -d+ -f2)
+          copr-cli build --chroot $chroot fapolicy-analyzer /tmp/fapolicy-analyzer-*.${{ matrix.props.dist }}.src.rpm
 
   rpm:
     needs: [ config, srpm ]
     name: Rebuild ${{ matrix.props.dist }}
-    container: ${{ matrix.props.image }}
     runs-on: ubuntu-20.04
     strategy:
       matrix: ${{ fromJson(needs.config.outputs.matrix )}}
@@ -289,25 +289,36 @@ jobs:
         run: |
           sha256sum /tmp/src/*
 
-      - name: Enable EPEL
-        if: startsWith(matrix.props.dist, 'el')
+      - name: Prepare build container
         run: |
-          dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-${{ matrix.props.version }}.noarch.rpm
+          sudo apt install -y podman
+          cid="${{ matrix.props.dist }}-${{ github.run_id }}"
+          podman run -dt --name $cid --privileged fedora:39
+          podman exec $cid dnf install -y mock
+          podman exec $cid mock -r ${{ matrix.props.chroot }} --init
 
-      - name: Install RPM build dependencies
+      - name: Build with Mock
         run: |
-          dnf install -y make rpm rpmdevtools dnf-plugins-core
+          cid="${{ matrix.props.dist }}-${{ github.run_id }}"
+          srpm=$(find . -name *.${{ matrix.props.dist }}.src.rpm)
+          podman cp $srpm $cid:/tmp/$srpm
+          podman exec $cid mock -r ${{ matrix.props.chroot }} rebuild /tmp/$srpm --resultdir /tmp/rpmbuild
+        working-directory: /tmp/src/
 
-      - name: Rebuild SRPM
+      - name: Show logs
+        if: always()
         run: |
-          dnf builddep -y ${{ matrix.props.spec }}
-          rpmbuild --rebuild /tmp/src/fapolicy-analyzer-*.${{ matrix.props.dist }}.src.rpm
+          cid="${{ matrix.props.dist }}-${{ github.run_id }}"
+          podman exec $cid ls -R /tmp/rpmbuild
+          podman exec $cid cat /tmp/rpmbuild/build.log
 
       - name: Export RPMs
         run: |
+          cid="${{ matrix.props.dist }}-${{ github.run_id }}"
+          podman cp $cid:/tmp/rpmbuild/ /tmp/rpmbuild
           mkdir -p /tmp/archives
-          ls | grep -v debug | xargs mv -t /tmp/archives
-        working-directory: /github/home/rpmbuild/RPMS/x86_64
+          cd /tmp/rpmbuild
+          ls | grep -v -e debug -e log | xargs mv -t /tmp/archives
 
       - name: Upload RPMs
         uses: actions/upload-artifact@v3

--- a/.github/workflows/rpm.yml
+++ b/.github/workflows/rpm.yml
@@ -37,7 +37,6 @@ jobs:
         env:
           COPR_KEY: ${{ secrets.COPR_API_LOGIN }}
 
-
   source0:
     name: Vendor Source0
     container: registry.fedoraproject.org/fedora:38
@@ -94,8 +93,51 @@ jobs:
         run: |
           sha256sum fapolicy-analyzer-*.tar.gz
 
+  crates0:
+    name: Vendor Crates0
+    container: registry.fedoraproject.org/fedora:rawhide
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Install RPM build dependencies
+        run: |
+          dnf install -y git dnf-plugins-core cargo2rpm
+
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.ref }}
+          fetch-depth: 0
+
+      - name: Adjust spec
+        run: |
+          # disable dev-tools crate
+          sed -i '/tools/d' Cargo.toml
+          # generate build deps with cargo2rpm
+          cargo2rpm -p Cargo.toml buildrequires | while read line; do
+            grep -n "BuildRequires:" fapolicy-analyzer.spec | head -n1 | cut -d: -f1 | xargs -I{} sed -i "{}iBuildRequires: $line" fapolicy-analyzer.spec
+          done
+
+      - name: Install build dependencies
+        run: |
+          dnf -y builddep fapolicy-analyzer.spec
+
+      - name: Tar crates
+        run: |
+          ls -l /usr/share/cargo/registry
+          scripts/srpm/vendor-rs.sh
+
+      - name: Upload tarball
+        uses: actions/upload-artifact@v3
+        with:
+          name: crates0
+          path: |
+            vendor-rs.tar.gz
+
+      - name: Checksum
+        run: |
+          sha256sum vendor-rs.tar.gz
+
   srpm:
-    needs: [ config, source0 ]
+    needs: [ config, source0, crates0 ]
     name: SRPM Build ${{ matrix.props.dist }}
     container: ${{ matrix.props.image }}
     runs-on: ubuntu-20.04
@@ -177,9 +219,19 @@ jobs:
           name: source0
           path: /tmp/rpmbuild/SOURCES/
 
-      - name: Mark as git safe
+      - name: Fetch Crates0 tarball
+        if: startsWith(matrix.props.dist, 'el')
+        uses: actions/download-artifact@v3
+        with:
+          name: crates0
+          path: /tmp/rpmbuild/SOURCES/
+
+      - name: Tag Crates0 tarball
+        if: startsWith(matrix.props.dist, 'el')
         run: |
-          git config --global --add safe.directory $GITHUB_WORKSPACE
+          spec_version=$(grep "Version:" ${{ matrix.props.spec }} | tr -s ' ' | cut -d' ' -f2)
+          cd /tmp/rpmbuild/SOURCES/
+          mv vendor-rs.tar.gz vendor-rs-${spec_version}.tar.gz
 
       - name: Generate doc tag
         if: startsWith(github.ref, 'refs/tags/v')
@@ -199,16 +251,14 @@ jobs:
         run: |
           mkdir -p /tmp/archives
           mv vendor-docs-*.tar.gz /tmp/archives
-        env:
-          PLATFORM: ${{ matrix.props.dist }}
 
       - name: Export el tarballs
         if: startsWith(matrix.props.dist, 'el')
         run: |
           version=$(grep "Version:" ${{ matrix.props.spec }} | tr -s ' ' | cut -d' ' -f2)
-          mv vendor-rs-${version}.tar.gz /tmp/archives/
+          mv /tmp/rpmbuild/SOURCES/vendor-rs-${version}.tar.gz /tmp/archives/
 
-      - name: Upload SourceX
+      - name: Upload Tarballs
         uses: actions/upload-artifact@v3
         with:
           name: tarball-artifacts
@@ -285,15 +335,26 @@ jobs:
           name: srpm-artifacts
           path: /tmp/src/
 
+      - name: Download tarball artifacts
+        if: startsWith(matrix.props.dist, 'el')
+        uses: actions/download-artifact@v3
+        with:
+          name: tarball-artifacts
+          path: /tmp/src/
+
       - name: Checksum artifacts
         run: |
           sha256sum /tmp/src/*
 
-      - name: Prepare build container
+      - name: Create container
         run: |
           sudo apt install -y podman
           cid="${{ matrix.props.dist }}-${{ github.run_id }}"
           podman run -dt --name $cid --privileged fedora:39
+
+      - name: Init container
+        run: |
+          cid="${{ matrix.props.dist }}-${{ github.run_id }}"
           podman exec $cid dnf install -y mock
           podman exec $cid mock -r ${{ matrix.props.chroot }} --init
 

--- a/crates/analyzer/tests/test_escaped_logs.rs
+++ b/crates/analyzer/tests/test_escaped_logs.rs
@@ -1,0 +1,72 @@
+/*
+ * Copyright Concurrent Technologies Corporation 2023
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+use fapolicy_analyzer::events::parse::parse_event;
+use std::error::Error;
+
+// todo;; test space char
+const ESCAPE_CHARS: &str = "\"'`$\\!()|";
+
+#[test]
+fn test_object_escape() -> Result<(), Box<dyn Error>> {
+    // not escaped
+    for c in ESCAPE_CHARS.chars() {
+        let c = c.to_string();
+        let log = format!("rule=1 dec=deny perm=open uid=1 gid=0 pid=7 exe=xyz : path=/foo{c}bar ftype=application/x-executable");
+        let (_, e) = parse_event(&log).unwrap();
+        assert_eq!(e.obj.path().unwrap(), format!("/foo{c}bar"));
+    }
+    // escaped
+    for c in ESCAPE_CHARS.chars() {
+        let log = format!("rule=1 dec=deny perm=open uid=1 gid=0 pid=7 exe=xyz : path=/foo\\{c}bar ftype=application/x-executable");
+        let (_, e) = parse_event(&log).unwrap();
+        assert_eq!(e.obj.path().unwrap(), format!("/foo\\{c}bar"));
+    }
+    Ok(())
+}
+
+#[test]
+fn test_subj_exe_escape() -> Result<(), Box<dyn Error>> {
+    // not escaped
+    for c in ESCAPE_CHARS.chars() {
+        let c = c.to_string();
+        let log = format!("rule=1 dec=deny perm=open uid=1 gid=0 pid=7 exe=foo{c}bar : path=/usr/bin/vi ftype=application/x-executable");
+        let (_, e) = parse_event(&log).unwrap();
+        assert_eq!(e.subj.exe().unwrap(), format!("foo{c}bar"));
+    }
+    // escaped
+    for c in ESCAPE_CHARS.chars() {
+        let log = format!("rule=1 dec=deny perm=open uid=1 gid=0 pid=7 exe=foo\\{c}bar : path=/usr/bin/vi ftype=application/x-executable");
+        let (_, e) = parse_event(&log).unwrap();
+        assert_eq!(e.subj.exe().unwrap(), format!("foo\\{c}bar"));
+    }
+    Ok(())
+}
+
+#[test]
+fn test_subj_command_escape() -> Result<(), Box<dyn Error>> {
+    // not escaped
+    for c in ESCAPE_CHARS.chars() {
+        let c = c.to_string();
+        let log = format!("rule=1 dec=deny perm=open uid=1 gid=0 pid=7 comm=foo{c}bar : path=/usr/bin/vi ftype=application/x-executable");
+        let (_, e) = parse_event(&log).unwrap();
+        assert_eq!(e.subj.comm().unwrap(), format!("foo{c}bar"));
+    }
+    // escaped
+    for c in ESCAPE_CHARS.chars() {
+        let log = format!("rule=1 dec=deny perm=open uid=1 gid=0 pid=7 comm=foo\\{c}bar : path=/usr/bin/vi ftype=application/x-executable");
+        let (_, e) = parse_event(&log).unwrap();
+        assert_eq!(e.subj.comm().unwrap(), format!("foo\\{c}bar"));
+    }
+    Ok(())
+}
+
+#[test]
+fn num_of_escapes() {
+    assert_eq!(ESCAPE_CHARS.len(), 9)
+}

--- a/crates/auparse/sys/src/event.rs
+++ b/crates/auparse/sys/src/event.rs
@@ -25,7 +25,10 @@ impl Event {
     }
 
     pub fn ts(&self) -> i64 {
-        unsafe { auparse_get_time(self.au.as_ptr()) }
+        #[allow(clippy::useless_conversion)]
+        unsafe {
+            auparse_get_time(self.au.as_ptr()).into()
+        }
     }
     pub fn int(&self, name: &str) -> Result<i32, Error> {
         unsafe { audit_get_int(self.au.as_ptr(), name) }

--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -9,6 +9,7 @@
 pub mod conf;
 pub mod error;
 pub mod fapolicyd;
+pub mod pipe;
 pub mod profiler;
 pub mod svc;
 pub mod version;

--- a/crates/daemon/src/pipe.rs
+++ b/crates/daemon/src/pipe.rs
@@ -1,0 +1,50 @@
+/*
+ * Copyright Concurrent Technologies Corporation 2023
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+use crate::error::Error;
+use crate::fapolicyd::FIFO_PIPE;
+use crate::pipe::Commands::{FlushCache, ReloadRules, ReloadTrust};
+use std::io::Write;
+
+#[repr(u8)]
+enum Commands {
+    ReloadTrust = 1,
+    FlushCache = 2,
+    ReloadRules = 3,
+}
+
+type CmdResult = Result<(), Error>;
+
+// 3
+pub fn reload_rules() -> CmdResult {
+    ReloadRules.send()
+}
+
+// 2
+pub fn flush_cache() -> CmdResult {
+    FlushCache.send()
+}
+
+// 1
+pub fn reload_trust() -> CmdResult {
+    ReloadTrust.send()
+}
+
+impl Commands {
+    fn send(self) -> CmdResult {
+        let mut fifo = std::fs::OpenOptions::new()
+            .write(true)
+            .read(false)
+            .open(FIFO_PIPE)?;
+
+        // the new line char is required here
+        fifo.write_all(format!("{}\n", self as u8).as_bytes())?;
+
+        Ok(())
+    }
+}

--- a/crates/pyo3/src/trust.rs
+++ b/crates/pyo3/src/trust.rs
@@ -11,6 +11,7 @@ use std::collections::HashMap;
 use std::io::Write;
 
 use fapolicy_daemon::fapolicyd::FIFO_PIPE;
+use fapolicy_daemon::pipe;
 use pyo3::prelude::*;
 use pyo3::PyObjectProtocol;
 
@@ -196,17 +197,15 @@ impl PyChangeset {
 /// send signal to fapolicyd FIFO pipe to reload the trust database
 #[pyfunction]
 fn signal_trust_reload() -> PyResult<()> {
-    let mut fifo = std::fs::OpenOptions::new()
-        .write(true)
-        .read(false)
-        .open(FIFO_PIPE)
-        .map_err(|e| PyRuntimeError::new_err(format!("failed to open fifo pipe: {}", e)))?;
+    pipe::reload_trust()
+        .map_err(|e| PyRuntimeError::new_err(format!("failed to signal trust reload: {:?}", e)))
+}
 
-    fifo.write_all("1".as_bytes()).map_err(|e| {
-        PyRuntimeError::new_err(format!("failed to write reload byte to pipe: {:?}", e))
-    })?;
-
-    Ok(())
+/// send signal to fapolicyd FIFO pipe to reload rules
+#[pyfunction]
+fn signal_rule_reload() -> PyResult<()> {
+    pipe::reload_rules()
+        .map_err(|e| PyRuntimeError::new_err(format!("failed to signal rules reload: {:?}", e)))
 }
 
 pub fn init_module(_py: Python, m: &PyModule) -> PyResult<()> {
@@ -214,5 +213,6 @@ pub fn init_module(_py: Python, m: &PyModule) -> PyResult<()> {
     m.add_class::<PyTrust>()?;
     m.add_class::<PyActual>()?;
     m.add_function(wrap_pyfunction!(signal_trust_reload, m)?)?;
+    m.add_function(wrap_pyfunction!(signal_rule_reload, m)?)?;
     Ok(())
 }

--- a/crates/rules/src/subject.rs
+++ b/crates/rules/src/subject.rs
@@ -40,6 +40,13 @@ impl Subject {
         }
     }
 
+    pub fn comm(&self) -> Option<String> {
+        match self.parts.iter().find(|p| matches!(p, Part::Comm(_))) {
+            Some(Part::Comm(path)) => Some(path.clone()),
+            _ => None,
+        }
+    }
+
     pub fn from_exe(path: &str) -> Subject {
         Subject::new(vec![SubjPart::Exe(path.into())])
     }

--- a/fapolicy-analyzer.spec
+++ b/fapolicy-analyzer.spec
@@ -1,8 +1,24 @@
+%bcond_without check
+
 Summary:       File Access Policy Analyzer
 Name:          fapolicy-analyzer
 Version:       1.2.0
 Release:       1%{?dist}
-License:       GPL-3.0-or-later
+
+SourceLicense: GPL-3.0-or-later
+# Apache-2.0
+# Apache-2.0 OR MIT
+# Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT
+# BSD-3-Clause
+# ISC
+# ISC AND OpenSSL AND MIT
+# MIT
+# MIT OR Apache-2.0
+# MIT OR X11 OR Apache-2.0
+# MPL-2.0
+# Unlicense OR MIT
+License:       GPL-3.0-or-later AND Apache-2.0 AND BSD-3-Clause AND ISC AND MIT AND MPL-2.0 AND OpenSSL AND (Apache-2.0 OR MIT) AND (Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT) AND (MIT OR X11 OR Apache-2.0) AND (Unlicense OR MIT)
+
 URL:           https://github.com/ctc-oss/fapolicy-analyzer
 Source0:       %{url}/releases/download/v%{version}/%{name}-%{version}.tar.gz
 
@@ -22,81 +38,8 @@ BuildRequires: desktop-file-utils
 BuildRequires: clang
 BuildRequires: audit-libs-devel
 
-BuildRequires: rust-packaging
+BuildRequires: cargo-rpm-macros
 BuildRequires: python3dist(setuptools-rust)
-
-BuildRequires: rust-assert_matches-devel
-BuildRequires: rust-autocfg-devel
-BuildRequires: (crate(bindgen/default) = 0.63.0)
-BuildRequires: rust-bitflags-devel
-BuildRequires: rust-bumpalo-devel
-BuildRequires: rust-byteorder-devel
-BuildRequires: rust-cc-devel
-BuildRequires: rust-cfg-if-devel
-BuildRequires: rust-chrono-devel
-BuildRequires: rust-confy-devel
-BuildRequires: rust-crossbeam-channel-devel
-BuildRequires: rust-crossbeam-deque-devel
-BuildRequires: rust-crossbeam-epoch-devel
-BuildRequires: rust-crossbeam-utils-devel
-BuildRequires: rust-data-encoding-devel
-BuildRequires: rust-dbus-devel
-BuildRequires: rust-directories-devel
-BuildRequires: rust-dirs-sys-devel
-BuildRequires: rust-either-devel
-BuildRequires: rust-fastrand-devel
-BuildRequires: rust-getrandom-devel
-BuildRequires: rust-iana-time-zone-devel
-BuildRequires: rust-is_executable-devel
-BuildRequires: rust-instant-devel
-BuildRequires: rust-libloading-devel
-BuildRequires: rust-lazy_static-devel
-BuildRequires: rust-libc-devel
-BuildRequires: rust-libdbus-sys-devel
-BuildRequires: rust-lmdb-devel
-BuildRequires: rust-lock_api-devel
-BuildRequires: rust-log-devel
-BuildRequires: rust-memchr-devel
-BuildRequires: rust-memoffset-devel
-BuildRequires: rust-minimal-lexical-devel
-BuildRequires: rust-nom-devel
-BuildRequires: rust-num-integer-devel
-BuildRequires: rust-num-traits-devel
-BuildRequires: rust-num_cpus-devel
-BuildRequires: rust-once_cell-devel
-BuildRequires: rust-parking_lot-devel
-BuildRequires: rust-parking_lot_core-devel
-BuildRequires: rust-pkg-config-devel
-BuildRequires: rust-proc-macro-hack-devel
-BuildRequires: rust-proc-macro2-devel
-BuildRequires: (crate(pyo3/default) >= 0.15.0 with crate(pyo3/default) < 0.16.0)
-BuildRequires: (crate(pyo3-macros/default) >= 0.15.0 with crate(pyo3-macros/default) < 0.16.0)
-BuildRequires: (crate(pyo3-build-config/default) >= 0.15.0 with crate(pyo3-build-config/default) < 0.16.0)
-BuildRequires: (crate(pyo3-macros-backend/default) >= 0.15.0 with crate(pyo3-macros-backend/default) < 0.16.0)
-BuildRequires: rust-pyo3-log-devel
-BuildRequires: rust-quote-devel
-BuildRequires: rust-rayon-devel
-BuildRequires: rust-rayon-core-devel
-BuildRequires: rust-remove_dir_all-devel
-BuildRequires: rust-ring-devel
-BuildRequires: rust-scopeguard-devel
-BuildRequires: rust-serde-devel
-BuildRequires: rust-serde_derive-devel
-BuildRequires: rust-similar-devel
-BuildRequires: rust-smallvec-devel
-BuildRequires: rust-spin-devel
-BuildRequires: rust-syn-devel
-BuildRequires: rust-tempfile-devel
-BuildRequires: rust-thiserror-devel
-BuildRequires: rust-thiserror-impl-devel
-BuildRequires: rust-time0.1-devel
-BuildRequires: rust-toml-devel
-BuildRequires: rust-unicode-xid-devel
-BuildRequires: rust-unindent-devel
-BuildRequires: rust-untrusted-devel
-BuildRequires: rust-which-devel
-BuildRequires: rust-paste-devel
-BuildRequires: rust-indoc-devel
 
 Requires:      python3
 Requires:      python3-gobject
@@ -149,6 +92,9 @@ scripts/build-info.py --os --time
 echo "audit" > FEATURES
 %endif
 
+%generate_buildrequires
+%cargo_generate_buildrequires -a
+
 %build
 # ensure standard Rust compiler flags are set
 export RUSTFLAGS="%{build_rustflags}"
@@ -156,6 +102,9 @@ export RUSTFLAGS="%{build_rustflags}"
 %{python3} setup.py compile_catalog -f
 %{python3} help build
 %{python3} setup.py bdist_wheel
+
+%{cargo_license_summary}
+%{cargo_license} > LICENSE.dependencies
 
 %install
 %{py3_install_wheel %{module}-%{module_version}*%{_target_cpu}.whl}
@@ -173,6 +122,7 @@ desktop-file-validate %{buildroot}/%{_datadir}/applications/%{name}.desktop
 %files -n %{name} -f %{name}.lang
 %doc scripts/srpm/README
 %license LICENSE
+%license LICENSE.dependencies
 %{python3_sitearch}/%{module}
 %{python3_sitearch}/%{module}-%{module_version}*
 %attr(755,root,root) %{_sbindir}/%{name}

--- a/fapolicy-analyzer.spec
+++ b/fapolicy-analyzer.spec
@@ -2,7 +2,7 @@
 
 Summary:       File Access Policy Analyzer
 Name:          fapolicy-analyzer
-Version:       1.2.0
+Version:       1.2.2
 Release:       1%{?dist}
 
 SourceLicense: GPL-3.0-or-later
@@ -128,5 +128,5 @@ desktop-file-validate %{buildroot}/%{_datadir}/applications/%{name}.desktop
 %ghost %attr(640,root,root) %verify(not md5 size mtime) %{_localstatedir}/log/%{name}/%{name}.log
 
 %changelog
-* Mon Nov 06 2023 John Wass <jwass3@gmail.com> 1.2.0-1
+* Wed Dec 27 2023 John Wass <jwass3@gmail.com> 1.2.2-1
 - New release

--- a/fapolicy-analyzer.spec
+++ b/fapolicy-analyzer.spec
@@ -58,10 +58,6 @@ Requires:      gnome-icon-theme
 Requires:      webkit2gtk3
 Requires:      mesa-dri-drivers
 
-# rust-ring-devel does not support s390x and ppc64le:
-# https://bugzilla.redhat.com/show_bug.cgi?id=1869980
-ExcludeArch:   s390x %{power64}
-
 %global module          fapolicy_analyzer
 # pep440 versions handle dev and rc differently, so we call them out explicitly here
 %global module_version  %{lua: v = string.gsub(rpm.expand("%{?version}"), "~dev", ".dev"); \

--- a/scripts/srpm/fapolicy-analyzer.el8.spec
+++ b/scripts/srpm/fapolicy-analyzer.el8.spec
@@ -120,6 +120,9 @@ cp -r  %{python3_sitelib}/pip* %{venv_lib}
 
 tar -xzf %{SOURCE1}
 
+# relock with available crates
+rm Cargo.lock
+
 # disable the dev-tools crate
 sed -i '/tools/d' Cargo.toml
 

--- a/scripts/srpm/fapolicy-analyzer.el8.spec
+++ b/scripts/srpm/fapolicy-analyzer.el8.spec
@@ -116,27 +116,12 @@ rm -rf %{venv_lib}/pip*
 cp -r  %{python3_sitelib}/pip* %{venv_lib}
 
 %autosetup -n %{name}
+%cargo_prep -V2
 
-# An unprivileged user cannot write to the default registry location of
-# /usr/share/cargo/registry so we work around this by linking the contents
-# of the default registry into a new writable location, and then extract
-# the contents of the vendor tarball to this new writable dir.
-# The extraction favor the system crates by untaring with --skip-old-files
-# Later the Cargo config will be updated to point to this new registry dir
-CARGO_REG_DIR=%{_builddir}/vendor-rs
-mkdir -p ${CARGO_REG_DIR}
-tar -xzf %{SOURCE2} -C ${CARGO_REG_DIR} --skip-old-files --strip-components=2
-ls -alR ${CARGO_REG_DIR}
-
-%cargo_prep
-
-# here the Cargo config is updated to point to the new registry dir
-sed -i "s#%{cargo_registry}#${CARGO_REG_DIR}#g" .cargo/config
+ls -al
+ls -al vendor
 
 tar -xzf %{SOURCE1}
-
-# relock with available crates
-rm Cargo.lock
 
 # disable the dev-tools crate
 sed -i '/tools/d' Cargo.toml

--- a/scripts/srpm/fapolicy-analyzer.el8.spec
+++ b/scripts/srpm/fapolicy-analyzer.el8.spec
@@ -123,10 +123,10 @@ cp -r  %{python3_sitelib}/pip* %{venv_lib}
 # the contents of the vendor tarball to this new writable dir.
 # The extraction favor the system crates by untaring with --skip-old-files
 # Later the Cargo config will be updated to point to this new registry dir
-CARGO_REG_DIR=%{_builddir}/vendor-rs/registry
+CARGO_REG_DIR=%{_builddir}/vendor-rs
 mkdir -p ${CARGO_REG_DIR}
-for d in %{cargo_registry}/*; do ln -sf ${d} ${CARGO_REG_DIR} || true; done
 tar -xzf %{SOURCE2} -C ${CARGO_REG_DIR} --skip-old-files --strip-components=2
+ls -alR ${CARGO_REG_DIR}
 
 %cargo_prep
 

--- a/scripts/srpm/fapolicy-analyzer.el8.spec
+++ b/scripts/srpm/fapolicy-analyzer.el8.spec
@@ -123,7 +123,7 @@ cp -r  %{python3_sitelib}/pip* %{venv_lib}
 # the contents of the vendor tarball to this new writable dir.
 # The extraction favor the system crates by untaring with --skip-old-files
 # Later the Cargo config will be updated to point to this new registry dir
-CARGO_REG_DIR=%{_builddir}/vendor-rs
+CARGO_REG_DIR=%{_builddir}/vendor-rs/registry
 mkdir -p ${CARGO_REG_DIR}
 for d in %{cargo_registry}/*; do ln -sf ${d} ${CARGO_REG_DIR} || true; done
 tar -xzf %{SOURCE2} -C ${CARGO_REG_DIR} --skip-old-files --strip-components=2

--- a/scripts/srpm/fapolicy-analyzer.el8.spec
+++ b/scripts/srpm/fapolicy-analyzer.el8.spec
@@ -123,6 +123,8 @@ ls -al vendor
 
 tar -xzf %{SOURCE1}
 
+rm Cargo.lock
+
 # disable the dev-tools crate
 sed -i '/tools/d' Cargo.toml
 

--- a/scripts/srpm/fapolicy-analyzer.el8.spec
+++ b/scripts/srpm/fapolicy-analyzer.el8.spec
@@ -38,6 +38,7 @@ BuildRequires: desktop-file-utils
 
 BuildRequires: clang
 BuildRequires: audit-libs-devel
+BuildRequires: lmdb-devel
 
 BuildRequires: rust-toolset
 BuildRequires: python3dist(toml)

--- a/scripts/srpm/fapolicy-analyzer.el8.spec
+++ b/scripts/srpm/fapolicy-analyzer.el8.spec
@@ -1,6 +1,6 @@
 Summary:       File Access Policy Analyzer
 Name:          fapolicy-analyzer
-Version:       1.2.0
+Version:       1.2.2
 Release:       1%{?dist}
 License:       GPL-3.0-or-later
 URL:           https://github.com/ctc-oss/fapolicy-analyzer
@@ -161,5 +161,5 @@ desktop-file-validate %{buildroot}/%{_datadir}/applications/%{name}.desktop
 %attr(755,root,root) %{_datadir}/applications/%{name}.desktop
 
 %changelog
-* Mon Nov 06 2023 John Wass <jwass3@gmail.com> 1.2.0-1
+* Wed Dec 27 2023 John Wass <jwass3@gmail.com> 1.2.2-1
 - New release

--- a/scripts/srpm/fapolicy-analyzer.el9.spec
+++ b/scripts/srpm/fapolicy-analyzer.el9.spec
@@ -41,6 +41,7 @@ BuildRequires: desktop-file-utils
 
 BuildRequires: clang
 BuildRequires: audit-libs-devel
+BuildRequires: lmdb-devel
 
 BuildRequires: rust-packaging
 

--- a/scripts/srpm/fapolicy-analyzer.el9.spec
+++ b/scripts/srpm/fapolicy-analyzer.el9.spec
@@ -131,10 +131,6 @@ Requires:      gnome-icon-theme
 Requires:      webkit2gtk3
 Requires:      mesa-dri-drivers
 
-# rust-ring-devel does not support s390x and ppc64le:
-# https://bugzilla.redhat.com/show_bug.cgi?id=1869980
-ExcludeArch:   s390x %{power64}
-
 %global module          fapolicy_analyzer
 
 %global venv_dir        %{_builddir}/vendor-py

--- a/scripts/srpm/fapolicy-analyzer.el9.spec
+++ b/scripts/srpm/fapolicy-analyzer.el9.spec
@@ -1,6 +1,6 @@
 Summary:       File Access Policy Analyzer
 Name:          fapolicy-analyzer
-Version:       1.2.0
+Version:       1.2.2
 Release:       1%{?dist}
 License:       GPL-3.0-or-later
 URL:           https://github.com/ctc-oss/fapolicy-analyzer
@@ -53,7 +53,7 @@ BuildRequires: rust-byteorder-devel
 BuildRequires: rust-cc-devel
 BuildRequires: rust-cfg-if-devel
 BuildRequires: rust-chrono-devel
-#BuildRequires: rust-confy-devel
+BuildRequires: rust-confy-devel
 BuildRequires: rust-crossbeam-channel-devel
 BuildRequires: rust-crossbeam-deque-devel
 BuildRequires: rust-crossbeam-epoch-devel
@@ -87,16 +87,13 @@ BuildRequires: rust-parking_lot_core-devel
 BuildRequires: rust-pkg-config-devel
 BuildRequires: rust-proc-macro-hack-devel
 BuildRequires: rust-proc-macro2-devel
-#BuildRequires: (crate(pyo3/default) >= 0.15.0 with crate(pyo3/default) < 0.16.0)
-#BuildRequires: (crate(pyo3-macros/default) >= 0.15.0 with crate(pyo3-macros/default) < 0.16.0)
-#BuildRequires: (crate(pyo3-build-config/default) >= 0.15.0 with crate(pyo3-build-config/default) < 0.16.0)
-#BuildRequires: (crate(pyo3-macros-backend/default) >= 0.15.0 with crate(pyo3-macros-backend/default) < 0.16.0)
+#BuildRequires: rust-pyo3-devel
 #BuildRequires: rust-pyo3-log-devel
 BuildRequires: rust-quote-devel
 BuildRequires: rust-rayon-devel
 BuildRequires: rust-rayon-core-devel
 BuildRequires: rust-remove_dir_all-devel
-#BuildRequires: rust-ring-devel
+BuildRequires: rust-ring-devel
 BuildRequires: rust-scopeguard-devel
 BuildRequires: rust-serde-devel
 BuildRequires: rust-serde_derive-devel
@@ -111,7 +108,7 @@ BuildRequires: rust-time0.1-devel
 BuildRequires: rust-toml-devel
 BuildRequires: rust-unicode-xid-devel
 BuildRequires: rust-unindent-devel
-#BuildRequires: rust-untrusted-devel
+BuildRequires: rust-untrusted-devel
 BuildRequires: rust-paste-devel
 BuildRequires: rust-indoc-devel
 
@@ -233,5 +230,5 @@ desktop-file-validate %{buildroot}/%{_datadir}/applications/%{name}.desktop
 %attr(755,root,root) %{_datadir}/applications/%{name}.desktop
 
 %changelog
-* Mon Nov 06 2023 John Wass <jwass3@gmail.com> 1.2.0-1
+* Wed Dec 27 2023 John Wass <jwass3@gmail.com> 1.2.2-1
 - New release

--- a/scripts/srpm/vendor-rs.sh
+++ b/scripts/srpm/vendor-rs.sh
@@ -19,9 +19,39 @@ set -e
 
 # rust
 rm -rf vendor-rs
-# the dest path here needs to stay synced up with the path in lock2spec.py
-cargo vendor-filterer --platform=x86_64-unknown-linux-gnu vendor-rs/vendor &> /dev/null
-python3 scripts/srpm/lock2spec.py --vendor_all
-tar czf vendor-rs-${1}.tar.gz -C vendor-rs .
 
-du -sh vendor-rs-${1}.tar.gz
+# the dest path here needs to stay synced up with the path in lock2spec.py
+vendor_dest=vendor-rs/vendor
+
+id=$(. /etc/os-release && echo $ID)
+
+case $id in
+  fedora)
+    echo "fedora: vendoring packages"
+    mkdir -p ${vendor_dest}
+    cp -r /usr/share/cargo/registry/* ${vendor_dest}
+    ;;
+
+  ubuntu)
+    echo "ubuntu: vendoring crates.io"
+    cargo check
+    cargo vendor-filterer --platform=x86_64-unknown-linux-gnu ${vendor_dest} &> /dev/null
+    python3 scripts/srpm/lock2spec.py --vendor_all
+    ;;
+
+  *)
+    echo "error: $id is an unsupported build platform"
+    ;;
+esac
+
+
+vendor_tar=vendor-rs.tar.gz
+vendor_root=$(dirname ${vendor_dest})
+tar czf ${vendor_tar} -C ${vendor_root} .
+
+if [[ ! -z "$1" ]]; then
+  vendor_tar=vendor-rs-${1}.tar.gz
+  mv vendor-rs.tar.gz ${vendor_tar}
+fi
+
+du -sh ${vendor_tar}


### PR DESCRIPTION
First release of forked el8

This commit rolls up changes from master which are listed below.

There are also some additional changes to support the el8 build.

- Release v1.2.2 (#969)

- Try harder to create rules backup (#967)

Add a fallback for when a rename does not succeed.

In the case where tempdir is on a different filesystem the
`std::fs::rename` call will fail.

```
This function will return an error in the following situations, but is not limited to just these cases:

  - from does not exist.
  - The user lacks permissions to view contents.
  - from and to are on separate filesystems.
```

https://doc.rust-lang.org/std/fs/fn.rename.html

This commit updates the logic to fallback to a copy and delete.

Closes #965

- Update fapolicyd pipe commands (#966)

Expands the fapolicyd fifo pipe signaling machinery to include cache
flush and rule reload.

This also fixes a bug from #672 where the trust reload was not including
a new line character.

This supports work that will take place for #877 to integrate the rule
reload with the profiler execution.

Closes #964

- Handle escapes in syslog entries (#959)

Adds tests to ensure escapes in syslog entries are being parsed properly

Closes #781

- Vendor updates (#957)

Updates crate vendoring to be sourced only from Fedora packages

Closes #958

- Build with Mock (#955)

Uses Fedora Mock to build RPMs in a clean chroot environment.

This commit modifies the GitHub CI RPM build by replacing the direct use
of rpmbuild with Fedora Mock through a Podman container.

This approach aligns our CI with the same approach used in Copr and
Koji. Mock is also recommended as an upstream best practice, and is
required for consistent behavior after the move to use
`%cargo_generate_buildrequires`.

Closes #952

- All arch support (#953)

Fixes an issue building auparse bindings for i686 and removes all
excluded arches from spec

An updated Rust ring crate made it possible to build on s390 and power64
arches. That update was present in #905 but was not enabled in the spec
until now.

Closes #947
Closes #948

- Update packaging for latest Rust and Legal guidelines (#951)

A couple of updates brought over from the rpm repo.

Update Rust build dependencies to use `%cargo_generate_buildrequires` to
generate, rather than explicitly listing dependencies. Projects with
subcrates were not originally supported but have been now for a while.

Update the license listing to include Rust statically linked licenses.

See https://src.fedoraproject.org/rpms/fapolicy-analyzer/pull-request/16

Closes #949