### PR TITLE
Release v1.3.0

### DIFF
--- a/.towncrier.template.md
+++ b/.towncrier.template.md
@@ -1,0 +1,14 @@
+{% for section_text, section in sections.items() %}{%- if section %}{{section_text}}{% endif -%}
+{% if section %}
+{% for category in ['packaging', 'added', 'changed', 'removed', 'fixed' ] if category in section %}
+### {{ definitions[category]['name'] }}
+
+{% if definitions[category]['showcontent'] %}
+{% for text, pull_requests in section[category].items() %}
+- {{ text }} {{ pull_requests|join(', ') }}
+  {% endfor %}
+  {% else %}
+- {{ section[category]['']|join(', ') }}
+  {% endif %}
+
+{% endfor %}{% else %}No significant changes.{% endif %}{% endfor %}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ Release notes
 ## [v1.3.0](https://github.com/ctc-oss/fapolicy-analyzer/releases/tag/v1.3.0) - 2024-02-11
 
 
-### _Added_
+### Added
 
 - Allow rules to be loaded dynamically into a profiling session ([#990](https://github.com/ctc-oss/fapolicy-analyzer/pull/990))
 - Added syntax highlighting to the fapolicyd config editor ([#991](https://github.com/ctc-oss/fapolicy-analyzer/pull/991))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,26 @@
 Release notes
-###
+===
 
-``fapolicy-analyzer`` issues are filed on [GitHub](https://github.com/ctc-oss/fapolicy-analyzer/issues).
+`fapolicy-analyzer` issues are filed on [GitHub](https://github.com/ctc-oss/fapolicy-analyzer/issues).
+
 
 ## Releases
 
 <!-- towncrier release notes start -->
+
+## [v1.3.0](https://github.com/ctc-oss/fapolicy-analyzer/releases/tag/v1.3.0) - 2024-02-11
+
+
+### _Added_
+
+- Allow rules to be loaded dynamically into a profiling session ([#990](https://github.com/ctc-oss/fapolicy-analyzer/pull/990))
+- Added syntax highlighting to the fapolicyd config editor ([#991](https://github.com/ctc-oss/fapolicy-analyzer/pull/991))
+
+### Packaging
+
+- Use digest crate for sha256 hashing, removing need for ring crate. ([#984](https://github.com/ctc-oss/fapolicy-analyzer/pull/984))
+- Add a version number to the PDF user guide content and filename. ([#995](https://github.com/ctc-oss/fapolicy-analyzer/pull/995))
+
 
 # v1.2.2
 

--- a/fapolicy-analyzer.spec
+++ b/fapolicy-analyzer.spec
@@ -2,7 +2,7 @@
 
 Summary:       File Access Policy Analyzer
 Name:          fapolicy-analyzer
-Version:       1.2.2
+Version:       1.3.0
 Release:       1%{?dist}
 
 SourceLicense: GPL-3.0-or-later
@@ -128,5 +128,5 @@ desktop-file-validate %{buildroot}/%{_datadir}/applications/%{name}.desktop
 %ghost %attr(640,root,root) %verify(not md5 size mtime) %{_localstatedir}/log/%{name}/%{name}.log
 
 %changelog
-* Wed Dec 27 2023 John Wass <jwass3@gmail.com> 1.2.2-1
+* Sat Feb 03 2024 John Wass <jwass3@gmail.com> 1.3.0-1
 - New release

--- a/fapolicy_analyzer/ui/rules/rules_admin_page.py
+++ b/fapolicy_analyzer/ui/rules/rules_admin_page.py
@@ -331,7 +331,6 @@ class RulesAdminPage(UIConnectedWidget, UIPage, Events):
 
     def on_next_profiling_state(self, state: ProfilerState):
         if self.__profiling_active != state.running:
-            print(state)
             self.__profiling_active = state.running
             self.refresh_toolbar()
 

--- a/news/984.packaging.md
+++ b/news/984.packaging.md
@@ -1,1 +1,0 @@
-Use digest crate for sha256 hashing, removing need for ring crate.

--- a/news/990.added.md
+++ b/news/990.added.md
@@ -1,1 +1,0 @@
-Allow rules to be loaded dynamically into a profiling session

--- a/news/991.added.md
+++ b/news/991.added.md
@@ -1,1 +1,0 @@
-Added syntax highlighting to the fapolicyd config editor

--- a/news/995.packaging.md
+++ b/news/995.packaging.md
@@ -1,1 +1,0 @@
-Add a version number to the PDF user guide content and filename.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,22 @@
 [tool.ruff.lint]
 ignore = ["E402"]
+
+[tool.towncrier]
+filename = "CHANGELOG.md"
+version = "1.3.0"
+start_string = "<!-- towncrier release notes start -->\n"
+title_format = "## [v{version}](https://github.com/ctc-oss/fapolicy-analyzer/releases/tag/v{version}) - {project_date}"
+issue_format = "[#{issue}](https://github.com/ctc-oss/fapolicy-analyzer/pull/{issue})"
+underlines = ["", "", ""]
+directory = "news"
+
+[tool.towncrier.fragment.added]
+name = "Added"
+[tool.towncrier.fragment.changed]
+name = "Changed"
+[tool.towncrier.fragment.removed]
+name = "Removed"
+[tool.towncrier.fragment.fixed]
+name = "Fixed"
+[tool.towncrier.fragment.packaging]
+name = "Packaging"

--- a/scripts/srpm/fapolicy-analyzer.el9.spec
+++ b/scripts/srpm/fapolicy-analyzer.el9.spec
@@ -1,6 +1,6 @@
 Summary:       File Access Policy Analyzer
 Name:          fapolicy-analyzer
-Version:       1.2.2
+Version:       1.3.0
 Release:       1%{?dist}
 License:       GPL-3.0-or-later
 URL:           https://github.com/ctc-oss/fapolicy-analyzer
@@ -221,5 +221,5 @@ desktop-file-validate %{buildroot}/%{_datadir}/applications/%{name}.desktop
 %attr(755,root,root) %{_datadir}/applications/%{name}.desktop
 
 %changelog
-* Wed Dec 27 2023 John Wass <jwass3@gmail.com> 1.2.2-1
+* Sat Feb 03 2024 John Wass <jwass3@gmail.com> 1.3.0-1
 - New release


### PR DESCRIPTION
## [v1.3.0](https://github.com/ctc-oss/fapolicy-analyzer/releases/tag/v1.3.0) - 2024-02-11


### Added

- Allow rules to be loaded dynamically into a profiling session ([#990](https://github.com/ctc-oss/fapolicy-analyzer/pull/990))
- Added syntax highlighting to the fapolicyd config editor ([#991](https://github.com/ctc-oss/fapolicy-analyzer/pull/991))

### Packaging

- Use digest crate for sha256 hashing, removing need for ring crate. ([#984](https://github.com/ctc-oss/fapolicy-analyzer/pull/984))
- Add a version number to the PDF user guide content and filename. ([#995](https://github.com/ctc-oss/fapolicy-analyzer/pull/995))
