### PR TITLE
Python updates for el10

### DIFF
--- a/.github/rpm-matrix.json
+++ b/.github/rpm-matrix.json
@@ -28,7 +28,7 @@
       "platform": "rhel",
       "dist": "el10",
       "spec": "scripts/srpm/fapolicy-analyzer.el10.spec",
-      "image": "almalinux:10-kitten",
+      "image": "almalinux/10-kitten-base",
       "chroot": "centos-stream+epel-10-x86_64",
       "prerelease": true
     }

--- a/.github/workflows/rpm.yml
+++ b/.github/workflows/rpm.yml
@@ -518,7 +518,8 @@ jobs:
 
       - name: Enable EPEL
         if: startsWith(matrix.props.dist, 'el')
-        run: dnf install -y epel-release
+        run: |
+          dnf install -y epel-release || dnf install -y epel-release || dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-10.noarch.rpm
 
       - name: Install RPM
         run: |

--- a/fapolicy-analyzer.spec
+++ b/fapolicy-analyzer.spec
@@ -70,7 +70,7 @@ Requires:      python3-matplotlib-gtk3
 
 Requires:      gtk3
 Requires:      gtksourceview3
-Requires:      adwaita-icon-theme
+Requires:      gnome-icon-theme
 
 # runtime required for rendering user guide
 Requires:      mesa-dri-drivers

--- a/fapolicy-analyzer.spec
+++ b/fapolicy-analyzer.spec
@@ -70,7 +70,7 @@ Requires:      python3-matplotlib-gtk3
 
 Requires:      gtk3
 Requires:      gtksourceview3
-Requires:      gnome-icon-theme
+Requires:      adwaita-icon-theme
 
 # runtime required for rendering user guide
 Requires:      mesa-dri-drivers

--- a/fapolicy_analyzer/ui/features/application_feature.py
+++ b/fapolicy_analyzer/ui/features/application_feature.py
@@ -13,7 +13,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import toml
+import tomli
 from rx import of
 from rx.core.pipe import pipe
 from rx.operators import catch, map
@@ -44,7 +44,7 @@ def create_application_feature() -> ReduxFeatureModule:
     def _get_app_config(_: Action) -> Action:
         path = config_file_path()
         with open(path, "r") as f:
-            config = toml.load(f)
+            config = tomli.load(f)
         return received_app_config(config.get("ui", {}))
 
     request_app_config_epic = pipe(

--- a/scripts/srpm/fapolicy-analyzer.el10.spec
+++ b/scripts/srpm/fapolicy-analyzer.el10.spec
@@ -127,7 +127,7 @@ Requires:      gtksourceview3
 Requires:      gnome-icon-theme
 
 # runtime required for rendering user guide
-Requires:      webkit2gtk3
+Requires:      webkit2gtk4.1
 Requires:      mesa-dri-drivers
 
 %description gui

--- a/scripts/srpm/fapolicy-analyzer.el10.spec
+++ b/scripts/srpm/fapolicy-analyzer.el10.spec
@@ -120,8 +120,7 @@ Requires:      python3-gobject
 Requires:      python3-configargparse
 Requires:      python3-more-itertools
 Requires:      python3-rx
-Requires:      python3-importlib-metadata
-Requires:      python3-toml
+Requires:      python3-tomli
 
 Requires:      gtk3
 Requires:      gtksourceview3

--- a/scripts/srpm/fapolicy-analyzer.el10.spec
+++ b/scripts/srpm/fapolicy-analyzer.el10.spec
@@ -124,7 +124,7 @@ Requires:      python3-tomli
 
 Requires:      gtk3
 Requires:      gtksourceview3
-Requires:      gnome-icon-theme
+Requires:      adwaita-icon-theme
 
 # runtime required for rendering user guide
 Requires:      webkit2gtk4.1


### PR DESCRIPTION
Updates runtime requires for tomli and importlib-metadata on el10

Also updates requires for
- webkit to webkit2gtk4.1.
- gnome-icon-theme to adwaita

#1067