### PR TITLE
Update runners to 22.04

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -10,7 +10,7 @@ jobs:
   changelog:
     name: Enforce changelog entry
     if: github.event_name == 'pull_request'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - uses: jw3/newsforce@v0

--- a/.github/workflows/common.yml
+++ b/.github/workflows/common.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   headers:
     name: License header check
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - name: Check for required headers

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   coverity:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - uses: vapier/coverity-scan-action@v1

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -20,7 +20,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       HUGO_VERSION: 0.123.1
       HUGO_ENVIRONMENT: production
@@ -68,7 +68,7 @@ jobs:
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: build
     steps:
       - id: deployment

--- a/.github/workflows/pdf.yml
+++ b/.github/workflows/pdf.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   pdf:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: install deps
         run: |

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -16,7 +16,7 @@ concurrency:
 
 jobs:
   ruff:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - uses: chartboost/ruff-action@v1
@@ -25,7 +25,7 @@ jobs:
 
   ui_test:
     name: UI Test Suite for Python ${{ matrix.python-version }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         python-version: [ "3.9", "3.10", "3.11", "3.12" ]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   release:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     name: Build
     steps:
       - name: Install git

--- a/.github/workflows/rpm.yml
+++ b/.github/workflows/rpm.yml
@@ -100,7 +100,7 @@ jobs:
 
   crates0:
     name: Vendor Crates0
-    container: registry.fedoraproject.org/fedora:latest
+    container: registry.fedoraproject.org/fedora:41
     runs-on: ubuntu-22.04
     steps:
       - name: Install RPM build dependencies

--- a/.github/workflows/rpm.yml
+++ b/.github/workflows/rpm.yml
@@ -20,7 +20,7 @@ concurrency:
 jobs:
   config:
     name: Load configuration
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
       is-copr-enabled: ${{ steps.is-copr-enabled.outputs.defined }}
@@ -44,7 +44,7 @@ jobs:
   source0:
     name: Vendor Source0
     container: registry.fedoraproject.org/fedora:38
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Install deps
         run: dnf install -y git make python3
@@ -101,7 +101,7 @@ jobs:
   crates0:
     name: Vendor Crates0
     container: registry.fedoraproject.org/fedora:latest
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Install RPM build dependencies
         run: |
@@ -142,7 +142,7 @@ jobs:
   docs0:
     name: Vendor Docs0
     container: registry.fedoraproject.org/fedora:latest
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Install RPM build dependencies
         run: |
@@ -182,7 +182,7 @@ jobs:
   python0:
     name: Vendor Python0
     container: registry.fedoraproject.org/fedora:latest
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Install RPM build dependencies
         run: |
@@ -216,7 +216,7 @@ jobs:
   srpm:
     needs: [ config, source0, crates0, docs0, python0 ]
     name: SRPM Build ${{ matrix.props.dist }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix: ${{ fromJson(needs.config.outputs.matrix) }}
     steps:
@@ -380,7 +380,7 @@ jobs:
     name: Copr Build ${{ matrix.props.dist }}
     if: needs.config.outputs.is-copr-enabled == 'true'
     container: 'rockylinux:8.6'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix: ${{ fromJson(needs.config.outputs.matrix) }}
     steps:
@@ -420,7 +420,7 @@ jobs:
   rpm:
     needs: [ config, srpm ]
     name: Rebuild ${{ matrix.props.dist }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix: ${{ fromJson(needs.config.outputs.matrix )}}
     steps:
@@ -501,7 +501,7 @@ jobs:
     needs: [ config, srpm, rpm ]
     name: Install ${{ matrix.props.dist }}
     container: ${{ matrix.props.image }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix: ${{ fromJson(needs.config.outputs.matrix )}}
     continue-on-error: ${{ matrix.props.prerelease }}
@@ -533,7 +533,7 @@ jobs:
     needs: [ srpm, rpm, install, copr ]
     name: Publish
     if: startsWith(github.ref, 'refs/tags/v')
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -17,7 +17,7 @@ concurrency:
 jobs:
   fmt:
     name: Rustfmt
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@v1
@@ -34,7 +34,7 @@ jobs:
 
   check:
     name: Check
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - name: Install package dependencies
@@ -50,7 +50,7 @@ jobs:
 
   clippy:
     name: Clippy
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
 
@@ -103,7 +103,7 @@ jobs:
 
   test:
     name: Test Suite
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - name: Install package dependencies

--- a/.github/workflows/tools.yml
+++ b/.github/workflows/tools.yml
@@ -19,7 +19,7 @@ concurrency:
 jobs:
   build:
     name: Build
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     # 29 has glibc-2.28, compatible >= el8, fc, ubuntu 20.04
     container: fedora:29
     steps:


### PR DESCRIPTION
GitHub deprecated 20.04, updating to 22.04

Bump vendor rs back to 41 to avoid a package issue that will be resolved separately.