### PR TITLE
Fix trust filter syntax reporting

### DIFF
--- a/crates/daemon/src/conf/read.rs
+++ b/crates/daemon/src/conf/read.rs
@@ -17,8 +17,8 @@ fn lines_in_file(path: PathBuf) -> Result<Vec<String>, Error> {
     let reader = File::open(path)
         .map(BufReader::new)
         .map_err(|_| Error::General)?;
-    let lines = reader.lines().flatten().collect();
-    Ok(lines)
+    let lines: Vec<_> = reader.lines().collect();
+    Ok(lines.into_iter().flatten().collect())
 }
 
 pub fn file(path: PathBuf) -> Result<DB, Error> {

--- a/crates/pyo3/src/trust.rs
+++ b/crates/pyo3/src/trust.rs
@@ -239,7 +239,7 @@ pub(crate) fn filter_info(db: &filter::DB) -> Vec<PyFilterInfo> {
             Line::Invalid(s) => Some((e, format!("Invalid: {s}"))),
             Line::Malformed(s) => Some((e, format!("Malformed: {s}"))),
             Line::Duplicate(s) => Some((e, format!("Duplicated: {s}"))),
-            Line::ValidWithWarning(_, m) => Some((w, format!("{m}"))),
+            Line::ValidWithWarning(_, m) => Some((w, m.to_owned())),
             _ => None,
         };
         if let Some((category, message)) = info {

--- a/crates/pyo3/src/trust.rs
+++ b/crates/pyo3/src/trust.rs
@@ -233,16 +233,18 @@ impl PyFilterInfo {
 
 pub(crate) fn filter_info(db: &filter::DB) -> Vec<PyFilterInfo> {
     let e = "e";
+    let w = "w";
     db.iter().fold(vec![], |mut acc, line| {
-        let message = match line {
-            Line::Invalid(s) => Some(format!("Invalid: {s}")),
-            Line::Malformed(s) => Some(format!("Malformed: {s}")),
-            Line::Duplicate(s) => Some(format!("Duplicated: {s}")),
+        let info = match line {
+            Line::Invalid(s) => Some((e, format!("Invalid: {s}"))),
+            Line::Malformed(s) => Some((e, format!("Malformed: {s}"))),
+            Line::Duplicate(s) => Some((e, format!("Duplicated: {s}"))),
+            Line::ValidWithWarning(_, m) => Some((w, format!("{m}"))),
             _ => None,
         };
-        if let Some(message) = message {
+        if let Some((category, message)) = info {
             acc.push(PyFilterInfo {
-                category: e.to_owned(),
+                category: category.to_owned(),
                 message,
             });
         };

--- a/crates/trust/src/filter/db.rs
+++ b/crates/trust/src/filter/db.rs
@@ -11,6 +11,7 @@ use std::slice::Iter;
 #[derive(Clone, Debug)]
 pub enum Line {
     Valid(String),
+    ValidWithWarning(String, String),
     Invalid(String),
     Malformed(String),
     Duplicate(String),
@@ -52,7 +53,7 @@ impl Display for Line {
         use Line::*;
 
         match self {
-            Valid(tok) => f.write_fmt(format_args!("{tok}")),
+            Valid(tok) | ValidWithWarning(tok, _) => f.write_fmt(format_args!("{tok}")),
             Invalid(tok) => f.write_fmt(format_args!("{tok}")),
             Malformed(txt) => f.write_str(txt),
             Duplicate(tok) => f.write_fmt(format_args!("{tok}")),

--- a/crates/trust/src/filter/parse.rs
+++ b/crates/trust/src/filter/parse.rs
@@ -206,7 +206,7 @@ pub fn decider(lines: &[&str]) -> Result<Decider, Error> {
     Ok(decider)
 }
 
-/// Parse a Decider from the conf lines
+/// Parse a Line from the conf lines
 pub fn lines(input: Vec<String>) -> Vec<Line> {
     let mut lines = vec![];
 
@@ -214,7 +214,7 @@ pub fn lines(input: Vec<String>) -> Vec<Line> {
     let mut stack = vec![];
 
     // process lines from the config, ignoring comments and empty lines
-    for (ln, line) in input.iter().enumerate() {
+    for (_, line) in input.iter().enumerate() {
         if line.trim_start().starts_with('#') {
             lines.push(Line::Comment(line.to_string()))
         } else if line.is_empty() {

--- a/crates/trust/src/filter/parse.rs
+++ b/crates/trust/src/filter/parse.rs
@@ -206,7 +206,7 @@ pub fn decider(lines: &[&str]) -> Result<Decider, Error> {
     Ok(decider)
 }
 
-/// Parse a Line from the conf lines
+/// Parse Lines entries from the conf lines
 pub fn lines(input: Vec<String>) -> Vec<Line> {
     let mut lines = vec![];
 
@@ -238,10 +238,18 @@ pub fn lines(input: Vec<String>) -> Vec<Line> {
                 (None, Ok((_, (_, _)))) => {
                     lines.push(Line::Invalid("TooManyStartIndents".to_owned()))
                 }
-                // handle an indentation
+                // handle indentation
                 (Some(pi), Ok((i, (k, _)))) if i > pi => {
+                    let entry = if i - pi == 1 {
+                        Line::Valid(line.to_string())
+                    } else {
+                        Line::ValidWithWarning(
+                            line.to_string(),
+                            format!("Excessive indent, {} spaces", i - pi - 1),
+                        )
+                    };
                     let p = stack.last().map(|l| l.join(k)).unwrap();
-                    lines.push(Line::Valid(line.to_string()));
+                    lines.push(entry);
                     stack.push(p);
                     prev_i = Some(i);
                 }

--- a/crates/trust/src/filter/read.rs
+++ b/crates/trust/src/filter/read.rs
@@ -7,7 +7,7 @@
  */
 
 use crate::filter::error::Error;
-use crate::filter::{Line, DB};
+use crate::filter::{parse, DB};
 use std::fs::File;
 use std::io::{BufRead, BufReader};
 
@@ -15,7 +15,8 @@ pub fn file(path: &str) -> Result<DB, Error> {
     let reader = File::open(path)
         .map(BufReader::new)
         .map_err(|_| Error::General("Parse file".to_owned()))?;
-    lines(reader.lines().flatten().collect())
+    let r: Vec<_> = reader.lines().collect();
+    lines(r.into_iter().flatten().collect())
 }
 
 pub fn mem(txt: &str) -> Result<DB, Error> {
@@ -23,24 +24,5 @@ pub fn mem(txt: &str) -> Result<DB, Error> {
 }
 
 fn lines(src: Vec<String>) -> Result<DB, Error> {
-    let mut lines = vec![];
-    let mut skip_blank = true;
-
-    for s in src {
-        let s = s.trim_end();
-        if s.is_empty() {
-            if skip_blank {
-                continue;
-            }
-            lines.push(Line::BlankLine);
-            skip_blank = true;
-        } else if s.trim_start().starts_with('#') {
-            lines.push(Line::Comment(s.to_string()));
-            skip_blank = false;
-        } else {
-            lines.push(Line::Valid(s.to_owned()));
-            skip_blank = false;
-        }
-    }
-    Ok(lines.into())
+    Ok(parse::lines(src).into())
 }


### PR DESCRIPTION
Connect trust filter syntax checks to the info GUI

This also adds a lint warning for too many indents.

Closes #1018 