### PR TITLE
Release v1.5.0

### DIFF
--- a/.github/workflows/rpm.yml
+++ b/.github/workflows/rpm.yml
@@ -454,9 +454,11 @@ jobs:
           tag_name: ${{ steps.tag_name.outputs.VERSION }}
           prerelease: ${{ startsWith(github.ref, 'refs/tags/v0') || contains(github.ref, 'rc') }}
           draft: true
+          # the tarball-artifacts are only published from el9 to prevent duplicates and capture vendor-rs
+          # el9 is also beneficial because it is always present, unlike the fc versions that are evolving
           files: |
             fapolicy-analyzer.spec
             /tmp/archives/source0/*.tar.gz
             /tmp/archives/rpm-artifacts-*/*.rpm
             /tmp/archives/srpm-artifacts-*/*.src.rpm
-            /tmp/archives/tarball-artifacts-*/*.tar.gz
+            /tmp/archives/tarball-artifacts-el9/*.tar.gz

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,26 @@ Release notes
 
 <!-- towncrier release notes start -->
 
+## [v1.5.0](https://github.com/ctc-oss/fapolicy-analyzer/releases/tag/v1.5.0) - 2024-12-31
+
+### Added
+
+- Include the command line based fapolicy Trust DB admin tool in the CLI RPM distribution. ([#1025](https://github.com/ctc-oss/fapolicy-analyzer/pull/1025))
+- Include the command line based fapolicy profile tool in the CLI RPM distribution. ([#1040](https://github.com/ctc-oss/fapolicy-analyzer/pull/1040))
+- Include the command line based rule compiler tool in the CLI RPM distribution. ([#1043](https://github.com/ctc-oss/fapolicy-analyzer/pull/1043))
+- Add friendly messages in case of application crash, with instructions for bug reporting and trace file. ([#1045](https://github.com/ctc-oss/fapolicy-analyzer/pull/1045))
+- Added fapolicyd cache stats view with text and 2D plots, showing cache performance. ([#1048](https://github.com/ctc-oss/fapolicy-analyzer/pull/1048))
+
+### Fixed
+
+- Fixed trust init issue related to sha1 hashes and improved diagnostics around parsing the trust db entries. ([#1038](https://github.com/ctc-oss/fapolicy-analyzer/pull/1038))
+- Fixed webkit version selection to support both Fedora and EPEL versions of webkit2. ([#1044](https://github.com/ctc-oss/fapolicy-analyzer/pull/1044))
+
+### Packaging
+
+- Subpackaged RPM build to support separate CLI and GUI installations. ([#1025](https://github.com/ctc-oss/fapolicy-analyzer/pull/1025))
+
+
 ## [v1.4.0](https://github.com/ctc-oss/fapolicy-analyzer/releases/tag/v1.4.0) - 2024-07-28
 
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -561,7 +561,7 @@ dependencies = [
 
 [[package]]
 name = "fapolicy-tools"
-version = "0.5.0"
+version = "1.5.0"
 dependencies = [
  "ariadne",
  "clap",

--- a/crates/tools/Cargo.toml
+++ b/crates/tools/Cargo.toml
@@ -2,7 +2,7 @@
 name = "fapolicy-tools"
 description = "Tools to assist with the configuration and maintenance of fapolicyd"
 license = "GPL-3.0-or-later"
-version = "0.5.0"
+version = "1.5.0"
 edition = "2021"
 
 [[bin]]

--- a/crates/tools/src/fapolicy_profiler.rs
+++ b/crates/tools/src/fapolicy_profiler.rs
@@ -26,7 +26,7 @@ use std::process::Command;
 use strip_ansi_escapes::strip_str;
 
 #[derive(Parser)]
-#[clap(name = "File Access Policy Profiler", version = "v0.0.0")]
+#[clap(name = "File Access Policy Profiler", version = "1.5.0")]
 struct Opts {
     /// do not write events to stdout
     #[clap(long)]

--- a/crates/tools/src/rule_check.rs
+++ b/crates/tools/src/rule_check.rs
@@ -35,7 +35,7 @@ use std::io::{BufRead, BufReader};
 use std::process::ExitCode;
 
 #[derive(Parser)]
-#[clap(name = "Rule Checker", version = "v0.0.0")]
+#[clap(name = "Rule Checker", version = "1.5.0")]
 struct Opts {
     /// path to *.rules or rules.d
     #[clap(default_value=fapolicyd::RULES_FILE_PATH)]

--- a/crates/tools/src/trust_db_util.rs
+++ b/crates/tools/src/trust_db_util.rs
@@ -69,7 +69,7 @@ pub enum Error {
 }
 
 #[derive(Parser)]
-#[clap(name = "Trust DB Utils", version = "v0.1")]
+#[clap(name = "Trust DB Util", version = "1.5.0")]
 struct Opts {
     #[clap(subcommand)]
     cmd: Subcommand,

--- a/fapolicy-analyzer.spec
+++ b/fapolicy-analyzer.spec
@@ -4,7 +4,7 @@
 
 Summary:       File Access Policy Analyzer
 Name:          fapolicy-analyzer
-Version:       1.4.0
+Version:       1.5.0
 Release:       1%{?dist}
 
 SourceLicense: GPL-3.0-or-later
@@ -186,5 +186,5 @@ desktop-file-validate %{buildroot}/%{_datadir}/applications/%{name}.desktop
 %license LICENSE.dependencies
 
 %changelog
-* Sun Jul 28 2024 John Wass <jwass3@gmail.com> 1.4.0-1
+* Tue Dec 31 2024 John Wass <jwass3@gmail.com> 1.5.0-1
 - New release

--- a/news/1025.added.md
+++ b/news/1025.added.md
@@ -1,0 +1,1 @@
+Include the command line based fapolicy Trust DB admin tool in the CLI RPM distribution.

--- a/news/1025.added.md
+++ b/news/1025.added.md
@@ -1,1 +1,0 @@
-Include the command line based fapolicy Trust DB admin tool in the CLI RPM distribution.

--- a/news/1025.packaging.md
+++ b/news/1025.packaging.md
@@ -1,1 +1,0 @@
-Subpackaged RPM build to support separate CLI and GUI installations.

--- a/news/1038.fixed.md
+++ b/news/1038.fixed.md
@@ -1,1 +1,0 @@
-Fixed trust init issue related to sha1 hashes and improved diagnostics around parsing the trust db entries.

--- a/news/1040.added.md
+++ b/news/1040.added.md
@@ -1,1 +1,0 @@
-Include the command line based fapolicy profile tool in the CLI RPM distribution.

--- a/news/1043.added.md
+++ b/news/1043.added.md
@@ -1,1 +1,0 @@
-Include the command line based rule compiler tool in the CLI RPM distribution.

--- a/news/1044.fixed.md
+++ b/news/1044.fixed.md
@@ -1,1 +1,0 @@
-Fixed webkit version selection to support both Fedora and EPEL versions of webkit2.

--- a/news/1045.added.md
+++ b/news/1045.added.md
@@ -1,1 +1,0 @@
-Add friendly messages in case of application crash, with instructions for bug reporting and trace file.

--- a/news/1048.added.md
+++ b/news/1048.added.md
@@ -1,1 +1,0 @@
-Added fapolicyd cache stats view with text and 2D plots, showing cache performance.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ ignore = ["E402"]
 
 [tool.towncrier]
 filename = "CHANGELOG.md"
-version = "1.4.0"
+version = "1.5.0"
 start_string = "<!-- towncrier release notes start -->\n"
 title_format = "## [v{version}](https://github.com/ctc-oss/fapolicy-analyzer/releases/tag/v{version}) - {project_date}"
 issue_format = "[#{issue}](https://github.com/ctc-oss/fapolicy-analyzer/pull/{issue})"

--- a/scripts/srpm/fapolicy-analyzer.el9.spec
+++ b/scripts/srpm/fapolicy-analyzer.el9.spec
@@ -3,7 +3,7 @@
 
 Summary:       File Access Policy Analyzer
 Name:          fapolicy-analyzer
-Version:       1.4.0
+Version:       1.5.0
 Release:       1%{?dist}
 License:       GPL-3.0-or-later
 URL:           https://github.com/ctc-oss/fapolicy-analyzer
@@ -275,5 +275,5 @@ desktop-file-validate %{buildroot}/%{_datadir}/applications/%{name}.desktop
 %license LICENSE
 
 %changelog
-* Sun Jul 28 2024 John Wass <jwass3@gmail.com> 1.4.0-1
+* Tue Dec 31 2024 John Wass <jwass3@gmail.com> 1.5.0-1
 - New release


### PR DESCRIPTION
## [v1.5.0](https://github.com/ctc-oss/fapolicy-analyzer/releases/tag/v1.5.0) - 2024-12-31

### Added

- Include the command line based fapolicy Trust DB admin tool in the CLI RPM distribution. ([#1025](https://github.com/ctc-oss/fapolicy-analyzer/pull/1025))
- Include the command line based fapolicy profile tool in the CLI RPM distribution. ([#1040](https://github.com/ctc-oss/fapolicy-analyzer/pull/1040))
- Include the command line based rule compiler tool in the CLI RPM distribution. ([#1043](https://github.com/ctc-oss/fapolicy-analyzer/pull/1043))
- Add friendly messages in case of application crash, with instructions for bug reporting and trace file. ([#1045](https://github.com/ctc-oss/fapolicy-analyzer/pull/1045))
- Added fapolicyd cache stats view with text and 2D plots, showing cache performance. ([#1048](https://github.com/ctc-oss/fapolicy-analyzer/pull/1048))

### Fixed

- Fixed trust init issue related to sha1 hashes and improved diagnostics around parsing the trust db entries. ([#1038](https://github.com/ctc-oss/fapolicy-analyzer/pull/1038))
- Fixed webkit version selection to support both Fedora and EPEL versions of webkit2. ([#1044](https://github.com/ctc-oss/fapolicy-analyzer/pull/1044))

### Packaging

- Subpackaged RPM build to support separate CLI and GUI installations. ([#1025](https://github.com/ctc-oss/fapolicy-analyzer/pull/1025))
