### PR TITLE
Enforce changelog

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,0 +1,23 @@
+on:
+  push:
+    branches:
+      - 'master'
+      - 'release/*'
+  pull_request:
+    types: [opened, synchronize, labeled, unlabeled, edited]
+    branches:
+      - 'master'
+      - 'release/*'
+
+name: Changelog
+
+jobs:
+  changelog:
+    name: Enforce changelog entry
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: jw3/newsforce@docker
+        with:
+          ignores: ci,documentation,release

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,13 +1,8 @@
 on:
-  push:
-    branches:
-      - 'master'
-      - 'release/*'
   pull_request:
     types: [opened, synchronize, labeled, unlabeled, edited]
     branches:
       - 'master'
-      - 'release/*'
 
 name: Changelog
 

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -18,6 +18,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4
-      - uses: jw3/newsforce@docker
+      - uses: jw3/newsforce@v0
         with:
           ignores: ci,documentation,release
+          contrib_url: https://github.com/ctc-oss/fapolicy-analyzer/blob/master/CONTRIBUTING.md#changelog-updates

--- a/.github/workflows/common.yml
+++ b/.github/workflows/common.yml
@@ -28,6 +28,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: jw3/newsforce@v0
+      - uses: jw3/newsforce@docker
         with:
           ignores: ci,documentation,release

--- a/.github/workflows/common.yml
+++ b/.github/workflows/common.yml
@@ -29,3 +29,5 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: jw3/newsforce@v0
+        with:
+          ignores: ci,documentation,release

--- a/.github/workflows/common.yml
+++ b/.github/workflows/common.yml
@@ -21,3 +21,11 @@ jobs:
           ! grep -R -L --exclude-dir=vendor \
             --include='*.py' --include='*.rs' --include='*.glade' --include='*.sh' \
             'Copyright Concurrent Technologies Corporation' *
+
+  changelog:
+    name: Enforce changelog entry
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: jw3/newsforce@v0

--- a/.github/workflows/common.yml
+++ b/.github/workflows/common.yml
@@ -21,13 +21,3 @@ jobs:
           ! grep -R -L --exclude-dir=vendor \
             --include='*.py' --include='*.rs' --include='*.glade' --include='*.sh' \
             'Copyright Concurrent Technologies Corporation' *
-
-  changelog:
-    name: Enforce changelog entry
-    if: github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: jw3/newsforce@docker
-        with:
-          ignores: ci,documentation,release

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,6 +43,28 @@ make format
 make test
 ```
 
+### Changelog updates
+
+We use [towncrier](https://towncrier.readthedocs.io/en/stable/index.html) to generate a CHANGELOG for each release.
+
+To include your change in the release notes please create a news article in the `news` directory.
+
+Valid articles should be saved as `<PR>.<CATEGORY>.md` where `<PR>` is the pull request number and `<CATEGORY>` is one of:
+
+- `fixed` - for bug fixes
+- `added` - added a new feature
+- `changed` - changed an existing feature
+- `removed` - removed capability
+- `packaging` - an RPM or dependency changes
+
+PRs may be excluded from the documentation requirement if they fall into one of the following categories:
+
+- `ci` - Continuous Integration changes do not need reported to users
+- `documentation` - Documentation improvements do not usually need reported to users
+- `release` - Release PRs do not need a news article
+
+To exclude the news check on a PR label the PR with the category or prefix the PR title with the name and a colon, `ci: Updated the build`.
+
 ### Getting Help
 Feel free to ask a question or start a discussion in the [Discussion](https://github.com/ctc-oss/fapolicy-analyzer/discussions) section of this project.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,7 +63,7 @@ PRs may be excluded from the documentation requirement if they fall into one of 
 - `documentation` - Documentation improvements do not usually need reported to users
 - `release` - Release PRs do not need a news article
 
-To exclude the news check on a PR label the PR with the category or prefix the PR title with the name and a colon, `ci: Updated the build`.
+To exclude the news check on a PR label the PR with the category or tag PR title with a prefix + `:`, eg. `ci: Updated the build`.
 
 ### Getting Help
 Feel free to ask a question or start a discussion in the [Discussion](https://github.com/ctc-oss/fapolicy-analyzer/discussions) section of this project.


### PR DESCRIPTION
Use ci to enfoce a changelog entry for each PR.

The changelog entries are made as a "news article" entry, which are rolled together at release-time through a manual operation. The resulting text is then prepended to the changelog and included in the release commit.

Changelog categories: added,removed,changed,fixed,packaging
Ignored labels: ci,documentation,release

This commit also adds a section to the contributing guide to describe how to add a news article.

Closes #978 