### PR TITLE
Use el9 setuptools-rust package

### DIFF
--- a/.github/rpm-matrix.json
+++ b/.github/rpm-matrix.json
@@ -23,7 +23,7 @@
       "dist": "el9",
       "spec": "scripts/srpm/fapolicy-analyzer.el9.spec",
       "image": "rockylinux:9",
-      "chroot": "rocky+epel-9-x86_64",
+      "chroot": "centos-stream+epel-9-x86_64",
       "version": "9",
       "prerelease": false
     }

--- a/Containerfile
+++ b/Containerfile
@@ -1,4 +1,4 @@
-ARG image=registry.fedoraproject.org/fedora:latest
+ARG image=registry.fedoraproject.org/fedora:39
 FROM $image AS fedorabuild
 ARG version
 ARG spec=fapolicy-analyzer.spec

--- a/Makefile
+++ b/Makefile
@@ -153,7 +153,7 @@ el-rpm:
 	@echo -e "${GRN}--- el$(el) RPM generation v${VERSION}...${NC}"
 	make -f .copr/Makefile vendor vendor-rs OS_ID=rhel VERSION=${VERSION} DIST=.el$(el) spec=scripts/srpm/fapolicy-analyzer.el$(el).spec
 	podman build -t fapolicy-analyzer:build-el$(el) --target elbuild --build-arg version=${VERSION} --build-arg spec=scripts/srpm/fapolicy-analyzer.el$(el).spec -f Containerfile .
-	podman run --privileged --rm -it -v /tmp:/v fapolicy-analyzer:build-el$(el) rocky+epel-$(el)-x86_64 /v
+	podman run --privileged --rm -it -v /tmp:/v fapolicy-analyzer:build-el$(el) centos-stream+epel-$(el)-x86_64 /v
 
 # Update embedded help documentation
 help-docs:

--- a/scripts/srpm/fapolicy-analyzer.el9.spec
+++ b/scripts/srpm/fapolicy-analyzer.el9.spec
@@ -177,15 +177,15 @@ scripts/build-info.py --os --time
 export RUSTFLAGS="%{build_rustflags}"
 
 %if %{with cli}
-cargo build --bin tdb --release
-cargo build --bin faprofiler --release
-cargo build --bin rulec --release
+%{cargo_build} --bin tdb
+%{cargo_build} --bin rulec
+%{cargo_build} --bin faprofiler
 %endif
 
 %if %{with gui}
-%{venv_py3} setup.py compile_catalog -f
-%{venv_py3} help build
-%{venv_py3} setup.py bdist_wheel
+%{python3} setup.py compile_catalog -f
+%{python3} help build
+%{python3} setup.py bdist_wheel
 %endif
 
 

--- a/scripts/srpm/fapolicy-analyzer.el9.spec
+++ b/scripts/srpm/fapolicy-analyzer.el9.spec
@@ -149,8 +149,9 @@ for d in %{cargo_registry}/*; do ln -sf ${d} ${CARGO_REG_DIR} || true; done
 tar -xzf %{SOURCE2} -C ${CARGO_REG_DIR} --skip-old-files --strip-components=2
 %endif
 
-%autosetup -n %{name}
 %cargo_prep -v ${CARGO_REG_DIR}
+
+%autosetup -n %{name}
 
 rm Cargo.lock
 
@@ -169,8 +170,6 @@ echo %{module_version} > VERSION
 # capture build info
 scripts/build-info.py --os --time
 
-%generate_buildrequires
-%pyproject_buildrequires
 
 %build
 # ensure standard Rust compiler flags are set

--- a/scripts/srpm/fapolicy-analyzer.el9.spec
+++ b/scripts/srpm/fapolicy-analyzer.el9.spec
@@ -134,8 +134,6 @@ Requires:      mesa-dri-drivers
 GUI Tools to assist with the configuration and management of fapolicyd.
 
 %prep
-
-%if %{with gui}
 # An unprivileged user cannot write to the default registry location of
 # /usr/share/cargo/registry so we work around this by linking the contents
 # of the default registry into a new writable location, and then extract
@@ -145,9 +143,9 @@ GUI Tools to assist with the configuration and management of fapolicyd.
 # The crates in the vendor tarball are collected from Rawhide.
 CARGO_REG_DIR=%{_builddir}/vendor-rs
 mkdir -p ${CARGO_REG_DIR}
+ls %{cargo_registry}
 for d in %{cargo_registry}/*; do ln -sf ${d} ${CARGO_REG_DIR} || true; done
 tar -xzf %{SOURCE2} -C ${CARGO_REG_DIR} --skip-old-files --strip-components=2
-%endif
 
 %cargo_prep -v ${CARGO_REG_DIR}
 

--- a/scripts/srpm/fapolicy-analyzer.el9.spec
+++ b/scripts/srpm/fapolicy-analyzer.el9.spec
@@ -32,6 +32,8 @@ BuildRequires: clang
 BuildRequires: audit-libs-devel
 BuildRequires: lmdb-devel
 
+BuildRequires: rust-packaging
+
 BuildRequires: rust-arc-swap-devel
 BuildRequires: rust-assert_matches-devel
 BuildRequires: rust-autocfg-devel

--- a/scripts/srpm/fapolicy-analyzer.el9.spec
+++ b/scripts/srpm/fapolicy-analyzer.el9.spec
@@ -159,11 +159,6 @@ rm Cargo.lock
 sed -i '/tools/d' Cargo.toml
 %endif
 
-%if %{with cli}
-# disable ariadne
-sed -i '/ariadne/d' crates/tools/Cargo.toml
-%endif
-
 # extract our doc sourcs
 tar xvzf %{SOURCE1}
 

--- a/scripts/srpm/fapolicy-analyzer.el9.spec
+++ b/scripts/srpm/fapolicy-analyzer.el9.spec
@@ -21,6 +21,7 @@ BuildRequires: python3dist(babel)
 BuildRequires: python3dist(packaging)
 BuildRequires: python3dist(pyparsing)
 BuildRequires: python3dist(pytz)
+BuildRequires: python3dist(setuptools-rust)
 
 BuildRequires: dbus-devel
 BuildRequires: gettext
@@ -30,8 +31,6 @@ BuildRequires: desktop-file-utils
 BuildRequires: clang
 BuildRequires: audit-libs-devel
 BuildRequires: lmdb-devel
-
-BuildRequires: rust-packaging
 
 BuildRequires: rust-arc-swap-devel
 BuildRequires: rust-assert_matches-devel


### PR DESCRIPTION
The setuptools-rust package was recently added to el9.

Using the package will remove the need to version in the build stack as we do now.

This PR removes the python sources for setuptools-rust and compatible stack components (pip, wheel, etc).

There are also some hygiene improvements to the el9 spec.


# TODO
- [ ] test in koji