### PR TITLE
Disable stats on el9

### DIFF
--- a/crates/pyo3/Cargo.toml
+++ b/crates/pyo3/Cargo.toml
@@ -28,4 +28,5 @@ fapolicy-util = { path = "../util" }
 [features]
 default = []
 audit = []
+stats = []
 xdg = ["fapolicy-app/xdg"]

--- a/crates/pyo3/src/features.rs
+++ b/crates/pyo3/src/features.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright Concurrent Technologies Corporation 2023
+ * Copyright Concurrent Technologies Corporation 2024
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -14,7 +14,14 @@ fn is_audit_available() -> bool {
     cfg!(feature = "audit")
 }
 
+/// Indicates whether performance stats are is available on this platform
+#[pyfunction]
+fn is_stats_available() -> bool {
+    cfg!(feature = "stats")
+}
+
 pub fn init_module(_py: Python, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(is_audit_available, m)?)?;
+    m.add_function(wrap_pyfunction!(is_stats_available, m)?)?;
     Ok(())
 }

--- a/crates/pyo3/src/lib.rs
+++ b/crates/pyo3/src/lib.rs
@@ -10,10 +10,10 @@ use pyo3::prelude::*;
 
 pub mod acl;
 pub mod analysis;
-pub mod auparse;
 pub mod check;
 pub mod config;
 pub mod daemon;
+pub mod features;
 pub mod profiler;
 pub mod rules;
 pub mod system;
@@ -21,12 +21,12 @@ pub mod trust;
 
 #[pymodule]
 fn rust(_py: Python, m: &Bound<'_, PyModule>) -> PyResult<()> {
-    auparse::init_module(_py, m)?;
     acl::init_module(_py, m)?;
     analysis::init_module(_py, m)?;
     check::init_module(_py, m)?;
     config::init_module(_py, m)?;
     daemon::init_module(_py, m)?;
+    features::init_module(_py, m)?;
     profiler::init_module(_py, m)?;
     rules::init_module(_py, m)?;
     system::init_module(_py, m)?;

--- a/fapolicy_analyzer/events/events.py
+++ b/fapolicy_analyzer/events/events.py
@@ -93,7 +93,7 @@ class Events:
             try:
                 for _ in events:
                     break
-            except:
+            except Exception:
                 raise AttributeError("type object %s is not iterable" %
                                      (type(events)))
             else:

--- a/fapolicy_analyzer/ui/main_window.py
+++ b/fapolicy_analyzer/ui/main_window.py
@@ -26,7 +26,7 @@ from typing import Sequence
 import gi
 
 import fapolicy_analyzer.ui.strings as strings
-from fapolicy_analyzer import System, is_audit_available
+from fapolicy_analyzer import System, is_audit_available, is_stats_available
 from fapolicy_analyzer import __version__ as app_version
 from fapolicy_analyzer.ui import get_resource
 from fapolicy_analyzer.ui.action_toolbar import ActionToolbar
@@ -138,6 +138,7 @@ class MainWindow(UIConnectedWidget):
         )
         self.get_object("profileExecMenu").set_sensitive(prof_ui_enable)
         self.get_object("auditlogMenu").set_sensitive(is_audit_available())
+        self.get_object("statsViewMenuItem").set_sensitive(is_stats_available())
 
         self.__add_toolbar()
 

--- a/setup.py
+++ b/setup.py
@@ -37,16 +37,20 @@ def get_version():
     return meta["version"]
 
 
-# comma separated list of features that should be enabled in the rust build
+# features can be defined as a mix of comma and line separated
 def get_features():
     enabling = None
     if "FEATURES" in os.environ:
         enabling = os.getenv("FEATURES")
     if os.path.exists("FEATURES"):
         with open("FEATURES", "r") as features:
-            v = features.readline().strip().split(",")
+            v = set()
+            for l in features.readlines():
+                for f in l.strip().split(","):
+                    if f:
+                        v.add(f)
             if len(v):
-                enabling = v
+                enabling = sorted(list(v))
     print(f"Enabled Rust features: {enabling}")
     return enabling
 


### PR DESCRIPTION
The reporting interval is not available on el9, so the stats view will be generally useless.  Disable with a feature flag.

This consolidates feature flags into a central binding module for clarity.

Closes #1049