### PR TITLE
Final el10 dependencies

### DIFF
--- a/.github/rpm-matrix.json
+++ b/.github/rpm-matrix.json
@@ -21,15 +21,15 @@
       "dist": "el9",
       "spec": "scripts/srpm/fapolicy-analyzer.el9.spec",
       "image": "rockylinux:9",
-      "chroot": "centos-stream+epel-9-x86_64",
+      "chroot": "rocky+epel-9-x86_64",
       "prerelease": false
     },
     {
       "platform": "rhel",
       "dist": "el10",
       "spec": "scripts/srpm/fapolicy-analyzer.el10.spec",
-      "image": "almalinux/10-kitten-base",
-      "chroot": "centos-stream+epel-10-x86_64",
+      "image": "rockylinux:10",
+      "chroot": "rocky+epel-10-x86_64",
       "prerelease": true
     }
   ]

--- a/.github/rpm-matrix.json
+++ b/.github/rpm-matrix.json
@@ -12,7 +12,7 @@
       "platform": "rhel",
       "dist": "el9",
       "spec": "scripts/srpm/fapolicy-analyzer.el9.spec",
-      "image": "rockylinux:9",
+      "image": "quay.io/rockylinux/rockylinux:9",
       "chroot": "rocky+epel-9-x86_64",
       "prerelease": false
     },
@@ -20,7 +20,7 @@
       "platform": "rhel",
       "dist": "el10",
       "spec": "scripts/srpm/fapolicy-analyzer.el10.spec",
-      "image": "rockylinux:10",
+      "image": "quay.io/rockylinux/rockylinux:10",
       "chroot": "rocky+epel-10-x86_64",
       "prerelease": false
     }

--- a/.github/rpm-matrix.json
+++ b/.github/rpm-matrix.json
@@ -9,14 +9,6 @@
       "prerelease": false
     },
     {
-      "platform": "fedora",
-      "dist": "fc40",
-      "spec": "fapolicy-analyzer.spec",
-      "image": "registry.fedoraproject.org/fedora:40",
-      "chroot": "fedora-40-x86_64",
-      "prerelease": false
-    },
-    {
       "platform": "rhel",
       "dist": "el9",
       "spec": "scripts/srpm/fapolicy-analyzer.el9.spec",

--- a/.github/rpm-matrix.json
+++ b/.github/rpm-matrix.json
@@ -30,7 +30,7 @@
       "spec": "scripts/srpm/fapolicy-analyzer.el10.spec",
       "image": "rockylinux:10",
       "chroot": "rocky+epel-10-x86_64",
-      "prerelease": true
+      "prerelease": false
     }
   ]
 }

--- a/.github/workflows/rpm.yml
+++ b/.github/workflows/rpm.yml
@@ -521,9 +521,14 @@ jobs:
         run: |
           dnf install -y epel-release
 
+      - name: Enable EPEL Testing Repo
+        if: startsWith(matrix.props.dist, 'el10')
+        run: |
+          dnf config-manager --set-enabled epel-testing
+
       - name: Install RPM
         run: |
-          dnf install -y --enablerepo=epel-testing /tmp/src/fapolicy-analyzer-*.${{ matrix.props.dist }}.x86_64.rpm
+          dnf install -y /tmp/src/fapolicy-analyzer-*.${{ matrix.props.dist }}.x86_64.rpm
 
       - name: Check RPM
         run: |

--- a/.github/workflows/rpm.yml
+++ b/.github/workflows/rpm.yml
@@ -520,6 +520,7 @@ jobs:
         if: startsWith(matrix.props.dist, 'el')
         run: |
           dnf install -y epel-release || dnf install -y epel-release || dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-10.noarch.rpm
+          dnf config-manager --set-enabled epel-testing
 
       - name: Install RPM
         run: |

--- a/.github/workflows/rpm.yml
+++ b/.github/workflows/rpm.yml
@@ -43,7 +43,7 @@ jobs:
 
   source0:
     name: Vendor Source0
-    container: registry.fedoraproject.org/fedora:38
+    container: registry.fedoraproject.org/fedora:41
     runs-on: ubuntu-22.04
     steps:
       - name: Install deps
@@ -100,7 +100,7 @@ jobs:
 
   crates0:
     name: Vendor Crates0
-    container: registry.fedoraproject.org/fedora:41
+    container: registry.fedoraproject.org/fedora:39
     runs-on: ubuntu-22.04
     steps:
       - name: Install RPM build dependencies
@@ -313,7 +313,7 @@ jobs:
         run: |
           sudo apt install -y podman
           cid="${{ matrix.props.dist }}-${{ github.run_id }}"
-          podman run -dt --name $cid --privileged fedora:39
+          podman run -dt --name $cid --privileged fedora:41
 
       - name: Init container
         run: |
@@ -449,7 +449,7 @@ jobs:
         run: |
           sudo apt install -y podman
           cid="${{ matrix.props.dist }}-${{ github.run_id }}"
-          podman run -dt --name $cid --privileged fedora:39
+          podman run -dt --name $cid --privileged fedora:41
 
       - name: Init container
         run: |

--- a/.github/workflows/rpm.yml
+++ b/.github/workflows/rpm.yml
@@ -100,7 +100,7 @@ jobs:
 
   crates0:
     name: Vendor Crates0
-    container: registry.fedoraproject.org/fedora:39
+    container: registry.fedoraproject.org/fedora:41
     runs-on: ubuntu-22.04
     steps:
       - name: Install RPM build dependencies

--- a/.github/workflows/rpm.yml
+++ b/.github/workflows/rpm.yml
@@ -519,12 +519,11 @@ jobs:
       - name: Enable EPEL
         if: startsWith(matrix.props.dist, 'el')
         run: |
-          dnf install -y epel-release || dnf install -y epel-release || dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-10.noarch.rpm
-          dnf config-manager --set-enabled epel-testing
+          dnf install -y epel-release
 
       - name: Install RPM
         run: |
-          dnf install -y /tmp/src/fapolicy-analyzer-*.${{ matrix.props.dist }}.x86_64.rpm
+          dnf install -y --enablerepo=epel-testing /tmp/src/fapolicy-analyzer-*.${{ matrix.props.dist }}.x86_64.rpm
 
       - name: Check RPM
         run: |

--- a/Containerfile
+++ b/Containerfile
@@ -1,4 +1,4 @@
-ARG image=registry.fedoraproject.org/fedora:39
+ARG image=registry.fedoraproject.org/fedora:41
 FROM $image AS fedorabuild
 ARG version
 ARG spec=fapolicy-analyzer.spec

--- a/Makefile
+++ b/Makefile
@@ -153,7 +153,7 @@ el-rpm:
 	@echo -e "${GRN}--- el$(el) RPM generation v${VERSION}...${NC}"
 	make -f .copr/Makefile vendor vendor-rs OS_ID=rhel VERSION=${VERSION} DIST=.el$(el) spec=scripts/srpm/fapolicy-analyzer.el$(el).spec
 	podman build -t fapolicy-analyzer:build-el$(el) --target elbuild --build-arg version=${VERSION} --build-arg spec=scripts/srpm/fapolicy-analyzer.el$(el).spec -f Containerfile .
-	podman run --privileged --rm -it -v /tmp:/v fapolicy-analyzer:build-el$(el) centos-stream+epel-$(el)-x86_64 /v
+	podman run --privileged --rm -it -v /tmp:/v fapolicy-analyzer:build-el$(el) rocky+epel-$(el)-x86_64 /v
 
 # Update embedded help documentation
 help-docs:

--- a/scripts/srpm/build.sh
+++ b/scripts/srpm/build.sh
@@ -21,7 +21,7 @@ rpmbuild_dir=/tmp/rpmbuild
 echo "[build.sh] mock $1"
 mock -r "$1" --init
 mock -r "$1" --resultdir ${rpmbuild_dir} --buildsrpm --sources ${rpmbuild_dir}/SOURCES/ --spec ${rpmbuild_dir}/SPECS/${spec_file}
-mock -r "$1" --resultdir ${rpmbuild_dir} --enablerepo=crb --rebuild ${rpmbuild_dir}/*.src.rpm
+mock -r "$1" --resultdir ${rpmbuild_dir} --rebuild ${rpmbuild_dir}/*.src.rpm
 
 if [[ -n "$2" ]]; then
   echo "[build.sh] exporting rpms to ${2}"

--- a/scripts/srpm/fapolicy-analyzer.el10.spec
+++ b/scripts/srpm/fapolicy-analyzer.el10.spec
@@ -124,7 +124,7 @@ Requires:      python3-tomli
 
 Requires:      gtk3
 Requires:      gtksourceview3
-Requires:      adwaita-icon-theme
+Requires:      gnome-icon-theme
 
 # runtime required for rendering user guide
 Requires:      webkit2gtk4.1


### PR DESCRIPTION
Complete el10 build with recent package additions

- use gnome-icon-theme
- use python-rx
- gtksourceview3
- use fc41 in builds
- move el10 to gnome-icon-theme
- use rocky-10 everywhere

Closes #1067