### PR TITLE
Release 1.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,23 @@ Release notes
 
 <!-- towncrier release notes start -->
 
+## [v1.4.0](https://github.com/ctc-oss/fapolicy-analyzer/releases/tag/v1.4.0) - 2024-07-28
+
+
+### Added
+
+- Added fapolicyd package filter config parser and analyzer. ([#1012](https://github.com/ctc-oss/fapolicy-analyzer/pull/1012))
+- Added fapolicyd package filter config editor GUI. ([#1014](https://github.com/ctc-oss/fapolicy-analyzer/pull/1014))
+
+### Fixed
+
+- Address new Py 3.13 eval() parameter list while still supporting RHEL9 Py 3.9 ([#1022](https://github.com/ctc-oss/fapolicy-analyzer/pull/1022))
+
+### Packaging
+
+- Supporting Fedora 41, 40, 39, dropped support for 38. ([#1016](https://github.com/ctc-oss/fapolicy-analyzer/pull/1016))
+
+
 ## [v1.3.0](https://github.com/ctc-oss/fapolicy-analyzer/releases/tag/v1.3.0) - 2024-02-11
 
 

--- a/fapolicy-analyzer.spec
+++ b/fapolicy-analyzer.spec
@@ -2,7 +2,7 @@
 
 Summary:       File Access Policy Analyzer
 Name:          fapolicy-analyzer
-Version:       1.3.0
+Version:       1.4.0
 Release:       1%{?dist}
 
 SourceLicense: GPL-3.0-or-later
@@ -132,5 +132,5 @@ desktop-file-validate %{buildroot}/%{_datadir}/applications/%{name}.desktop
 %ghost %attr(640,root,root) %verify(not md5 size mtime) %{_localstatedir}/log/%{name}/%{name}.log
 
 %changelog
-* Sat Feb 03 2024 John Wass <jwass3@gmail.com> 1.3.0-1
+* Sun Jul 28 2024 John Wass <jwass3@gmail.com> 1.4.0-1
 - New release

--- a/news/1012.added.md
+++ b/news/1012.added.md
@@ -1,1 +1,0 @@
-Added fapolicyd package filter config parser and analyzer.

--- a/news/1014.added.md
+++ b/news/1014.added.md
@@ -1,1 +1,0 @@
-Added fapolicyd package filter config editor GUI.

--- a/news/1016.packaging.md
+++ b/news/1016.packaging.md
@@ -1,1 +1,0 @@
-Supporting Fedora 41, 40, 39, dropped support for 38.

--- a/news/1022.fixed.md
+++ b/news/1022.fixed.md
@@ -1,1 +1,0 @@
-Address new Py 3.13 eval() parameter list while still supporting RHEL9 Py 3.9

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ ignore = ["E402"]
 
 [tool.towncrier]
 filename = "CHANGELOG.md"
-version = "1.3.0"
+version = "1.4.0"
 start_string = "<!-- towncrier release notes start -->\n"
 title_format = "## [v{version}](https://github.com/ctc-oss/fapolicy-analyzer/releases/tag/v{version}) - {project_date}"
 issue_format = "[#{issue}](https://github.com/ctc-oss/fapolicy-analyzer/pull/{issue})"

--- a/scripts/srpm/fapolicy-analyzer.el9.spec
+++ b/scripts/srpm/fapolicy-analyzer.el9.spec
@@ -1,6 +1,6 @@
 Summary:       File Access Policy Analyzer
 Name:          fapolicy-analyzer
-Version:       1.3.0
+Version:       1.4.0
 Release:       1%{?dist}
 License:       GPL-3.0-or-later
 URL:           https://github.com/ctc-oss/fapolicy-analyzer
@@ -219,5 +219,5 @@ desktop-file-validate %{buildroot}/%{_datadir}/applications/%{name}.desktop
 %attr(755,root,root) %{_datadir}/applications/%{name}.desktop
 
 %changelog
-* Sat Feb 03 2024 John Wass <jwass3@gmail.com> 1.3.0-1
+* Sun Jul 28 2024 John Wass <jwass3@gmail.com> 1.4.0-1
 - New release


### PR DESCRIPTION
## [v1.4.0](https://github.com/ctc-oss/fapolicy-analyzer/releases/tag/v1.4.0) - 2024-07-28


### Added

- Added fapolicyd package filter config parser and analyzer. ([#1012](https://github.com/ctc-oss/fapolicy-analyzer/pull/1012))
- Added fapolicyd package filter config editor GUI. ([#1014](https://github.com/ctc-oss/fapolicy-analyzer/pull/1014))

### Fixed

- Address new Py 3.13 eval() parameter list while still supporting RHEL9 Py 3.9 ([#1022](https://github.com/ctc-oss/fapolicy-analyzer/pull/1022))

### Packaging

- Supporting Fedora 41, 40, 39, dropped support for 38. ([#1016](https://github.com/ctc-oss/fapolicy-analyzer/pull/1016))
