### PR TITLE
Add matplotlib to spec files

### DIFF
--- a/.github/rpm-matrix.json
+++ b/.github/rpm-matrix.json
@@ -16,7 +16,7 @@
       "image": "registry.fedoraproject.org/fedora:41",
       "chroot": "fedora-41-x86_64",
       "version": "41",
-      "prerelease": true
+      "prerelease": false
     },
     {
       "platform": "fedora",

--- a/.github/rpm-matrix.json
+++ b/.github/rpm-matrix.json
@@ -28,15 +28,6 @@
       "prerelease": false
     },
     {
-      "platform": "fedora",
-      "dist": "fc39",
-      "spec": "fapolicy-analyzer.spec",
-      "image": "registry.fedoraproject.org/fedora:39",
-      "chroot": "fedora-39-x86_64",
-      "version": "39",
-      "prerelease": false
-    },
-    {
       "platform": "rhel",
       "dist": "el9",
       "spec": "scripts/srpm/fapolicy-analyzer.el9.spec",

--- a/Containerfile
+++ b/Containerfile
@@ -1,4 +1,4 @@
-ARG image=registry.fedoraproject.org/fedora:latest
+ARG image=registry.fedoraproject.org/fedora:41
 FROM $image AS fedorabuild
 ARG version
 ARG spec=fapolicy-analyzer.spec

--- a/Containerfile
+++ b/Containerfile
@@ -15,9 +15,6 @@ WORKDIR /tmp/rpmbuild
 
 COPY --chown=10001:0 $spec SPECS/fapolicy-analyzer.spec
 
-USER root
-RUN dnf -y builddep SPECS/fapolicy-analyzer.spec
-
 USER 10001
 
 COPY --chown=10001:0 fapolicy-analyzer-$version.tar.gz SOURCES/

--- a/Containerfile
+++ b/Containerfile
@@ -1,4 +1,4 @@
-ARG image=registry.fedoraproject.org/fedora:41
+ARG image=registry.fedoraproject.org/fedora:latest
 FROM $image AS fedorabuild
 ARG version
 ARG spec=fapolicy-analyzer.spec

--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,7 @@ RED=\033[0;31m
 NC=\033[0m # No Color
 
 VERSION ?= $(shell sed -n 's/^Version: *//p' fapolicy-analyzer.spec)
+FID     ?= rawhide
 
 # List the common developer targets
 list:
@@ -141,10 +142,10 @@ build-info:
 
 # Generate Fedora rawhide rpms
 fc-rpm:
-	@echo -e "${GRN}--- Fedora RPM generation v${VERSION}...${NC}"
+	@echo -e "${GRN}--- Fedora $(FID) RPM generation v${VERSION}...${NC}"
 	make -f .copr/Makefile vendor OS_ID=fedora VERSION=${VERSION}
 	podman build -t fapolicy-analyzer:build --target fedorabuild --build-arg version=${VERSION} -f Containerfile .
-	podman run --privileged --rm -it -v /tmp:/v fapolicy-analyzer:build fedora-41-x86_64 /v
+	podman run --privileged --rm -it -v /tmp:/v fapolicy-analyzer:build fedora-$(FID)-x86_64 /v
 
 # Generate RHEL 9 rpms
 el9-rpm:

--- a/Makefile
+++ b/Makefile
@@ -144,7 +144,7 @@ fc-rpm:
 	@echo -e "${GRN}--- Fedora RPM generation v${VERSION}...${NC}"
 	make -f .copr/Makefile vendor OS_ID=fedora VERSION=${VERSION}
 	podman build -t fapolicy-analyzer:build --target fedorabuild --build-arg version=${VERSION} -f Containerfile .
-	podman run --privileged --rm -it -v /tmp:/v fapolicy-analyzer:build fedora-39-x86_64 /v
+	podman run --privileged --rm -it -v /tmp:/v fapolicy-analyzer:build fedora-41-x86_64 /v
 
 # Generate RHEL 9 rpms
 el9-rpm:

--- a/fapolicy-analyzer.spec
+++ b/fapolicy-analyzer.spec
@@ -67,6 +67,7 @@ Requires:      python3-more-itertools
 Requires:      python3-rx
 Requires:      python3-importlib-metadata
 Requires:      python3-toml
+Requires:      python3-matplotlib-gtk3
 
 Requires:      gtk3
 Requires:      gtksourceview3

--- a/scripts/srpm/fapolicy-analyzer.el9.spec
+++ b/scripts/srpm/fapolicy-analyzer.el9.spec
@@ -140,6 +140,7 @@ Requires:      python3-more-itertools
 Requires:      python3-rx
 Requires:      python3-importlib-metadata
 Requires:      python3-toml
+Requires:      python3-matplotlib-gtk3
 
 Requires:      gtk3
 Requires:      gtksourceview3


### PR DESCRIPTION
Adds matplotlib for gtk3 as a requirement.

Also updates
- Makefile target for fc by adding a version arg for convenience
- moves fc41 out of pre-release state
- removes unnecessary spectool install from Containerfile