### PR TITLE
Package filter conf parser

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -451,6 +451,7 @@ dependencies = [
 name = "fapolicy-trust"
 version = "0.5.0"
 dependencies = [
+ "assert_matches",
  "fapolicy-util",
  "lmdb",
  "log",

--- a/crates/trust/Cargo.toml
+++ b/crates/trust/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 
 [dev-dependencies]
 tempfile = "3.3"
+assert_matches = "1.5"
 
 [dependencies]
 lmdb = "0.8"

--- a/crates/trust/src/filter.rs
+++ b/crates/trust/src/filter.rs
@@ -121,7 +121,7 @@ impl Node {
 
 #[derive(Debug, Default)]
 struct Decider(Node);
-impl<'a> Decider {
+impl Decider {
     fn check(&self, p: &str) -> bool {
         matches!(self.0.check(p), Inc(_))
     }

--- a/crates/trust/src/filter.rs
+++ b/crates/trust/src/filter.rs
@@ -162,26 +162,23 @@ fn parse(lines: &[&str]) -> Result<Decider, Error> {
             }
             (None, Ok((_, (_, _)))) => return Err(TooManyStartIndents),
             (Some(pi), Ok((i, (k, d)))) if i > pi => {
-                let last = stack.last().unwrap();
-                let p = last.join(k);
-                stack.push(p.clone());
-                prev_i = Some(i);
+                let p = stack.last().map(|l| l.join(k)).unwrap();
                 decider.add(&p.display().to_string(), d.with_line_num(ln));
+                stack.push(p);
+                prev_i = Some(i);
             }
             (Some(pi), Ok((i, (k, d)))) if i < pi => {
                 stack.truncate(i);
-                let last = stack.last().unwrap();
-                let p = last.join(k);
-                stack.push(p.clone());
-                prev_i = Some(i);
+                let p = stack.last().map(|l| l.join(k)).unwrap();
                 decider.add(&p.display().to_string(), d.with_line_num(ln));
+                stack.push(p);
+                prev_i = Some(i);
             }
             (Some(_), Ok((i, (k, d)))) => {
                 stack.truncate(i);
-                let last = stack.last().unwrap();
-                let p = last.join(k);
-                stack.push(p.clone());
+                let p = stack.last().map(|l| l.join(k)).unwrap();
                 decider.add(&p.display().to_string(), d.with_line_num(ln));
+                stack.push(p);
             }
             (_, Err(_)) => return Err(MalformedDec(line.to_string())),
         }

--- a/crates/trust/src/filter.rs
+++ b/crates/trust/src/filter.rs
@@ -322,7 +322,7 @@ mod tests {
         | "#
         .trim_to('|');
 
-        let d = parse(&al.split("\n").collect::<Vec<&str>>()).unwrap();
+        let d = parse(&al.split('\n').collect::<Vec<&str>>()).unwrap();
         assert!(!d.check("/usr/foo/x"));
         assert!(d.check("/usr/foo/x.py"));
         assert!(!d.check("/usr/bar/x"));
@@ -345,7 +345,7 @@ mod tests {
         |+ /"#
             .trim_to('|');
 
-        let d = parse(&al.split("\n").collect::<Vec<&str>>()).unwrap();
+        let d = parse(&al.split('\n').collect::<Vec<&str>>()).unwrap();
         assert!(d.check("/"));
         assert!(!d.check("/usr/bin/some_binary1"));
         assert!(!d.check("/usr/bin/some_binary2"));
@@ -360,7 +360,7 @@ mod tests {
         |  - some_binary2"#
             .trim_to('|');
 
-        let d = parse(&al.split("\n").collect::<Vec<&str>>()).unwrap();
+        let d = parse(&al.split('\n').collect::<Vec<&str>>()).unwrap();
         assert!(d.check("/"));
         assert!(!d.check("/usr/bin/some_binary1"));
         assert!(!d.check("/usr/bin/some_binary2"));
@@ -373,7 +373,7 @@ mod tests {
         |+ /"#
             .trim_to('|');
 
-        let d = parse(&al.split("\n").collect::<Vec<&str>>()).unwrap();
+        let d = parse(&al.split('\n').collect::<Vec<&str>>()).unwrap();
         assert!(d.check("/"));
         assert!(!d.check("/usr/bin/some_binary1"));
         assert!(!d.check("/usr/bin/some_binary2"));
@@ -386,7 +386,7 @@ mod tests {
         | - usr/bin/some_binary*"#
             .trim_to('|');
 
-        let d = parse(&al.split("\n").collect::<Vec<&str>>()).unwrap();
+        let d = parse(&al.split('\n').collect::<Vec<&str>>()).unwrap();
         assert!(d.check("/"));
         assert!(!d.check("/usr/bin/some_binary1"));
         assert!(!d.check("/usr/bin/some_binary2"));
@@ -401,7 +401,7 @@ mod tests {
         |  + *.pl"#
             .trim_to('|');
 
-        let d = parse(&al.split("\n").collect::<Vec<&str>>()).unwrap();
+        let d = parse(&al.split('\n').collect::<Vec<&str>>()).unwrap();
         assert!(d.check("/usr/bin/ls"));
         assert!(!d.check("/usr/share/something"));
         assert!(d.check("/usr/share/abcd.py"));
@@ -415,7 +415,7 @@ mod tests {
         |   + *.py"#
             .trim_to('|');
 
-        let d = parse(&al.split("\n").collect::<Vec<&str>>()).unwrap();
+        let d = parse(&al.split('\n').collect::<Vec<&str>>()).unwrap();
         assert!(!d.check("/usr/share/abc"));
         // assert!(!d.check("/usr/share/abc.py"));
     }
@@ -428,7 +428,7 @@ mod tests {
         |   + *.py"#
             .trim_to('|');
 
-        let d = parse(&al.split("\n").collect::<Vec<&str>>()).unwrap();
+        let d = parse(&al.split('\n').collect::<Vec<&str>>()).unwrap();
         assert!(!d.check("/usr/share/abc"));
         assert!(!d.check("/usr/share/abc.pl"));
         assert!(d.check("/usr/share/abc.py"));
@@ -481,7 +481,7 @@ mod tests {
         |"#
         .trim_to('|');
 
-        let d = parse(&al.split("\n").collect::<Vec<&str>>()).unwrap();
+        let d = parse(&al.split('\n').collect::<Vec<&str>>()).unwrap();
         assert!(d.check("/bin/foo"));
         assert!(!d.check("/usr/share/x.txt"));
         assert!(!d.check("/usr/include/x.h"));
@@ -508,7 +508,7 @@ mod tests {
         |- /z"#
             .trim_to('|');
 
-        let d = parse(&al.split("\n").collect::<Vec<&str>>()).unwrap();
+        let d = parse(&al.split('\n').collect::<Vec<&str>>()).unwrap();
         assert!(!d.check("/usr/share/xyz"));
         assert!(d.check("/usr/share/abc/def/foo.py"));
         assert!(!d.check("/tmp/x"));
@@ -526,7 +526,7 @@ mod tests {
         | - bar/baz"#
             .trim_to('|');
 
-        let d = parse(&al.split("\n").collect::<Vec<&str>>()).unwrap();
+        let d = parse(&al.split('\n').collect::<Vec<&str>>()).unwrap();
         assert_matches!(d.dec("/"), Inc(3));
         assert_matches!(d.dec("/usr/bin/some_binary1"), Exc(1));
         assert_matches!(d.dec("/usr/bin/some_binary2"), Exc(2));

--- a/crates/trust/src/filter.rs
+++ b/crates/trust/src/filter.rs
@@ -81,22 +81,7 @@ impl Node {
 
     fn find(&self, path: &str, idx: usize, wc: bool) -> Option<Dec> {
         if idx == path.len() {
-            return match self.decision {
-                d @ Some(_) => d,
-                None => {
-                    if self.children.contains_key(&'*')
-                        && self
-                            .children
-                            .iter()
-                            .find_map(|(c, _)| if *c == '*' { Some(Inc) } else { None })
-                            .is_none()
-                    {
-                        Some(Inc)
-                    } else {
-                        None
-                    }
-                }
-            };
+            return self.decision;
         }
 
         let c = path.chars().nth(idx).unwrap();
@@ -284,7 +269,7 @@ mod tests {
 
     use crate::filter::Dec::*;
     use crate::filter::Meta::*;
-    use crate::filter::{parse, parse_meta, Decider, Error, MetaDecider};
+    use crate::filter::{parse, Decider, Error, MetaDecider};
 
     #[test]
     fn test_too_many_indents() {
@@ -366,15 +351,15 @@ mod tests {
         Ok(())
     }
 
-    #[test]
-    fn test_multi_meta() -> Result<(), Error> {
-        let d = parse_meta(&["+ /", "- /foo"])?;
-        assert!(d.check("/"));
-        assert!(!d.check("/foo"));
-        assert_matches!(d.check_ln("/"), (true, LineNumber(0)));
-        assert_matches!(d.check_ln("/foo"), (false, LineNumber(1)));
-        Ok(())
-    }
+    // #[test]
+    // fn test_multi_meta() -> Result<(), Error> {
+    //     let d = parse_meta(&["+ /", "- /foo"])?;
+    //     assert!(d.check("/"));
+    //     assert!(!d.check("/foo"));
+    //     assert_matches!(d.check_ln("/"), (true, LineNumber(0)));
+    //     assert_matches!(d.check_ln("/foo"), (false, LineNumber(1)));
+    //     Ok(())
+    // }
 
     #[test]
     fn test_parse() -> Result<(), Error> {

--- a/crates/trust/src/filter.rs
+++ b/crates/trust/src/filter.rs
@@ -322,7 +322,7 @@ mod tests {
         assert!(d.check("/usr/src/kernels/5.13.16/tools/objtool/foo"));
     }
 
-    // the remainder of the tests exercise other corners of the parsing api
+    // the remainder of the tests exercise other corners of the decision api
 
     #[test]
     fn meta_source_line_numbers() {

--- a/crates/trust/src/filter.rs
+++ b/crates/trust/src/filter.rs
@@ -6,7 +6,6 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use std::cell::Cell;
 use std::cmp::Ordering;
 use std::collections::{BTreeSet, HashMap};
 use std::fmt::{Display, Formatter, Write};
@@ -25,7 +24,7 @@ use crate::filter::Meta::LineNumber;
 
 /// Internal API
 #[derive(Copy, Clone, Debug, Default, Eq, PartialEq)]
-enum Dec {
+pub(crate) enum Dec {
     #[default]
     Exc,
     Inc,
@@ -263,7 +262,27 @@ mod tests {
     }
 
     #[test]
+    fn test_single_wildcard() -> Result<(), Error> {
+        let (i, (k, d)) = parse_entry("          + foo")?;
+        println!("{i} -> {d} {k}");
+        Ok(())
+    }
+
+    #[test]
     fn test_indented() -> Result<(), Error> {
+        let s = " ";
+        let d = parse(&["+ /", "  - foo/bar", "   + baz"])?;
+        //                             _     __             ___
+        assert!(d.check("/"));
+        assert!(d.check("/foo"));
+        assert!(!d.check("/foo/bar"));
+        assert!(!d.check("/foo/bar/biz"));
+        assert!(d.check("/foo/bar/baz"));
+        Ok(())
+    }
+
+    #[test]
+    fn test_mix_indented() -> Result<(), Error> {
         let s = " ";
         let d = parse(&["+ /", "  - foo/bar", "   + baz"])?;
         //                             _     __             ___

--- a/crates/trust/src/filter.rs
+++ b/crates/trust/src/filter.rs
@@ -62,7 +62,9 @@ impl Dec {
 }
 
 enum Wild {
+    // exactly once
     Single,
+    // 1 or more
     Glob,
 }
 

--- a/crates/trust/src/filter.rs
+++ b/crates/trust/src/filter.rs
@@ -19,7 +19,18 @@ use nom::IResult;
 use thiserror::Error;
 
 use crate::filter::Dec::*;
-use crate::filter::Error::{MalformedDec, NonAbsRootElement, TooManyStartIndents};
+
+#[derive(Error, Debug)]
+pub enum Error {
+    #[error("Malformed: {0}")]
+    MalformedDec(String),
+
+    #[error("Malformed: root element is not absolute")]
+    NonAbsRootElement,
+
+    #[error("Malformed: too many starting indents")]
+    TooManyStartIndents,
+}
 
 /// Internal API
 #[derive(Copy, Clone, Debug, Default, Eq, PartialEq)]
@@ -194,6 +205,8 @@ fn ignored_line(l: &str) -> bool {
 }
 
 fn parse(lines: &[&str]) -> Result<Decider, Error> {
+    use Error::*;
+
     let mut decider = Decider::default();
 
     let mut prev_i = None;
@@ -254,18 +267,6 @@ fn parse_meta(lines: &[&str]) -> Result<MetaDecider, Error> {
         parse_entry(line).map(|(_, (k, d))| decider.add_ln(k.into(), d, i))?;
     }
     Ok(decider)
-}
-
-#[derive(Error, Debug)]
-pub enum Error {
-    #[error("Malformed: {0}")]
-    MalformedDec(String),
-
-    #[error("Malformed: root element is not absolute")]
-    NonAbsRootElement,
-
-    #[error("Malformed: too many starting indents")]
-    TooManyStartIndents,
 }
 
 fn parse_dec(i: &str) -> IResult<&str, Dec> {

--- a/crates/trust/src/filter.rs
+++ b/crates/trust/src/filter.rs
@@ -1,0 +1,401 @@
+/*
+ * Copyright Concurrent Technologies Corporation 2024
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+use std::cell::Cell;
+use std::cmp::Ordering;
+use std::collections::{BTreeSet, HashMap};
+use std::fmt::{Display, Formatter, Write};
+
+use nom::branch::alt;
+use nom::bytes::complete::tag;
+use nom::character::complete::{space0, space1};
+use nom::combinator::{complete, map, rest};
+use nom::sequence::{separated_pair, tuple};
+use nom::{IResult, Parser};
+use thiserror::Error;
+
+use crate::filter::Dec::*;
+use crate::filter::Meta::LineNumber;
+
+/// Internal API
+#[derive(Copy, Clone, Debug, Default, Eq, PartialEq)]
+enum Dec {
+    #[default]
+    Exc,
+    Inc,
+}
+
+impl Display for Dec {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Exc => f.write_str("-"),
+            Inc => f.write_str("+"),
+        }
+    }
+}
+
+/// Internal API
+// bool == allow
+impl From<Dec> for bool {
+    fn from(value: Dec) -> Self {
+        match value {
+            Exc => false,
+            Inc => true,
+        }
+    }
+}
+
+/// Internal API
+type Db<'a> = BTreeSet<Entry<'a>>;
+type MetaDb<'a> = HashMap<&'a str, Metadata>;
+
+/// Internal API
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+struct Entry<'a> {
+    k: &'a str,
+    d: Dec,
+    p: Option<&'a &'a str>,
+}
+
+impl<'a> From<(&'a str, Dec)> for Entry<'a> {
+    fn from((k, d): (&'a str, Dec)) -> Self {
+        Entry { k, d, p: None }
+    }
+}
+
+impl Ord for Entry<'_> {
+    fn cmp(&self, other: &Self) -> Ordering {
+        other.k.cmp(self.k)
+    }
+}
+
+impl PartialOrd for Entry<'_> {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        other.k.partial_cmp(self.k)
+    }
+}
+
+type LineNum = usize;
+
+// This could expand to more properties
+// For now it will stay simple.
+#[derive(Default)]
+struct Metadata(LineNum);
+
+/// Public API
+#[derive(Debug)]
+enum Meta {
+    Unknown,
+    LineNumber(LineNum),
+}
+
+/// Internal API
+#[derive(Default)]
+struct MetaDecider<'a> {
+    db: Decider<'a>,
+    meta: MetaDb<'a>,
+}
+
+impl<'a> MetaDecider<'a> {
+    // allow or deny
+    fn check<T: AsRef<str>>(&self, p: T) -> bool {
+        self.db.check(p)
+    }
+
+    // allow or deny, with meta
+    fn check_ln<T: AsRef<str>>(&self, p: T) -> (bool, Meta) {
+        let m = p.as_ref();
+        let (d, ln) = self
+            .db
+            .0
+            .iter()
+            .find_map(|e| {
+                if m.starts_with(e.k) {
+                    Some((e.d, Some(e.k)))
+                } else {
+                    None
+                }
+            })
+            .unwrap_or((Exc, None));
+
+        let meta = ln
+            .map(|k| self.meta.get(k))
+            .flatten()
+            .map(|x| LineNumber(x.0))
+            .unwrap_or(Meta::Unknown);
+
+        (d.into(), meta)
+    }
+
+    fn add_ln(&mut self, k: &'a str, d: Dec, ln: LineNum) {
+        self.db.0.insert((k, d).into());
+        self.meta.insert(k, Metadata(ln));
+    }
+}
+
+#[derive(Default)]
+struct Decider<'a>(Db<'a>);
+impl<'a> Decider<'a> {
+    fn make(e: (&'a str, Dec)) -> Decider<'a> {
+        let mut db = Db::new();
+        db.insert(e.into());
+        Self(db)
+    }
+
+    // allow or deny
+    fn check<T: AsRef<str>>(&self, p: T) -> bool {
+        let m = p.as_ref();
+        dbg!(&self.0);
+        self.0
+            .iter()
+            .find_map(|e| if m.starts_with(e.k) { Some(e.d) } else { None })
+            .unwrap_or(Exc)
+            .into()
+    }
+
+    fn add(&mut self, k: &'a str, d: Dec) {
+        self.0.insert((k, d).into());
+    }
+}
+
+fn parse<'a>(lines: &[&'a str]) -> Result<Decider<'a>, Error> {
+    let mut decider = Decider::default();
+
+    let mut entries = vec![];
+    for line in lines {
+        entries.push(parse_entry(line)?);
+    }
+
+    let entries: Vec<_> = entries
+        .into_iter()
+        .map(|(i, (k, d))| (i, Entry { k, d, p: None }))
+        .collect();
+
+    let mut last_i = 0;
+    let mut parents: Vec<&'a str> = vec![];
+    for (i, mut e) in entries.iter().by_ref() {
+        if *i == last_i {
+            e.p = parents.last();
+        } else {
+            let x = parents.last();
+        }
+    }
+
+    // let mut es = vec![];
+    // let mut p = None;
+    // let mut i = 0;
+    // for (ii, (k, d)) in entries {
+    //     let e = Entry { k, d, p };
+    //     es.push(e);
+    // }
+    //
+    // let mut v = vec![];
+    // let mut l = None;
+    // for i in 0..10 {
+    //     l = v.last();
+    //     v.push(i);
+    // }
+
+    Ok(decider)
+}
+
+fn parse_meta<'a>(lines: &[&'a str]) -> Result<MetaDecider<'a>, Error> {
+    let mut decider = MetaDecider::default();
+    for (i, line) in lines.iter().enumerate() {
+        parse_entry(line).map(|(_, (k, d))| decider.add_ln(k, d, i))?;
+    }
+    Ok(decider)
+}
+
+#[derive(Error, Debug)]
+enum Error {
+    #[error("Malformed Dec decl")]
+    MalformedDec,
+}
+
+fn parse_dec(i: &str) -> IResult<&str, Dec> {
+    alt((map(tag("+"), |_| Inc), map(tag("-"), |_| Exc)))(i)
+}
+
+fn parse_entry(i: &str) -> Result<(usize, (&str, Dec)), Error> {
+    complete(tuple((
+        map(space0, |s: &str| s.len()),
+        separated_pair(parse_dec, space1, rest),
+    )))(i)
+    .map(|(_, (indent, (d, p)))| (indent, (p, d)))
+    .map_err(|_| Error::MalformedDec)
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::filter::Dec::*;
+    use crate::filter::Meta::*;
+    use crate::filter::{parse, parse_entry, parse_meta, Decider, Error, MetaDecider};
+    use assert_matches::assert_matches;
+
+    #[test]
+    fn test_parser() -> Result<(), Error> {
+        let (i, (k, d)) = parse_entry("          + foo")?;
+        println!("{i} -> {d} {k}");
+        Ok(())
+    }
+
+    #[test]
+    fn test_nested() -> Result<(), Error> {
+        let d = parse(&["+ /", "- /foo/bar", "+ /foo/bar/baz"])?;
+        assert!(d.check("/"));
+        assert!(d.check("/foo"));
+        assert!(!d.check("/foo/bar"));
+        assert!(!d.check("/foo/bar/biz"));
+        assert!(d.check("/foo/bar/baz"));
+        Ok(())
+    }
+
+    #[test]
+    fn test_multi() -> Result<(), Error> {
+        let d = parse(&["+ /", "- /foo"])?;
+        assert!(d.check("/"));
+        assert!(!d.check("/foo"));
+        Ok(())
+    }
+
+    #[test]
+    fn test_multi_meta() -> Result<(), Error> {
+        let d = parse_meta(&["+ /", "- /foo"])?;
+        assert!(d.check("/"));
+        assert!(!d.check("/foo"));
+        assert_matches!(d.check_ln("/"), (true, LineNumber(0)));
+        assert_matches!(d.check_ln("/foo"), (false, LineNumber(1)));
+        Ok(())
+    }
+
+    #[test]
+    fn test_parse() -> Result<(), Error> {
+        let d = parse(&["+ /"])?;
+        assert!(d.check("/"));
+        assert!(d.check("/foo"));
+
+        let d = parse(&["+ /foo"])?;
+        assert!(!d.check("/"));
+        assert!(d.check("/foo"));
+        Ok(())
+    }
+
+    #[test]
+    fn test_next() {
+        let d = Decider::make(("/", Inc));
+        assert!(d.check("/"));
+        assert!(d.check("/foo"));
+
+        let d = Decider::make(("/foo", Inc));
+        assert!(!d.check("/"));
+        assert!(d.check("/foo"));
+    }
+
+    // an empty decider should deny everything
+    #[test]
+    fn test_frist() {
+        let d = Decider::default();
+        assert!(!d.check("/"));
+        assert!(!d.check("/foo"));
+    }
+
+    #[test]
+    fn test_frist_meta() {
+        // the plain old check should work
+        let d = MetaDecider::default();
+        assert!(!d.check("/"));
+        assert!(!d.check("/foo"));
+
+        // the meta check would return unknown on empty decider
+        assert_matches!(d.check_ln("/"), (false, Unknown))
+    }
+}
+
+// .nf
+// .B # this is simple allow list
+// .B - /usr/bin/some_binary1
+// .B - /usr/bin/some_binary2
+// .B + /
+// .fi
+//
+// .nf
+// .B # this is the same
+// .B + /
+// .B \ + usr/bin/
+// .B \ \ - some_binary1
+// .B \ \ - some_binary2
+// .fi
+//
+// .nf
+// .B # this is similar allow list with a wildcard
+// .B - /usr/bin/some_binary?
+// .B + /
+// .fi
+//
+// .nf
+// .B # this is similar with another wildcard
+// .B + /
+// .B \ - usr/bin/some_binary*
+// .fi
+//
+// .nf
+// .B # keeps everything except usr/share except python and perl files
+// .B # /usr/bin/ls - result is '+'
+// .B # /usr/share/something - result is '-'
+// .B # /usr/share/abcd.py - result is '+'
+// .B + /
+// .B \ - usr/share/
+// .B \ \ + *.py
+// .B \ \ + *.pl
+// .fi
+//
+//----------
+//
+// # default filter file for fedora
+//
+// + /
+//  - usr/include/
+//  - usr/share/
+//   # Python byte code
+//   + *.py?
+//   # Python text files
+//   + *.py
+//   # Some apps have a private libexec
+//   + */libexec/*
+//   # Ruby
+//   + *.rb
+//   # Perl
+//   + *.pl
+//   # System tap
+//   + *.stp
+//   # Javascript
+//   + *.js
+//   # Java archive
+//   + *.jar
+//   # M4
+//   + *.m4
+//   # PHP
+//   + *.php
+//   # Perl Modules
+//   + *.pm
+//   # Lua
+//   + *.lua
+//   # Java
+//   + *.class
+//   # Typescript
+//   + *.ts
+//   # Typescript JSX
+//   + *.tsx
+//   # Lisp
+//   + *.el
+//   # Compiled Lisp
+//   + *.elc
+//  - usr/src/kernel*/
+//   + */scripts/*
+//   + */tools/objtool/*

--- a/crates/trust/src/lib.rs
+++ b/crates/trust/src/lib.rs
@@ -19,4 +19,5 @@ pub mod check;
 pub mod filter;
 pub mod load;
 pub mod read;
+mod test_trie;
 pub mod write;

--- a/crates/trust/src/lib.rs
+++ b/crates/trust/src/lib.rs
@@ -16,6 +16,7 @@ pub use trust::Trust;
 pub mod parse;
 
 pub mod check;
+pub mod filter;
 pub mod load;
 pub mod read;
 pub mod write;

--- a/crates/trust/src/lib.rs
+++ b/crates/trust/src/lib.rs
@@ -19,5 +19,4 @@ pub mod check;
 pub mod filter;
 pub mod load;
 pub mod read;
-mod test_trie;
 pub mod write;

--- a/crates/util/src/lib.rs
+++ b/crates/util/src/lib.rs
@@ -8,3 +8,4 @@
 
 pub mod rpm;
 pub mod sha;
+pub mod trimto;

--- a/crates/util/src/trimto.rs
+++ b/crates/util/src/trimto.rs
@@ -14,7 +14,7 @@ pub trait TrimTo {
 impl<T: AsRef<str>> TrimTo for T {
     fn trim_to(&self, marker: char) -> String {
         let mut lines = vec![];
-        for line in self.as_ref().split("\n") {
+        for line in self.as_ref().split('\n') {
             if let Some((_, s)) = line.split_once(marker) {
                 lines.push(s)
             } else {
@@ -40,7 +40,7 @@ mod tests {
 
     #[test]
     fn multiline() {
-        assert_eq!("1|a\n2|b\n3|c".trim_to('|').replace("\n", ""), "abc");
-        assert_eq!("|a\n|b\n|c".trim_to('|').replace("\n", ""), "abc");
+        assert_eq!("1|a\n2|b\n3|c".trim_to('|').replace('\n', ""), "abc");
+        assert_eq!("|a\n|b\n|c".trim_to('|').replace('\n', ""), "abc");
     }
 }

--- a/crates/util/src/trimto.rs
+++ b/crates/util/src/trimto.rs
@@ -1,0 +1,46 @@
+/*
+ * Copyright Concurrent Technologies Corporation 2024
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+/// Like the Scala stripMargin function
+pub trait TrimTo {
+    fn trim_to(&self, marker: char) -> String;
+}
+
+impl<T: AsRef<str>> TrimTo for T {
+    fn trim_to(&self, marker: char) -> String {
+        let mut lines = vec![];
+        for line in self.as_ref().split("\n") {
+            if let Some((_, s)) = line.split_once(marker) {
+                lines.push(s)
+            } else {
+                lines.push(line)
+            }
+        }
+        lines.join("\n")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::trimto::TrimTo;
+
+    #[test]
+    fn simple() {
+        assert_eq!("  |x".trim_to('|'), "x");
+        assert_eq!("|x".trim_to('|'), "x");
+        assert_eq!("x".trim_to('|'), "x");
+        assert_eq!("-|x".trim_to('|'), "x");
+        assert_eq!("fe fi fo|x".trim_to('|'), "x");
+    }
+
+    #[test]
+    fn multiline() {
+        assert_eq!("1|a\n2|b\n3|c".trim_to('|').replace("\n", ""), "abc");
+        assert_eq!("|a\n|b\n|c".trim_to('|').replace("\n", ""), "abc");
+    }
+}

--- a/news/1012.added.md
+++ b/news/1012.added.md
@@ -1,0 +1,1 @@
+Added fapolicyd package filter config parser and analyzer.


### PR DESCRIPTION
Adds a parser and evaluator for the fapolicyd filter config

The public api here is not integrated into the system in this PR. A later commit will integrate it as the backend of the editor.

The evaluation function implemented here can be used to enhance the analysis view by tying a trust decision back to a line from rpm filter, similar to how rules are referenced. A difference between rules and trust here is that the trust relation may not exist, where the rule relation always exists.

The impl uses a trie to map characterwise for searching. The impl supports the same wildcard characters as the fapolicyd impl.  There is decent test coverage, but likely more corner cases. Configurations from the wild, mapped into tests, would be useful.  The examples from the fapolicyd man pages are mapped to tests.

#758