### PR TITLE
Rust 1.71.1

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@v1
         with:
-          toolchain: 1.66.1
+          toolchain: 1.71.1
       - name: Install extra locales
         id: install_locales
         run: |

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@v1
         with:
           components: rustfmt
-          toolchain: 1.66.1
+          toolchain: 1.71.1
       - run: rustup component add rustfmt
       # use a placeholder for bindgen bindings
       - run: echo "//placeholder" | tee crates/auparse/sys/src/bindings.rs
@@ -39,7 +39,7 @@ jobs:
           sudo apt-get install libdbus-1-dev libaudit-dev libauparse-dev
       - uses: dtolnay/rust-toolchain@v1
         with:
-          toolchain: 1.66.1
+          toolchain: 1.71.1
       - uses: actions-rs/cargo@v1
         with:
           command: check
@@ -61,7 +61,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@v1
         with:
           components: clippy
-          toolchain: 1.66.1
+          toolchain: 1.71.1
       - run: rustup component add clippy
       - uses: actions-rs/cargo@v1
         with:
@@ -112,7 +112,7 @@ jobs:
           sudo apt-get install libdbus-1-dev libaudit-dev libauparse-dev
       - uses: dtolnay/rust-toolchain@v1
         with:
-          toolchain: 1.66.1
+          toolchain: 1.71.1
       - uses: actions-rs/cargo@v1
         with:
           command: test

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -50,10 +50,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      # disable lint on pyo3 due to
-      # https://github.com/rust-lang/rust-clippy/issues/8971
-      - run: sed -i '/pyo3/d' Cargo.toml
-
       - name: Install package dependencies
         run: |
           sudo apt-get update

--- a/.github/workflows/tools.yml
+++ b/.github/workflows/tools.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Install toolchain
         uses: dtolnay/rust-toolchain@v1
         with:
-          toolchain: 1.66.1
+          toolchain: 1.71.1
 
       - uses: actions/checkout@v3
         with:

--- a/crates/pyo3/src/trust.rs
+++ b/crates/pyo3/src/trust.rs
@@ -8,9 +8,7 @@
 
 use pyo3::exceptions::PyRuntimeError;
 use std::collections::HashMap;
-use std::io::Write;
 
-use fapolicy_daemon::fapolicyd::FIFO_PIPE;
 use fapolicy_daemon::pipe;
 use pyo3::prelude::*;
 


### PR DESCRIPTION
Upgrade Rust to 1.71.1

Restores clippy on bindings project in ci.

Closes #894
Closes #981