### PR TITLE
Backwards compat for webkit version

### DIFF
--- a/fapolicy_analyzer/ui/help_browser.py
+++ b/fapolicy_analyzer/ui/help_browser.py
@@ -21,7 +21,11 @@ from urllib.parse import ParseResult, urlparse, urlunparse
 import gi
 
 gi.require_version("Gtk", "3.0")
-gi.require_version("WebKit2", "4.0")
+try:
+    gi.require_version("WebKit2", "4.0")
+except Exception:
+    gi.require_version("WebKit2", "4.1")
+
 from gi.repository import Gtk, WebKit2
 
 

--- a/news/1044.fixed.md
+++ b/news/1044.fixed.md
@@ -1,0 +1,1 @@
+Fixed webkit version selection to support both Fedora and EPEL versions of webkit2.


### PR DESCRIPTION
This is needed due to difference in webkit between Fedora and EPEL.

There is a patch in the RPM repo that was added when this was discovered, that will disappear when the next package is merged.

Closes #1031