### PR TITLE
Handle quotes in profiler args

### DIFF
--- a/crates/pyo3/src/profiler.rs
+++ b/crates/pyo3/src/profiler.rs
@@ -28,6 +28,7 @@ use std::{io, thread};
 use crate::system::PySystem;
 use fapolicy_daemon::profiler::Profiler;
 use fapolicy_rules::read::load_rules_db;
+use fapolicy_util::tokenize;
 
 type EnvVars = HashMap<String, String>;
 type CmdArgs = (Command, String);
@@ -492,45 +493,6 @@ fn reload_profiler_rules(system: &PySystem) -> PyResult<()> {
 
     pipe::reload_rules()
         .map_err(|e| exceptions::PyRuntimeError::new_err(format!("Reload failed: {:?}", e)))
-}
-
-fn tokenize(input: &str) -> Vec<String> {
-    let mut tokens = Vec::new();
-    let mut current = String::new();
-    let mut in_quotes = false;
-    let mut quote_char = '\0';
-
-    for c in input.chars() {
-        if in_quotes {
-            if c == quote_char {
-                in_quotes = false;
-                tokens.push(current.clone());
-                current.clear();
-            } else {
-                current.push(c);
-            }
-        } else {
-            if c.is_whitespace() {
-                if !current.is_empty() {
-                    tokens.push(current.clone());
-                    current.clear();
-                }
-            } else if c == '"' || c == '\'' {
-                in_quotes = true;
-                quote_char = c;
-                if !current.is_empty() {
-                    tokens.push(current.clone());
-                    current.clear();
-                }
-            } else {
-                current.push(c);
-            }
-        }
-    }
-    if !current.is_empty() {
-        tokens.push(current);
-    }
-    tokens
 }
 
 pub fn init_module(_py: Python, m: &Bound<'_, PyModule>) -> PyResult<()> {

--- a/crates/util/src/lib.rs
+++ b/crates/util/src/lib.rs
@@ -9,4 +9,5 @@
 pub mod rpm;
 pub mod sha;
 pub mod tokenize;
+pub use tokenize::tokenize;
 pub mod trimto;

--- a/crates/util/src/lib.rs
+++ b/crates/util/src/lib.rs
@@ -8,4 +8,5 @@
 
 pub mod rpm;
 pub mod sha;
+pub mod tokenize;
 pub mod trimto;

--- a/crates/util/src/tokenize.rs
+++ b/crates/util/src/tokenize.rs
@@ -1,3 +1,10 @@
+/*
+ * Copyright Concurrent Technologies Corporation 2025
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
 pub fn tokenize(input: &str) -> Vec<String> {
     let mut tokens = Vec::new();
     let mut current = String::new();

--- a/crates/util/src/tokenize.rs
+++ b/crates/util/src/tokenize.rs
@@ -1,0 +1,62 @@
+pub fn tokenize(input: &str) -> Vec<String> {
+    let mut tokens = Vec::new();
+    let mut current = String::new();
+    let mut chars = input.chars().peekable();
+
+    while let Some(&c) = chars.peek() {
+        if c.is_whitespace() {
+            chars.next();
+            continue;
+        }
+        if c == '"' || c == '\'' {
+            let quote_char = c;
+            chars.next();
+            while let Some(ch) = chars.next() {
+                match ch {
+                    '\\' => {
+                        if let Some(escaped) = chars.next() {
+                            current.push(escaped);
+                        }
+                    }
+                    c if c == quote_char => {
+                        break;
+                    }
+                    _ => current.push(ch),
+                }
+            }
+            tokens.push(current.clone());
+            current.clear();
+        } else {
+            while let Some(&ch) = chars.peek() {
+                if ch.is_whitespace() || ch == '"' || ch == '\'' {
+                    break;
+                } else {
+                    current.push(ch);
+                    chars.next();
+                }
+            }
+            tokens.push(current.clone());
+            current.clear();
+        }
+    }
+    tokens
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn test_tokenize() {
+        assert_eq!(&tokenize("bar"), &["bar"]);
+        assert_eq!(&tokenize("foo bar"), &["foo", "bar"]);
+        assert_eq!(&tokenize(" foo bar"), &["foo", "bar"]);
+        assert_eq!(&tokenize("foo bar "), &["foo", "bar"]);
+        assert_eq!(&tokenize("foo     bar"), &["foo", "bar"]);
+        assert_eq!(&tokenize("  foo bar  "), &["foo", "bar"]);
+        assert_eq!(&tokenize("'foo bar'"), &["foo bar"]);
+        assert_eq!(&tokenize("'foo ba'r"), &["foo ba", "r"]);
+        assert_eq!(&tokenize("\"foo bar\""), &["foo bar"]);
+        assert_eq!(&tokenize("'foo bar' 'biz baz'"), &["foo bar", "biz baz"]);
+        assert_eq!(&tokenize("'foo bar' 'biz baz"), &["foo bar", "biz baz"]);
+    }
+}

--- a/news/1066.fixed.md
+++ b/news/1066.fixed.md
@@ -1,0 +1,1 @@
+Fixed use of quotes in profiler args allowing commands like bash -c "echo 'hello world'".


### PR DESCRIPTION
Allow quoted args to be passed together as profiler args.

Example:
- cmd: bash
- arg: -c "ls /tmp"

Closes #999