### PR TITLE
Add profiler to build

### DIFF
--- a/crates/tools/Cargo.toml
+++ b/crates/tools/Cargo.toml
@@ -27,3 +27,8 @@ fapolicy-daemon = { path = "../daemon" }
 fapolicy-rules = { path = "../rules" }
 fapolicy-trust = { path = "../trust" }
 fapolicy-util = { path = "../util" }
+
+
+[features]
+default = []
+deb = []

--- a/crates/tools/src/trust_db_util.rs
+++ b/crates/tools/src/trust_db_util.rs
@@ -423,10 +423,10 @@ const DPKG_QUERY_HEADER_LINES: usize = 6;
 const DPKG_QUERY: &str = "dpkg-query";
 #[cfg(feature = "deb")]
 fn dpkg_trust() -> Result<Vec<Trust>, Error> {
+    use crate::Error::{DpkgCommandFail, DpkgNotFound};
     use fapolicy_trust::load::keep_entry;
     use rayon::prelude::*;
     use std::process::Command;
-    use crate::Error::{DpkgCommandFail, DpkgNotFound};
 
     // check that dpkg-query exists and can be called
     let _exists = Command::new(DPKG_QUERY)

--- a/fapolicy-analyzer.spec
+++ b/fapolicy-analyzer.spec
@@ -141,7 +141,8 @@ export RUSTFLAGS="%{build_rustflags}"
 %install
 
 %if %{with cli}
-install -D target/release/tdb %{buildroot}/%{_sbindir}/%{name}-trust
+install -D target/release/tdb %{buildroot}/%{_sbindir}/%{name}-cli-trust
+install -D target/release/faprofiler %{buildroot}/%{_sbindir}/%{name}-cli-profiler
 %endif
 
 %if %{with gui}
@@ -161,7 +162,8 @@ desktop-file-validate %{buildroot}/%{_datadir}/applications/%{name}.desktop
 %endif
 
 %files cli
-%attr(755,root,root) %{_sbindir}/%{name}-trust
+%attr(755,root,root) %{_sbindir}/%{name}-cli-trust
+%attr(755,root,root) %{_sbindir}/%{name}-cli-profiler
 
 %files gui
 %{python3_sitearch}/%{module}

--- a/fapolicy-analyzer.spec
+++ b/fapolicy-analyzer.spec
@@ -124,6 +124,7 @@ echo "audit" > FEATURES
 
 %if %{with cli}
 cargo build --bin tdb --release
+cargo build --bin faprofiler --release
 %endif
 
 %if %{with gui}

--- a/news/1040.added.md
+++ b/news/1040.added.md
@@ -1,0 +1,1 @@
+Include the command line based fapolicy profile tool in the CLI RPM distribution.

--- a/scripts/srpm/fapolicy-analyzer.el9.spec
+++ b/scripts/srpm/fapolicy-analyzer.el9.spec
@@ -218,6 +218,7 @@ export RUSTFLAGS="%{build_rustflags}"
 
 %if %{with cli}
 cargo build --bin tdb --release
+cargo build --bin faprofiler --release
 %endif
 
 %if %{with gui}

--- a/scripts/srpm/fapolicy-analyzer.el9.spec
+++ b/scripts/srpm/fapolicy-analyzer.el9.spec
@@ -230,7 +230,8 @@ cargo build --bin tdb --release
 %install
 
 %if %{with cli}
-install -D target/release/tdb %{buildroot}/%{_sbindir}/%{name}-trust
+install -D target/release/tdb %{buildroot}/%{_sbindir}/%{name}-cli-trust
+install -D target/release/faprofiler %{buildroot}/%{_sbindir}/%{name}-cli-profiler
 %endif
 
 %if %{with gui}
@@ -249,7 +250,8 @@ desktop-file-validate %{buildroot}/%{_datadir}/applications/%{name}.desktop
 %endif
 
 %files cli
-%attr(755,root,root) %{_sbindir}/%{name}-trust
+%attr(755,root,root) %{_sbindir}/%{name}-cli-trust
+%attr(755,root,root) %{_sbindir}/%{name}-cli-profiler
 
 %files gui
 %{python3_sitearch}/%{module}


### PR DESCRIPTION
Adding the profiler tool to the rpm build.

This adds the "deb" feature to the tools build. This feature is disabled by default and toggles the dpkg support in the trust tool. It can be enabled for development on Debian based environments to get dpkg trust db init support.

#1013
