### PR TITLE
Add el10 Build

### DIFF
--- a/.github/rpm-matrix.json
+++ b/.github/rpm-matrix.json
@@ -6,7 +6,6 @@
       "spec": "fapolicy-analyzer.spec",
       "image": "registry.fedoraproject.org/fedora:41",
       "chroot": "fedora-41-x86_64",
-      "version": "41",
       "prerelease": false
     },
     {
@@ -15,7 +14,6 @@
       "spec": "fapolicy-analyzer.spec",
       "image": "registry.fedoraproject.org/fedora:40",
       "chroot": "fedora-40-x86_64",
-      "version": "40",
       "prerelease": false
     },
     {
@@ -24,7 +22,6 @@
       "spec": "scripts/srpm/fapolicy-analyzer.el9.spec",
       "image": "rockylinux:9",
       "chroot": "rocky+epel-9-x86_64",
-      "version": "9",
       "prerelease": false
     },
     {
@@ -32,8 +29,7 @@
       "dist": "el10",
       "spec": "scripts/srpm/fapolicy-analyzer.el9.spec",
       "image": "rockylinux:9",
-      "chroot": "almalinux-kitten-10-x86_64",
-      "version": "9",
+      "chroot": "centos-stream+epel-10-x86_64",
       "prerelease": false
     }
   ]

--- a/.github/rpm-matrix.json
+++ b/.github/rpm-matrix.json
@@ -32,7 +32,7 @@
       "dist": "el10",
       "spec": "scripts/srpm/fapolicy-analyzer.el9.spec",
       "image": "rockylinux:9",
-      "chroot": "rocky+epel-10-x86_64",
+      "chroot": "almalinux-kitten-10-x86_64",
       "version": "9",
       "prerelease": false
     }

--- a/.github/rpm-matrix.json
+++ b/.github/rpm-matrix.json
@@ -27,7 +27,7 @@
     {
       "platform": "rhel",
       "dist": "el10",
-      "spec": "scripts/srpm/fapolicy-analyzer.el9.spec",
+      "spec": "scripts/srpm/fapolicy-analyzer.el10.spec",
       "image": "rockylinux:9",
       "chroot": "centos-stream+epel-10-x86_64",
       "prerelease": false

--- a/.github/rpm-matrix.json
+++ b/.github/rpm-matrix.json
@@ -30,7 +30,7 @@
       "spec": "scripts/srpm/fapolicy-analyzer.el10.spec",
       "image": "almalinux:10-kitten",
       "chroot": "centos-stream+epel-10-x86_64",
-      "prerelease": false
+      "prerelease": true
     }
   ]
 }

--- a/.github/rpm-matrix.json
+++ b/.github/rpm-matrix.json
@@ -28,7 +28,7 @@
       "platform": "rhel",
       "dist": "el10",
       "spec": "scripts/srpm/fapolicy-analyzer.el10.spec",
-      "image": "almalinux:10-kitten",
+      "image": "rockylinux:9",
       "chroot": "centos-stream+epel-10-x86_64",
       "prerelease": false
     }

--- a/.github/rpm-matrix.json
+++ b/.github/rpm-matrix.json
@@ -26,6 +26,15 @@
       "chroot": "rocky+epel-9-x86_64",
       "version": "9",
       "prerelease": false
+    },
+    {
+      "platform": "rhel",
+      "dist": "el10",
+      "spec": "scripts/srpm/fapolicy-analyzer.el9.spec",
+      "image": "rockylinux:10",
+      "chroot": "rocky+epel-10-x86_64",
+      "version": "10",
+      "prerelease": false
     }
   ]
 }

--- a/.github/rpm-matrix.json
+++ b/.github/rpm-matrix.json
@@ -33,7 +33,7 @@
       "spec": "scripts/srpm/fapolicy-analyzer.el9.spec",
       "image": "rockylinux:9",
       "chroot": "rocky+epel-10-x86_64",
-      "version": "10",
+      "version": "9",
       "prerelease": false
     }
   ]

--- a/.github/rpm-matrix.json
+++ b/.github/rpm-matrix.json
@@ -21,7 +21,7 @@
       "dist": "el9",
       "spec": "scripts/srpm/fapolicy-analyzer.el9.spec",
       "image": "rockylinux:9",
-      "chroot": "rocky+epel-9-x86_64",
+      "chroot": "centos-stream+epel-9-x86_64",
       "prerelease": false
     },
     {

--- a/.github/rpm-matrix.json
+++ b/.github/rpm-matrix.json
@@ -31,7 +31,7 @@
       "platform": "rhel",
       "dist": "el10",
       "spec": "scripts/srpm/fapolicy-analyzer.el9.spec",
-      "image": "rockylinux:10",
+      "image": "rockylinux:9",
       "chroot": "rocky+epel-10-x86_64",
       "version": "10",
       "prerelease": false

--- a/.github/rpm-matrix.json
+++ b/.github/rpm-matrix.json
@@ -28,7 +28,7 @@
       "platform": "rhel",
       "dist": "el10",
       "spec": "scripts/srpm/fapolicy-analyzer.el10.spec",
-      "image": "rockylinux:9",
+      "image": "almalinux:10-kitten",
       "chroot": "centos-stream+epel-10-x86_64",
       "prerelease": false
     }

--- a/.github/workflows/rpm.yml
+++ b/.github/workflows/rpm.yml
@@ -247,12 +247,6 @@ jobs:
           cid="${{ matrix.props.dist }}-${{ github.run_id }}"
           podman run -dt --name $cid --privileged fedora:39
 
-      - name: Build SRPM
-        run: |
-          make -f .copr/Makefile vendor      \
-               spec=${{ matrix.props.spec }} \
-               OS_ID=${{ matrix.props.platform }}
-
       - name: Init container
         run: |
           cid="${{ matrix.props.dist }}-${{ github.run_id }}"

--- a/.github/workflows/rpm.yml
+++ b/.github/workflows/rpm.yml
@@ -242,13 +242,47 @@ jobs:
           echo "${{ steps.tag_name.outputs.VERSION }}" > help/version
           cat help/version
 
+      - name: Create container
+        run: |
+          sudo apt install -y podman
+          cid="${{ matrix.props.dist }}-${{ github.run_id }}"
+          podman run -dt --name $cid --privileged fedora:39
+
       - name: Build SRPM
         run: |
-          make -f .copr/Makefile             \
-               vendor build export           \
-               outdir=/tmp/archives          \
+          make -f .copr/Makefile vendor      \
                spec=${{ matrix.props.spec }} \
                OS_ID=${{ matrix.props.platform }}
+
+      - name: Init container
+        run: |
+          cid="${{ matrix.props.dist }}-${{ github.run_id }}"
+          podman exec $cid dnf install -y mock
+          podman exec $cid mock -r ${{ matrix.props.chroot }} --init
+
+      - name: Build SRPM with Mock
+        run: |
+          ls -al
+          cid="${{ matrix.props.dist }}-${{ github.run_id }}"
+          podman cp ${{ matrix.props.spec }} $cid:/tmp/SPECS/
+          podman cp 
+          podman exec $cid mock -r ${{ matrix.props.chroot }} --resultdir /tmp/rpmbuild/ --buildsrpm --sources /tmp/SOURCES/ --spec /tmp/SPECS/${spec_file}
+        working-directory: /tmp/src/
+
+      - name: Show logs
+        if: always()
+        run: |
+          cid="${{ matrix.props.dist }}-${{ github.run_id }}"
+          podman exec $cid ls -R /tmp/rpmbuild
+          podman exec $cid cat /tmp/rpmbuild/build.log
+
+      - name: Export SRPM
+        run: |
+          cid="${{ matrix.props.dist }}-${{ github.run_id }}"
+          podman cp $cid:/tmp/rpmbuild/ /tmp/rpmbuild
+          mkdir -p /tmp/archives
+          cd /tmp/rpmbuild
+          ls | grep -v -e debug -e log | xargs mv -t /tmp/archives
 
       - name: Export common tarballs
         run: |

--- a/.github/workflows/rpm.yml
+++ b/.github/workflows/rpm.yml
@@ -274,12 +274,11 @@ jobs:
           path: /tmp/rpmbuild/SOURCES/
 
       - name: Tag 0 tarballs
-        if: startsWith(matrix.props.dist, 'el')
         run: |
           spec_version=$(grep "Version:" ${{ matrix.props.spec }} | tr -s ' ' | cut -d' ' -f2)
           cd /tmp/rpmbuild/SOURCES/
-          mv vendor-rs.tar.gz vendor-rs-${spec_version}.tar.gz
           mv vendor-docs.tar.gz vendor-docs-${spec_version}.tar.gz
+          mv vendor-rs.tar.gz vendor-rs-${spec_version}.tar.gz | true
 
       - name: Create container
         run: |

--- a/.github/workflows/rpm.yml
+++ b/.github/workflows/rpm.yml
@@ -146,12 +146,12 @@ jobs:
     strategy:
       matrix: ${{ fromJson(needs.config.outputs.matrix) }}
     steps:
-      - name: Enable EPEL
-        if: startsWith(matrix.props.dist, 'el')
-        run: dnf install -y epel-release
+      #      - name: Enable EPEL
+      #        if: startsWith(matrix.props.dist, 'el')
+      #        run: dnf install -y epel-release
 
       - name: Install Git
-        run: dnf install -y git
+        run: sudo apt install -y git
 
       - uses: actions/checkout@v4
         with:
@@ -209,11 +209,11 @@ jobs:
 
       - name: Install RPM build dependencies
         run: |
-          dnf install -y make rpm rpmdevtools dnf-plugins-core
+          apt install -y make
 
-      - name: Install SRPM build dependencies
-        run: |
-          make -f .copr/Makefile dnf OS_ID=${{ matrix.props.platform }}
+      #      - name: Install SRPM build dependencies
+      #        run: |
+      #          make -f .copr/Makefile dnf OS_ID=${{ matrix.props.platform }}
 
       - name: Fetch Source0 tarball
         uses: actions/download-artifact@v4

--- a/.github/workflows/rpm.yml
+++ b/.github/workflows/rpm.yml
@@ -264,7 +264,7 @@ jobs:
         run: |
           cid="${{ matrix.props.dist }}-${{ github.run_id }}"
           podman cp ${{ matrix.props.spec }} $cid:/tmp/SPECS/
-          podman cp /tmp/SOURCES/ $cid:/tmp/SOURCES/
+          podman cp /tmp/rpmbuild/SOURCES/ $cid:/tmp/SOURCES/
           podman exec $cid mock -r ${{ matrix.props.chroot }} --resultdir /tmp/rpmbuild/ --buildsrpm --sources /tmp/SOURCES/ --spec /tmp/SPECS/${spec_file}
 
       - name: Show logs

--- a/.github/workflows/rpm.yml
+++ b/.github/workflows/rpm.yml
@@ -457,7 +457,7 @@ jobs:
           podman exec $cid dnf install -y mock
           podman exec $cid mock -r ${{ matrix.props.chroot }} --init
 
-      - name: Build el with Mock
+      - name: Build for FC with Mock
         if: startsWith(matrix.props.dist, 'fc')
         run: |
           cid="${{ matrix.props.dist }}-${{ github.run_id }}"
@@ -466,7 +466,7 @@ jobs:
           podman exec $cid mock -r ${{ matrix.props.chroot }} --resultdir /tmp/rpmbuild --rebuild /tmp/$srpm
         working-directory: /tmp/src/
 
-      - name: Build with Mock
+      - name: Build for EL with Mock
         if: startsWith(matrix.props.dist, 'el')
         run: |
           cid="${{ matrix.props.dist }}-${{ github.run_id }}"

--- a/.github/workflows/rpm.yml
+++ b/.github/workflows/rpm.yml
@@ -161,7 +161,8 @@ jobs:
 
       - name: Build SRPM
         run: |
-          make -f .copr/Makefile prepfs vendor-doc
+          mkdir -p /tmp/rpmbuild/SOURCES /tmp/archives
+          make -f .copr/Makefile vendor-doc
 
       - name: Export common tarballs
         run: |

--- a/.github/workflows/rpm.yml
+++ b/.github/workflows/rpm.yml
@@ -256,11 +256,11 @@ jobs:
 
       - name: Build SRPM with Mock
         run: |
-          ls /tmp/rpmbuild/SOURCES/
           cid="${{ matrix.props.dist }}-${{ github.run_id }}"
           spec_file=$(basename ${{ matrix.props.spec }})
           podman cp ${{ matrix.props.spec }} $cid:/tmp/SPECS
           podman cp /tmp/rpmbuild/SOURCES $cid:/tmp/SOURCES
+          podman exec $cid ls -al /tmp/SOURCES
           podman exec $cid mock -r ${{ matrix.props.chroot }} --resultdir /tmp/rpmbuild/ --buildsrpm --sources /tmp/SOURCES/ --spec /tmp/SPECS/${spec_file}
 
       - name: Show logs

--- a/.github/workflows/rpm.yml
+++ b/.github/workflows/rpm.yml
@@ -428,7 +428,17 @@ jobs:
           podman exec $cid dnf install -y mock
           podman exec $cid mock -r ${{ matrix.props.chroot }} --init
 
+      - name: Build el with Mock
+        if: startsWith(matrix.props.dist, 'fc')
+        run: |
+          cid="${{ matrix.props.dist }}-${{ github.run_id }}"
+          srpm=$(find . -name *.${{ matrix.props.dist }}.src.rpm)
+          podman cp $srpm $cid:/tmp/$srpm
+          podman exec $cid mock -r ${{ matrix.props.chroot }} --resultdir /tmp/rpmbuild --rebuild /tmp/$srpm
+        working-directory: /tmp/src/
+
       - name: Build with Mock
+        if: startsWith(matrix.props.dist, 'el')
         run: |
           cid="${{ matrix.props.dist }}-${{ github.run_id }}"
           srpm=$(find . -name *.${{ matrix.props.dist }}.src.rpm)

--- a/.github/workflows/rpm.yml
+++ b/.github/workflows/rpm.yml
@@ -506,10 +506,6 @@ jobs:
       matrix: ${{ fromJson(needs.config.outputs.matrix )}}
     continue-on-error: ${{ matrix.props.prerelease }}
     steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.ref }}
-
       - name: Download rpm artifacts
         uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/rpm.yml
+++ b/.github/workflows/rpm.yml
@@ -366,7 +366,7 @@ jobs:
           cid="${{ matrix.props.dist }}-${{ github.run_id }}"
           srpm=$(find . -name *.${{ matrix.props.dist }}.src.rpm)
           podman cp $srpm $cid:/tmp/$srpm
-          podman exec $cid mock -r ${{ matrix.props.chroot }} rebuild /tmp/$srpm --resultdir /tmp/rpmbuild
+          podman exec $cid mock -r ${{ matrix.props.chroot }} --resultdir /tmp/rpmbuild --enablerepo=crb --rebuild /tmp/$srpm
         working-directory: /tmp/src/
 
       - name: Show logs

--- a/.github/workflows/rpm.yml
+++ b/.github/workflows/rpm.yml
@@ -142,7 +142,6 @@ jobs:
   srpm:
     needs: [ config, source0, crates0 ]
     name: SRPM Build ${{ matrix.props.dist }}
-    container: ${{ matrix.props.image }}
     runs-on: ubuntu-20.04
     strategy:
       matrix: ${{ fromJson(needs.config.outputs.matrix) }}
@@ -244,7 +243,7 @@ jobs:
 
       - name: Create container
         run: |
-          dnf install -y podman
+          sudo apt install -y podman
           cid="${{ matrix.props.dist }}-${{ github.run_id }}"
           podman run -dt --name $cid --privileged fedora:39
 

--- a/.github/workflows/rpm.yml
+++ b/.github/workflows/rpm.yml
@@ -521,7 +521,6 @@ jobs:
         run: dnf install -y epel-release
 
       - name: Install RPM
-        if: ${{ !startsWith(matrix.props.dist, 'el10') }}
         run: |
           dnf install -y /tmp/src/fapolicy-analyzer-*.${{ matrix.props.dist }}.x86_64.rpm
 

--- a/.github/workflows/rpm.yml
+++ b/.github/workflows/rpm.yml
@@ -146,7 +146,7 @@ jobs:
     steps:
       - name: Install RPM build dependencies
         run: |
-          dnf install -y git  python3-pip python3-toml python3-beautifulsoup4 python3-markdown2
+          dnf install -y git make python3-pip python3-toml python3-beautifulsoup4 python3-markdown2
 
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/rpm.yml
+++ b/.github/workflows/rpm.yml
@@ -258,13 +258,14 @@ jobs:
           cid="${{ matrix.props.dist }}-${{ github.run_id }}"
           podman exec $cid dnf install -y mock
           podman exec $cid mock -r ${{ matrix.props.chroot }} --init
+          podman exec $cid mkdir -p /tmp/SPECS /tmp/SOURCES
 
       - name: Build SRPM with Mock
         run: |
           cid="${{ matrix.props.dist }}-${{ github.run_id }}"
-          podman cp ${{ matrix.props.spec }} $cid:/tmp/
+          podman cp ${{ matrix.props.spec }} $cid:/tmp/SPECS/
           podman cp /tmp/SOURCES/ $cid:/tmp/SOURCES/
-          podman exec $cid mock -r ${{ matrix.props.chroot }} --resultdir /tmp/rpmbuild/ --buildsrpm --sources /tmp/SOURCES/ --spec /tmp/${spec_file}
+          podman exec $cid mock -r ${{ matrix.props.chroot }} --resultdir /tmp/rpmbuild/ --buildsrpm --sources /tmp/SOURCES/ --spec /tmp/SPECS/${spec_file}
 
       - name: Show logs
         if: always()

--- a/.github/workflows/rpm.yml
+++ b/.github/workflows/rpm.yml
@@ -47,7 +47,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Install deps
-        run: dnf install -y git make python3 python3-pip python3-toml python3-beautifulsoup4 python3-markdown2
+        run: dnf install -y git make python3
 
       - uses: actions/checkout@v4
         with:
@@ -146,7 +146,7 @@ jobs:
     steps:
       - name: Install RPM build dependencies
         run: |
-          dnf install -y git dnf5-plugins dnf-plugins-core cargo2rpm
+          dnf install -y git  python3-pip python3-toml python3-beautifulsoup4 python3-markdown2
 
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/rpm.yml
+++ b/.github/workflows/rpm.yml
@@ -209,7 +209,7 @@ jobs:
 
       - name: Install RPM build dependencies
         run: |
-          apt install -y make
+          sudo apt install -y make
 
       #      - name: Install SRPM build dependencies
       #        run: |

--- a/.github/workflows/rpm.yml
+++ b/.github/workflows/rpm.yml
@@ -261,12 +261,10 @@ jobs:
 
       - name: Build SRPM with Mock
         run: |
-          ls -al
           cid="${{ matrix.props.dist }}-${{ github.run_id }}"
           podman cp ${{ matrix.props.spec }} $cid:/tmp/SPECS/
           podman cp /tmp/SOURCES/ $cid:/tmp/SOURCES/
           podman exec $cid mock -r ${{ matrix.props.chroot }} --resultdir /tmp/rpmbuild/ --buildsrpm --sources /tmp/SOURCES/ --spec /tmp/SPECS/${spec_file}
-        working-directory: /tmp/src/
 
       - name: Show logs
         if: always()

--- a/.github/workflows/rpm.yml
+++ b/.github/workflows/rpm.yml
@@ -244,7 +244,7 @@ jobs:
 
       - name: Create container
         run: |
-          sudo apt install -y podman
+          sudo dnf install -y podman
           cid="${{ matrix.props.dist }}-${{ github.run_id }}"
           podman run -dt --name $cid --privileged fedora:39
 

--- a/.github/workflows/rpm.yml
+++ b/.github/workflows/rpm.yml
@@ -244,7 +244,7 @@ jobs:
 
       - name: Create container
         run: |
-          sudo dnf install -y podman
+          dnf install -y podman
           cid="${{ matrix.props.dist }}-${{ github.run_id }}"
           podman run -dt --name $cid --privileged fedora:39
 

--- a/.github/workflows/rpm.yml
+++ b/.github/workflows/rpm.yml
@@ -139,6 +139,46 @@ jobs:
         run: |
           sha256sum vendor-rs.tar.gz
 
+  docs0:
+    name: Vendor Docs0
+    container: registry.fedoraproject.org/fedora:latest
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Install RPM build dependencies
+        run: |
+          dnf install -y git dnf5-plugins dnf-plugins-core cargo2rpm
+
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref }}
+          fetch-depth: 0
+
+      - name: Generate doc tag
+        if: startsWith(github.ref, 'refs/tags/v')
+        run: |
+          echo "${{ steps.tag_name.outputs.VERSION }}" > help/version
+          cat help/version
+
+      - name: Build SRPM
+        run: |
+          make -f .copr/Makefile vendor-doc
+
+      - name: Export common tarballs
+        run: |
+          mkdir -p /tmp/rpmbuild/SOURCES /tmp/archives
+          mv /tmp/rpmbuild/SOURCES/vendor-docs-*.tar.gz /tmp/archives/vendor-docs.tar.gz
+
+      - name: Upload tarball
+        uses: actions/upload-artifact@v4
+        with:
+          name: docs0
+          path: |
+            vendor-docs.tar.gz
+
+      - name: Checksum
+        run: |
+          sha256sum vendor-docs.tar.gz
+
   srpm:
     needs: [ config, source0, crates0 ]
     name: SRPM Build ${{ matrix.props.dist }}
@@ -207,9 +247,9 @@ jobs:
           sed -i "s#Version:\s*${spec_version}#Version: ${patched_version}#" ${{ matrix.props.spec }}
           grep Version ${{ matrix.props.spec }}
 
-      - name: Install dependencies
-        run: |
-          sudo apt install -y make libxml2-utils python3-toml python3-bs4 python3-requests python3-babel itstool python3-markdown2
+      #      - name: Install dependencies
+      #        run: |
+      #          sudo apt install -y make libxml2-utils python3-toml python3-bs4 python3-requests python3-babel itstool python3-markdown2
 
       #      - name: Install SRPM build dependencies
       #        run: |
@@ -221,6 +261,12 @@ jobs:
           name: source0
           path: /tmp/rpmbuild/SOURCES/
 
+      - name: Fetch Docs0 tarball
+        uses: actions/download-artifact@v4
+        with:
+          name: docs0
+          path: /tmp/rpmbuild/SOURCES/
+
       - name: Fetch Crates0 tarball
         if: startsWith(matrix.props.dist, 'el')
         uses: actions/download-artifact@v4
@@ -228,18 +274,13 @@ jobs:
           name: crates0
           path: /tmp/rpmbuild/SOURCES/
 
-      - name: Tag Crates0 tarball
+      - name: Tag 0 tarballs
         if: startsWith(matrix.props.dist, 'el')
         run: |
           spec_version=$(grep "Version:" ${{ matrix.props.spec }} | tr -s ' ' | cut -d' ' -f2)
           cd /tmp/rpmbuild/SOURCES/
           mv vendor-rs.tar.gz vendor-rs-${spec_version}.tar.gz
-
-      - name: Generate doc tag
-        if: startsWith(github.ref, 'refs/tags/v')
-        run: |
-          echo "${{ steps.tag_name.outputs.VERSION }}" > help/version
-          cat help/version
+          mv vendor-docs.tar.gz vendor-docs-${spec_version}.tar.gz
 
       - name: Create container
         run: |

--- a/.github/workflows/rpm.yml
+++ b/.github/workflows/rpm.yml
@@ -268,7 +268,6 @@ jobs:
           path: /tmp/rpmbuild/SOURCES/
 
       - name: Fetch Crates0 tarball
-        if: startsWith(matrix.props.dist, 'el')
         uses: actions/download-artifact@v4
         with:
           name: crates0

--- a/.github/workflows/rpm.yml
+++ b/.github/workflows/rpm.yml
@@ -209,7 +209,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          sudo apt install -y make python3-markdown2
+          sudo apt install -y make python3-toml python3-bs4 python3-requests python3-babel itstool python3-markdown2
 
       #      - name: Install SRPM build dependencies
       #        run: |

--- a/.github/workflows/rpm.yml
+++ b/.github/workflows/rpm.yml
@@ -161,11 +161,10 @@ jobs:
 
       - name: Build SRPM
         run: |
-          make -f .copr/Makefile vendor-doc
+          make -f .copr/Makefile prepfs vendor-doc
 
       - name: Export common tarballs
         run: |
-          mkdir -p /tmp/rpmbuild/SOURCES /tmp/archives
           mv /tmp/rpmbuild/SOURCES/vendor-docs-*.tar.gz /tmp/archives/vendor-docs.tar.gz
 
       - name: Upload tarball

--- a/.github/workflows/rpm.yml
+++ b/.github/workflows/rpm.yml
@@ -186,7 +186,7 @@ jobs:
     steps:
       - name: Install RPM build dependencies
         run: |
-          dnf install -y git make rpm-build rpmdevtools
+          dnf install -y git make which rpm-build rpmdevtools
 
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/rpm.yml
+++ b/.github/workflows/rpm.yml
@@ -322,7 +322,7 @@ jobs:
       - name: Export common tarballs
         run: |
           mkdir -p /tmp/archives
-          mv vendor-docs-*.tar.gz /tmp/archives
+          mv /tmp/rpmbuild/SOURCES/vendor-docs-*.tar.gz /tmp/archives
 
       - name: Export el tarballs
         if: startsWith(matrix.props.dist, 'el')

--- a/.github/workflows/rpm.yml
+++ b/.github/workflows/rpm.yml
@@ -179,17 +179,47 @@ jobs:
         run: |
           sha256sum vendor-docs.tar.gz
 
+  python0:
+    name: Vendor Python0
+    container: registry.fedoraproject.org/fedora:latest
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Install RPM build dependencies
+        run: |
+          dnf install -y rpm-build rpmdevtools
+
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref }}
+          fetch-depth: 0
+
+      - name: Build SRPM
+        run: |
+          mkdir -p /tmp/rpmbuild/SOURCES
+          make -f .copr/Makefile vendor-py
+
+      - name: Export common tarballs
+        run: |
+          mv /tmp/rpmbuild/SOURCES/*.tar.gz .
+
+      - name: Upload tarball
+        uses: actions/upload-artifact@v4
+        with:
+          name: python0
+          path: |
+            ./*.tar.gz
+
+      - name: Checksum
+        run: |
+          sha256sum ./*.tar.gz
+
   srpm:
-    needs: [ config, source0, crates0, docs0 ]
+    needs: [ config, source0, crates0, docs0, python0 ]
     name: SRPM Build ${{ matrix.props.dist }}
     runs-on: ubuntu-20.04
     strategy:
       matrix: ${{ fromJson(needs.config.outputs.matrix) }}
     steps:
-      #      - name: Enable EPEL
-      #        if: startsWith(matrix.props.dist, 'el')
-      #        run: dnf install -y epel-release
-
       - name: Install Git
         run: sudo apt install -y git
 
@@ -247,14 +277,6 @@ jobs:
           sed -i "s#Version:\s*${spec_version}#Version: ${patched_version}#" ${{ matrix.props.spec }}
           grep Version ${{ matrix.props.spec }}
 
-      #      - name: Install dependencies
-      #        run: |
-      #          sudo apt install -y make libxml2-utils python3-toml python3-bs4 python3-requests python3-babel itstool python3-markdown2
-
-      #      - name: Install SRPM build dependencies
-      #        run: |
-      #          make -f .copr/Makefile dnf OS_ID=${{ matrix.props.platform }}
-
       - name: Fetch Source0 tarball
         uses: actions/download-artifact@v4
         with:
@@ -271,6 +293,13 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: crates0
+          path: /tmp/rpmbuild/SOURCES/
+
+      - name: Fetch Python0 tarball
+        if: startsWith(matrix.props.dist, 'el9')
+        uses: actions/download-artifact@v4
+        with:
+          name: python0
           path: /tmp/rpmbuild/SOURCES/
 
       - name: Tag 0 tarballs

--- a/.github/workflows/rpm.yml
+++ b/.github/workflows/rpm.yml
@@ -207,9 +207,9 @@ jobs:
           sed -i "s#Version:\s*${spec_version}#Version: ${patched_version}#" ${{ matrix.props.spec }}
           grep Version ${{ matrix.props.spec }}
 
-      - name: Install RPM build dependencies
+      - name: Install dependencies
         run: |
-          sudo apt install -y make
+          sudo apt install -y make python3-markdown2
 
       #      - name: Install SRPM build dependencies
       #        run: |

--- a/.github/workflows/rpm.yml
+++ b/.github/workflows/rpm.yml
@@ -521,6 +521,7 @@ jobs:
         run: dnf install -y epel-release
 
       - name: Install RPM
+        if: ${{ !startsWith(matrix.props.dist, 'el10') }}
         run: |
           dnf install -y /tmp/src/fapolicy-analyzer-*.${{ matrix.props.dist }}.x86_64.rpm
 

--- a/.github/workflows/rpm.yml
+++ b/.github/workflows/rpm.yml
@@ -263,6 +263,7 @@ jobs:
       - name: Build SRPM with Mock
         run: |
           cid="${{ matrix.props.dist }}-${{ github.run_id }}"
+          spec_file=$(basename ${{ matrix.props.spec }})
           podman cp ${{ matrix.props.spec }} $cid:/tmp/SPECS/
           podman cp /tmp/rpmbuild/SOURCES/ $cid:/tmp/SOURCES/
           podman exec $cid mock -r ${{ matrix.props.chroot }} --resultdir /tmp/rpmbuild/ --buildsrpm --sources /tmp/SOURCES/ --spec /tmp/SPECS/${spec_file}

--- a/.github/workflows/rpm.yml
+++ b/.github/workflows/rpm.yml
@@ -146,7 +146,7 @@ jobs:
     steps:
       - name: Install RPM build dependencies
         run: |
-          dnf install -y git make python3-pip python3-toml python3-beautifulsoup4 python3-markdown2
+          dnf install -y git make python3-pip python3-toml python3-beautifulsoup4 python3-markdown2 itstool
 
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/rpm.yml
+++ b/.github/workflows/rpm.yml
@@ -149,8 +149,7 @@ jobs:
     steps:
       - name: Enable EPEL
         if: startsWith(matrix.props.dist, 'el')
-        run: |
-          dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-${{ matrix.props.version }}.noarch.rpm
+        run: dnf install -y epel-release
 
       - name: Install Git
         run: dnf install -y git
@@ -417,8 +416,7 @@ jobs:
 
       - name: Enable EPEL
         if: startsWith(matrix.props.dist, 'el')
-        run: |
-          dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-${{ matrix.props.version }}.noarch.rpm
+        run: dnf install -y epel-release
 
       - name: Install RPM
         run: |

--- a/.github/workflows/rpm.yml
+++ b/.github/workflows/rpm.yml
@@ -47,7 +47,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Install deps
-        run: dnf install -y git make python3
+        run: dnf install -y git make python3 python3-pip python3-toml python3-beautifulsoup4 python3-markdown2
 
       - uses: actions/checkout@v4
         with:
@@ -180,7 +180,7 @@ jobs:
           sha256sum vendor-docs.tar.gz
 
   srpm:
-    needs: [ config, source0, crates0 ]
+    needs: [ config, source0, crates0, docs0 ]
     name: SRPM Build ${{ matrix.props.dist }}
     runs-on: ubuntu-20.04
     strategy:

--- a/.github/workflows/rpm.yml
+++ b/.github/workflows/rpm.yml
@@ -312,9 +312,9 @@ jobs:
       - name: Export SRPM
         run: |
           cid="${{ matrix.props.dist }}-${{ github.run_id }}"
-          podman cp $cid:/tmp/rpmbuild/ /tmp/rpmbuild
+          podman cp $cid:/tmp/rpmbuild/ /tmp/build
           mkdir -p /tmp/archives
-          cd /tmp/rpmbuild
+          cd /tmp/build
           ls | grep -v -e debug -e log | xargs mv -t /tmp/archives
 
       - name: Export common tarballs

--- a/.github/workflows/rpm.yml
+++ b/.github/workflows/rpm.yml
@@ -262,9 +262,9 @@ jobs:
       - name: Build SRPM with Mock
         run: |
           cid="${{ matrix.props.dist }}-${{ github.run_id }}"
-          podman cp ${{ matrix.props.spec }} $cid:/tmp/SPECS/
+          podman cp ${{ matrix.props.spec }} $cid:/tmp/
           podman cp /tmp/SOURCES/ $cid:/tmp/SOURCES/
-          podman exec $cid mock -r ${{ matrix.props.chroot }} --resultdir /tmp/rpmbuild/ --buildsrpm --sources /tmp/SOURCES/ --spec /tmp/SPECS/${spec_file}
+          podman exec $cid mock -r ${{ matrix.props.chroot }} --resultdir /tmp/rpmbuild/ --buildsrpm --sources /tmp/SOURCES/ --spec /tmp/${spec_file}
 
       - name: Show logs
         if: always()

--- a/.github/workflows/rpm.yml
+++ b/.github/workflows/rpm.yml
@@ -186,7 +186,7 @@ jobs:
     steps:
       - name: Install RPM build dependencies
         run: |
-          dnf install -y git make which rpm-build rpmdevtools
+          dnf install -y git which rpm-build rpmdevtools
 
       - uses: actions/checkout@v4
         with:
@@ -195,12 +195,12 @@ jobs:
 
       - name: Build SRPM
         run: |
-          mkdir -p /tmp/rpmbuild/SOURCES
-          make -f .copr/Makefile vendor-py
+          mkdir -p /tmp/SOURCES
+          spectool -g -C /tmp/SOURCES ${{ matrix.props.spec }}
 
       - name: Export common tarballs
         run: |
-          mv /tmp/rpmbuild/SOURCES/*.tar.gz .
+          mv /tmp/SOURCES/*.tar.gz .
 
       - name: Upload tarball
         uses: actions/upload-artifact@v4

--- a/.github/workflows/rpm.yml
+++ b/.github/workflows/rpm.yml
@@ -262,6 +262,7 @@ jobs:
 
       - name: Build SRPM with Mock
         run: |
+          ls /tmp/rpmbuild/SOURCES/
           cid="${{ matrix.props.dist }}-${{ github.run_id }}"
           spec_file=$(basename ${{ matrix.props.spec }})
           podman cp ${{ matrix.props.spec }} $cid:/tmp/SPECS/

--- a/.github/workflows/rpm.yml
+++ b/.github/workflows/rpm.yml
@@ -209,7 +209,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          sudo apt install -y make python3-toml python3-bs4 python3-requests python3-babel itstool python3-markdown2
+          sudo apt install -y make libxml2-utils python3-toml python3-bs4 python3-requests python3-babel itstool python3-markdown2
 
       #      - name: Install SRPM build dependencies
       #        run: |

--- a/.github/workflows/rpm.yml
+++ b/.github/workflows/rpm.yml
@@ -265,8 +265,8 @@ jobs:
           ls /tmp/rpmbuild/SOURCES/
           cid="${{ matrix.props.dist }}-${{ github.run_id }}"
           spec_file=$(basename ${{ matrix.props.spec }})
-          podman cp ${{ matrix.props.spec }} $cid:/tmp/SPECS/
-          podman cp /tmp/rpmbuild/SOURCES/ $cid:/tmp/SOURCES/
+          podman cp ${{ matrix.props.spec }} $cid:/tmp/SPECS
+          podman cp /tmp/rpmbuild/SOURCES $cid:/tmp/SOURCES
           podman exec $cid mock -r ${{ matrix.props.chroot }} --resultdir /tmp/rpmbuild/ --buildsrpm --sources /tmp/SOURCES/ --spec /tmp/SPECS/${spec_file}
 
       - name: Show logs

--- a/.github/workflows/rpm.yml
+++ b/.github/workflows/rpm.yml
@@ -196,7 +196,7 @@ jobs:
       - name: Build SRPM
         run: |
           mkdir -p /tmp/SOURCES
-          spectool -g -C /tmp/SOURCES ${{ matrix.props.spec }}
+          spectool -g -C /tmp/SOURCES scripts/srpm/fapolicy-analyzer.el9.spec
 
       - name: Export common tarballs
         run: |

--- a/.github/workflows/rpm.yml
+++ b/.github/workflows/rpm.yml
@@ -166,7 +166,7 @@ jobs:
 
       - name: Export common tarballs
         run: |
-          mv /tmp/rpmbuild/SOURCES/vendor-docs-*.tar.gz /tmp/archives/vendor-docs.tar.gz
+          mv /tmp/rpmbuild/SOURCES/vendor-docs-*.tar.gz vendor-docs.tar.gz
 
       - name: Upload tarball
         uses: actions/upload-artifact@v4

--- a/.github/workflows/rpm.yml
+++ b/.github/workflows/rpm.yml
@@ -264,7 +264,7 @@ jobs:
           ls -al
           cid="${{ matrix.props.dist }}-${{ github.run_id }}"
           podman cp ${{ matrix.props.spec }} $cid:/tmp/SPECS/
-          podman cp 
+          podman cp /tmp/SOURCES/ $cid:/tmp/SOURCES/
           podman exec $cid mock -r ${{ matrix.props.chroot }} --resultdir /tmp/rpmbuild/ --buildsrpm --sources /tmp/SOURCES/ --spec /tmp/SPECS/${spec_file}
         working-directory: /tmp/src/
 

--- a/.github/workflows/rpm.yml
+++ b/.github/workflows/rpm.yml
@@ -258,8 +258,8 @@ jobs:
         run: |
           cid="${{ matrix.props.dist }}-${{ github.run_id }}"
           spec_file=$(basename ${{ matrix.props.spec }})
-          podman cp ${{ matrix.props.spec }} $cid:/tmp/SPECS
-          podman cp /tmp/rpmbuild/SOURCES $cid:/tmp/SOURCES
+          podman cp ${{ matrix.props.spec }} $cid:/tmp/SPECS/
+          podman cp /tmp/rpmbuild/SOURCES $cid:/tmp
           podman exec $cid ls -al /tmp/SOURCES
           podman exec $cid mock -r ${{ matrix.props.chroot }} --resultdir /tmp/rpmbuild/ --buildsrpm --sources /tmp/SOURCES/ --spec /tmp/SPECS/${spec_file}
 

--- a/.github/workflows/rpm.yml
+++ b/.github/workflows/rpm.yml
@@ -186,7 +186,7 @@ jobs:
     steps:
       - name: Install RPM build dependencies
         run: |
-          dnf install -y rpm-build rpmdevtools
+          dnf install -y git make rpm-build rpmdevtools
 
       - uses: actions/checkout@v4
         with:

--- a/Containerfile
+++ b/Containerfile
@@ -1,4 +1,4 @@
-ARG image=registry.fedoraproject.org/fedora:latest
+ARG image=registry.fedoraproject.org/fedora:39
 FROM $image AS fedorabuild
 ARG version
 ARG spec=fapolicy-analyzer.spec

--- a/Makefile
+++ b/Makefile
@@ -153,7 +153,7 @@ el-rpm:
 	@echo -e "${GRN}--- el$(el) RPM generation v${VERSION}...${NC}"
 	make -f .copr/Makefile vendor vendor-rs OS_ID=rhel VERSION=${VERSION} DIST=.el$(el) spec=scripts/srpm/fapolicy-analyzer.el$(el).spec
 	podman build -t fapolicy-analyzer:build-el$(el) --target elbuild --build-arg version=${VERSION} --build-arg spec=scripts/srpm/fapolicy-analyzer.el$(el).spec -f Containerfile .
-	podman run --privileged --rm -it -v /tmp:/v fapolicy-analyzer:build-el$(el) rocky+epel-$(el)-x86_64 /v
+	podman run --privileged --rm -it -v /tmp:/v fapolicy-analyzer:build-el$(el) centos-stream+epel-$(el)-x86_64 /v
 
 # Update embedded help documentation
 help-docs:

--- a/news/1065.packaging.md
+++ b/news/1065.packaging.md
@@ -1,0 +1,1 @@
+Add RPM build for EPEL-10.

--- a/scripts/srpm/build.sh
+++ b/scripts/srpm/build.sh
@@ -21,7 +21,7 @@ rpmbuild_dir=/tmp/rpmbuild
 echo "[build.sh] mock $1"
 mock -r "$1" --init
 mock -r "$1" --resultdir ${rpmbuild_dir} --buildsrpm --sources ${rpmbuild_dir}/SOURCES/ --spec ${rpmbuild_dir}/SPECS/${spec_file}
-mock -r "$1" --resultdir ${rpmbuild_dir} --rebuild ${rpmbuild_dir}/*.src.rpm
+mock -r "$1" --resultdir ${rpmbuild_dir} --enablerepo=crb --rebuild ${rpmbuild_dir}/*.src.rpm
 
 if [[ -n "$2" ]]; then
   echo "[build.sh] exporting rpms to ${2}"

--- a/scripts/srpm/fapolicy-analyzer.el10.spec
+++ b/scripts/srpm/fapolicy-analyzer.el10.spec
@@ -136,7 +136,6 @@ GUI Tools to assist with the configuration and management of fapolicyd.
 
 %prep
 
-%if %{with gui}
 # An unprivileged user cannot write to the default registry location of
 # /usr/share/cargo/registry so we work around this by linking the contents
 # of the default registry into a new writable location, and then extract
@@ -148,7 +147,6 @@ CARGO_REG_DIR=%{_builddir}/vendor-rs
 mkdir -p ${CARGO_REG_DIR}
 for d in %{cargo_registry}/*; do ln -sf ${d} ${CARGO_REG_DIR} || true; done
 tar -xzf %{SOURCE2} -C ${CARGO_REG_DIR} --skip-old-files --strip-components=2
-%endif
 
 %cargo_prep -v ${CARGO_REG_DIR}
 

--- a/scripts/srpm/fapolicy-analyzer.el10.spec
+++ b/scripts/srpm/fapolicy-analyzer.el10.spec
@@ -19,10 +19,8 @@ BuildRequires: python3-devel
 BuildRequires: python3dist(setuptools)
 BuildRequires: python3dist(setuptools-rust)
 BuildRequires: python3dist(pip)
+BuildRequires: python3dist(wheel)
 BuildRequires: python3dist(babel)
-BuildRequires: python3dist(packaging)
-BuildRequires: python3dist(pyparsing)
-BuildRequires: python3dist(pytz)
 
 BuildRequires: dbus-devel
 BuildRequires: gettext

--- a/scripts/srpm/fapolicy-analyzer.el10.spec
+++ b/scripts/srpm/fapolicy-analyzer.el10.spec
@@ -1,0 +1,241 @@
+%bcond_without cli
+%bcond_without gui
+
+Summary:       File Access Policy Analyzer
+Name:          fapolicy-analyzer
+Version:       1.5.0
+Release:       1%{?dist}
+License:       GPL-3.0-or-later
+URL:           https://github.com/ctc-oss/fapolicy-analyzer
+Source0:       %{url}/releases/download/v%{version}/%{name}-%{version}.tar.gz
+
+# vendored documentation sources, used to generate help docs
+Source1:       %{url}/releases/download/v%{version}/vendor-docs-%{version}.tar.gz
+
+# vendored rust dependencies
+Source2:       %{url}/releases/download/v%{version}/vendor-rs-%{version}.tar.gz
+
+BuildRequires: python3-devel
+BuildRequires: python3dist(setuptools)
+BuildRequires: python3dist(setuptools-rust)
+BuildRequires: python3dist(pip)
+BuildRequires: python3dist(babel)
+BuildRequires: python3dist(packaging)
+BuildRequires: python3dist(pyparsing)
+BuildRequires: python3dist(pytz)
+
+BuildRequires: dbus-devel
+BuildRequires: gettext
+BuildRequires: itstool
+BuildRequires: desktop-file-utils
+
+BuildRequires: clang
+BuildRequires: audit-libs-devel
+BuildRequires: lmdb-devel
+
+BuildRequires: rust-packaging
+
+BuildRequires: rust-arc-swap-devel
+BuildRequires: rust-assert_matches-devel
+BuildRequires: rust-autocfg-devel
+BuildRequires: rust-bindgen-devel
+BuildRequires: rust-block-buffer-devel
+BuildRequires: rust-bumpalo-devel
+BuildRequires: rust-cc-devel
+BuildRequires: rust-cexpr-devel
+BuildRequires: rust-cfg-if-devel
+BuildRequires: rust-chrono-devel
+BuildRequires: rust-clang-sys-devel
+#BuildRequires: rust-confy-devel
+BuildRequires: rust-cpufeatures-devel
+BuildRequires: rust-crossbeam-epoch-devel
+BuildRequires: rust-crossbeam-utils-devel
+BuildRequires: rust-crypto-common-devel
+BuildRequires: rust-digest-devel
+BuildRequires: rust-directories-devel
+BuildRequires: rust-dirs-sys-devel
+BuildRequires: rust-either-devel
+BuildRequires: rust-generic-array-devel
+BuildRequires: rust-getrandom-devel
+BuildRequires: rust-glob-devel
+BuildRequires: rust-heck-devel
+BuildRequires: rust-indoc-devel
+#BuildRequires: rust-instant-devel
+BuildRequires: rust-is_executable-devel
+BuildRequires: rust-lazy_static-devel
+BuildRequires: rust-libc-devel
+BuildRequires: rust-libloading-devel
+BuildRequires: rust-lock_api-devel
+BuildRequires: rust-log-devel
+BuildRequires: rust-memchr-devel
+BuildRequires: rust-memoffset-devel
+BuildRequires: rust-nom-devel
+BuildRequires: rust-num-integer-devel
+BuildRequires: rust-num-traits-devel
+BuildRequires: rust-num_cpus-devel
+BuildRequires: rust-option-ext-devel
+BuildRequires: rust-parking_lot-devel
+BuildRequires: rust-pkg-config-devel
+BuildRequires: rust-proc-macro2-devel
+BuildRequires: rust-rayon-devel
+BuildRequires: rust-regex-devel
+BuildRequires: rust-regex-syntax-devel
+BuildRequires: rust-rustc-hash-devel
+BuildRequires: rust-sha2-devel
+BuildRequires: rust-shlex-devel
+BuildRequires: rust-similar-devel
+BuildRequires: rust-smallvec-devel
+BuildRequires: rust-syn-devel
+BuildRequires: rust-target-lexicon-devel
+BuildRequires: rust-thiserror-devel
+BuildRequires: rust-typenum-devel
+BuildRequires: rust-unicode-ident-devel
+BuildRequires: rust-unindent-devel
+BuildRequires: rust-version_check-devel
+BuildRequires: rust-which-devel
+
+%global module          fapolicy_analyzer
+
+# pep440 versions handle dev and rc differently, so we call them out explicitly here
+%global module_version  %{lua: v = string.gsub(rpm.expand("%{?version}"), "~dev", ".dev"); \
+                               v = string.gsub(v, "~rc",  "rc"); print(v) }
+
+Requires:      %{name}-cli
+Requires:      %{name}-gui
+
+%description
+Tools to assist with the configuration and management of fapolicyd.
+
+
+%package cli
+Summary:       File Access Policy Analyzer CLI
+
+%description cli
+CLI Tools to assist with the configuration and management of fapolicyd.
+
+
+%package gui
+Summary:       File Access Policy Analyzer GUI
+
+Requires:      python3
+Requires:      python3-gobject
+Requires:      python3-configargparse
+Requires:      python3-more-itertools
+Requires:      python3-rx
+Requires:      python3-importlib-metadata
+Requires:      python3-toml
+
+Requires:      gtk3
+Requires:      gtksourceview3
+Requires:      gnome-icon-theme
+
+# runtime required for rendering user guide
+Requires:      webkit2gtk3
+Requires:      mesa-dri-drivers
+
+%description gui
+GUI Tools to assist with the configuration and management of fapolicyd.
+
+%prep
+
+%if %{with gui}
+# An unprivileged user cannot write to the default registry location of
+# /usr/share/cargo/registry so we work around this by linking the contents
+# of the default registry into a new writable location, and then extract
+# the contents of the vendor tarball to this new writable dir.
+# The extraction favors the system crates by untaring with --skip-old-files
+# Later the Cargo config will be updated to point to this new registry dir
+# The crates in the vendor tarball are collected from Rawhide.
+CARGO_REG_DIR=%{_builddir}/vendor-rs
+mkdir -p ${CARGO_REG_DIR}
+for d in %{cargo_registry}/*; do ln -sf ${d} ${CARGO_REG_DIR} || true; done
+tar -xzf %{SOURCE2} -C ${CARGO_REG_DIR} --skip-old-files --strip-components=2
+%endif
+
+%cargo_prep -v ${CARGO_REG_DIR}
+
+%autosetup -n %{name}
+
+rm Cargo.lock
+
+%if %{without cli}
+# disable the dev-tools crate
+sed -i '/tools/d' Cargo.toml
+%endif
+
+%if %{with cli}
+# disable ariadne
+sed -i '/ariadne/d' crates/tools/Cargo.toml
+%endif
+
+# extract our doc sourcs
+tar xvzf %{SOURCE1}
+
+# our setup.py looks up the version from git describe
+# this overrides that check to use the RPM version
+echo %{module_version} > VERSION
+
+# capture build info
+scripts/build-info.py --os --time
+
+%build
+# ensure standard Rust compiler flags are set
+export RUSTFLAGS="%{build_rustflags}"
+
+%if %{with cli}
+cargo build --bin tdb --release
+cargo build --bin faprofiler --release
+cargo build --bin rulec --release
+%endif
+
+%if %{with gui}
+%{python3} setup.py compile_catalog -f
+%{python3} help build
+%{python3} setup.py bdist_wheel
+%endif
+
+
+%install
+
+%if %{with cli}
+install -D target/release/tdb %{buildroot}/%{_sbindir}/%{name}-cli-trust
+install -D target/release/faprofiler %{buildroot}/%{_sbindir}/%{name}-cli-profiler
+install -D target/release/rulec %{buildroot}/%{_sbindir}/%{name}-cli-rules
+%endif
+
+%if %{with gui}
+%{py3_install_wheel %{module}-%{module_version}*%{_target_cpu}.whl}
+%{python3} help install --dest %{buildroot}/%{_datadir}/help
+install -D bin/%{name} %{buildroot}/%{_sbindir}/%{name}
+install -D data/%{name}.8 -t %{buildroot}/%{_mandir}/man8/
+install -D data/%{name}-cli-*.8 -t %{buildroot}/%{_mandir}/man8/
+desktop-file-install data/%{name}.desktop
+find locale -name %{name}.mo -exec cp --parents -rv {} %{buildroot}/%{_datadir} \;
+%find_lang %{name} --with-gnome
+%endif
+
+%check
+%if %{with gui}
+desktop-file-validate %{buildroot}/%{_datadir}/applications/%{name}.desktop
+%endif
+
+%files cli
+%attr(755,root,root) %{_sbindir}/%{name}-cli-trust
+%attr(755,root,root) %{_sbindir}/%{name}-cli-profiler
+%attr(755,root,root) %{_sbindir}/%{name}-cli-rules
+
+%files gui
+%{python3_sitearch}/%{module}
+%{python3_sitearch}/%{module}-%{module_version}*
+%attr(755,root,root) %{_sbindir}/%{name}
+%attr(644,root,root) %{_mandir}/man8/%{name}.8*
+%attr(644,root,root) %{_mandir}/man8/%{name}-cli-*.8*
+%attr(755,root,root) %{_datadir}/applications/%{name}.desktop
+
+%files -f %{name}.lang
+%doc scripts/srpm/README
+%license LICENSE
+
+%changelog
+* Tue Dec 31 2024 John Wass <jwass3@gmail.com> 1.5.0-1
+- New release


### PR DESCRIPTION
Adds EPEL 10 build to CI

Uses a separate el10 spec that removes the Python vendoring.

Changes required to integrate the build:

- move srpm build to mock
- vendor python deps in a 0 task
- enable crb repo in el builds
- build in centos stream rather than rocky
- install in alma rather than rocky

Closes #1047