### PR TITLE
Update eval parameter passing during formatting

### DIFF
--- a/fapolicy_analyzer/tests/test_format.py
+++ b/fapolicy_analyzer/tests/test_format.py
@@ -13,8 +13,10 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+import fapolicy_analyzer
 from fapolicy_analyzer.util.format import f, snake_to_camelcase
 
+import pytest
 import context  # noqa: F401
 
 
@@ -41,3 +43,16 @@ def test_f():
 
 def test_f_none():
     assert f(None) is None
+
+@pytest.mark.parametrize("version, f_in, eval_out",[((3,9), "foo", "insert is foo"),
+                                                  ((3,12), "bar", "insert is bar"),
+                                                  ((3,13), "baz", "insert is baz")])
+def test_f_supported_py_vers(version, f_in, eval_out, mocker):
+    insert = f_in
+    mockEval = mocker.patch('builtins.eval', return_value=f"insert is {insert}")
+    mockSysVer = mocker.patch.object(fapolicy_analyzer.util.format, "sys")
+    mockSysVer.version_info = version
+
+    assert f(None) is None
+    assert f(f"insert is {insert}") == eval_out
+    assert mockEval.called

--- a/fapolicy_analyzer/tests/test_format.py
+++ b/fapolicy_analyzer/tests/test_format.py
@@ -44,15 +44,28 @@ def test_f():
 def test_f_none():
     assert f(None) is None
 
-@pytest.mark.parametrize("version, f_in, eval_out",[((3,9), "foo", "insert is foo"),
+@pytest.mark.parametrize("py_ver, f_in, eval_out",[((3,9), "foo", "insert is foo"),
                                                   ((3,12), "bar", "insert is bar"),
                                                   ((3,13), "baz", "insert is baz")])
-def test_f_supported_py_vers(version, f_in, eval_out, mocker):
+def test_f_supported_py_vers(py_ver, f_in, eval_out, mocker):
     insert = f_in
     mockEval = mocker.patch('builtins.eval', return_value=f"insert is {insert}")
     mockSysVer = mocker.patch.object(fapolicy_analyzer.util.format, "sys")
-    mockSysVer.version_info = version
+    mockSysVer.version_info = py_ver
 
     assert f(None) is None
     assert f(f"insert is {insert}") == eval_out
-    assert mockEval.called
+
+    # Check if keyword args were in eval()'s call
+    assert mockEval.called_once
+    tupleEvalArgs = mockEval.call_args
+
+    if py_ver < (3, 13):
+        # Py <3.13 only uses positional args, Kwargs dict should be empty
+        assert not tupleEvalArgs.kwargs
+
+    else:
+        # Py 3.13 call uses kw args in our code
+        assert tupleEvalArgs.kwargs
+        assert "locals" in tupleEvalArgs.kwargs
+        assert "globals" in tupleEvalArgs.kwargs

--- a/fapolicy_analyzer/tests/test_format.py
+++ b/fapolicy_analyzer/tests/test_format.py
@@ -57,7 +57,7 @@ def test_f_supported_py_vers(py_ver, f_in, eval_out, mocker):
     assert f(f"insert is {insert}") == eval_out
 
     # Check if keyword args were in eval()'s call
-    assert mockEval.called_once
+    assert mockEval.called
     tupleEvalArgs = mockEval.call_args
 
     if py_ver < (3, 13):

--- a/fapolicy_analyzer/util/format.py
+++ b/fapolicy_analyzer/util/format.py
@@ -22,11 +22,12 @@ def f(formatString):
     frame = currentframe().f_back
 
     if formatString:
-        if sys.version_info < (3, 11):
+        if sys.version_info < (3, 13):
             formatString = eval(f'f"""{formatString}"""', frame.f_locals,
                                 frame.f_globals)
         else:
-            formatString = eval(f'f"""{formatString}"""', locals=frame.f_locals,
+            formatString = eval(f'f"""{formatString}"""',
+                                locals=frame.f_locals,
                                 globals=frame.f_globals)
     return formatString
 

--- a/fapolicy_analyzer/util/format.py
+++ b/fapolicy_analyzer/util/format.py
@@ -14,16 +14,21 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import re
+import sys
 from inspect import currentframe
 
 
 def f(formatString):
     frame = currentframe().f_back
-    return (
-        eval(f'f"""{formatString}"""', locals=frame.f_locals, globals=frame.f_globals)
-        if formatString
-        else formatString
-    )
+
+    if formatString:
+        if sys.version_info < (3, 11):
+            formatString = eval(f'f"""{formatString}"""', frame.f_locals,
+                                frame.f_globals)
+        else:
+            formatString = eval(f'f"""{formatString}"""', locals=frame.f_locals,
+                                globals=frame.f_globals)
+    return formatString
 
 
 def snake_to_camelcase(string):

--- a/fapolicy_analyzer/util/format.py
+++ b/fapolicy_analyzer/util/format.py
@@ -20,7 +20,7 @@ from inspect import currentframe
 def f(formatString):
     frame = currentframe().f_back
     return (
-        eval(f'f"""{formatString}"""', frame.f_locals, frame.f_globals)
+        eval(f'f"""{formatString}"""', locals=frame.f_locals, globals=frame.f_globals)
         if formatString
         else formatString
     )

--- a/news/1022.fixed.md
+++ b/news/1022.fixed.md
@@ -1,0 +1,1 @@
+Address new Py 3.13 eval() parameter list while still supporting RHEL9 Py 3.9


### PR DESCRIPTION
Portable eval call during formatting

The eval() built-in functions API is evolving in 3.13. This change uses a version check to add support for 3.13 while keeping support back to 3.9.

Closes #1019