### PR TITLE
Python feature flag compat

### DIFF
--- a/.github/rpm-matrix.json
+++ b/.github/rpm-matrix.json
@@ -2,15 +2,6 @@
   "props": [
     {
       "platform": "fedora",
-      "dist": "fc42",
-      "spec": "fapolicy-analyzer.spec",
-      "image": "registry.fedoraproject.org/fedora:42",
-      "chroot": "fedora-rawhide-x86_64",
-      "version": "42",
-      "prerelease": true
-    },
-    {
-      "platform": "fedora",
       "dist": "fc41",
       "spec": "fapolicy-analyzer.spec",
       "image": "registry.fedoraproject.org/fedora:41",

--- a/fapolicy_analyzer/ui/__init__.py
+++ b/fapolicy_analyzer/ui/__init__.py
@@ -21,7 +21,7 @@ import sys
 from typing import Dict, Optional, Sequence, Tuple
 
 import gi
-import pkg_resources
+
 from fapolicy_analyzer.ui.strings import (
     RESOURCE_LOAD_FAILURE_DIALOG_ADD_TEXT,
     RESOURCE_LOAD_FAILURE_DIALOG_TEXT,
@@ -37,8 +37,8 @@ from gi.repository import Gtk  # isort: skip
 
 DOMAIN = "fapolicy_analyzer"
 locale.setlocale(locale.LC_ALL, locale.getlocale())
-locale_path = pkg_resources.resource_filename("fapolicy_analyzer", "locale")
-locale.bindtextdomain(DOMAIN, locale_path)
+locale_path = resources.path("fapolicy_analyzer", "locale")
+locale.bindtextdomain(DOMAIN, str(locale_path))
 locale.textdomain(DOMAIN)
 
 _RESOURCES: Dict[str, str] = {}

--- a/fapolicy_analyzer/ui/main_window.py
+++ b/fapolicy_analyzer/ui/main_window.py
@@ -16,7 +16,7 @@
 import logging
 import os
 import json
-from fapolicy_analyzer.ui.stats import StatsViewPage
+
 from locale import gettext as _
 from os import getenv, geteuid, path
 from threading import Thread
@@ -27,6 +27,10 @@ import gi
 
 import fapolicy_analyzer.ui.strings as strings
 from fapolicy_analyzer import System, is_audit_available, is_stats_available
+
+if is_stats_available():
+   from fapolicy_analyzer.ui.stats import StatsViewPage
+
 from fapolicy_analyzer import __version__ as app_version
 from fapolicy_analyzer.ui import get_resource
 from fapolicy_analyzer.ui.action_toolbar import ActionToolbar
@@ -82,8 +86,10 @@ def router(page: PAGE_SELECTION, *data) -> UIPage:
         PAGE_SELECTION.PROFILER: ProfilerPage,
         PAGE_SELECTION.CONFIG: ConfigAdminPage,
         PAGE_SELECTION.TRUST_FILTER: TrustFilterAdminPage,
-        PAGE_SELECTION.STATS_VIEW: StatsViewPage,
-    }.get(page, RulesAdminPage)
+    }
+    if is_stats_available():
+        route[PAGE_SELECTION.STATS_VIEW] = StatsViewPage
+    route = route.get(page, route)
     return route(*data)
 
 

--- a/scripts/srpm/fapolicy-analyzer.el9.spec
+++ b/scripts/srpm/fapolicy-analyzer.el9.spec
@@ -139,7 +139,6 @@ Requires:      python3-more-itertools
 Requires:      python3-rx
 Requires:      python3-importlib-metadata
 Requires:      python3-toml
-Requires:      python3-matplotlib-gtk3
 
 Requires:      gtk3
 Requires:      gtksourceview3


### PR DESCRIPTION
Some checks to ensure all platforms load with stats feature flag

- remove use of deprecated pkg_resources
- check stats enabled before loading the StatsViewPage and route
- remove matplotlib from el9 spec