### PR TITLE
Release v1.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ Release notes
 
 <!-- towncrier release notes start -->
 
+## [v1.5.1](https://github.com/ctc-oss/fapolicy-analyzer/releases/tag/v1.5.1) - 2026-01-31
+### Packaging
+
+- Add RPM build for EPEL-10. [#1065](https://github.com/ctc-oss/fapolicy-analyzer/pull/1065)
+- Builds are now performed with Maturin, setuptools usage has been removed (execpt el9). [#1079](https://github.com/ctc-oss/fapolicy-analyzer/pull/1079)
+- Updated Python Reactive Extensions (PyRx) to v4 to support upstream Fedora packaging changes. [#1082](https://github.com/ctc-oss/fapolicy-analyzer/pull/1082)_
+
+### Fixed
+
+- Fixed use of quotes in profiler args allowing commands like bash -c "echo 'hello world'". [#1066](https://github.com/ctc-oss/fapolicy-analyzer/pull/1066)
+  - Preserve daemon state on deploy. [#1078](https://github.com/ctc-oss/fapolicy-analyzer/pull/1078)
+    
 ## [v1.5.0](https://github.com/ctc-oss/fapolicy-analyzer/releases/tag/v1.5.0) - 2024-12-31
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ Release notes
 ### Fixed
 
 - Fixed use of quotes in profiler args allowing commands like bash -c "echo 'hello world'". [#1066](https://github.com/ctc-oss/fapolicy-analyzer/pull/1066)
-  - Preserve daemon state on deploy. [#1078](https://github.com/ctc-oss/fapolicy-analyzer/pull/1078)
+- Preserve daemon state on deploy. [#1078](https://github.com/ctc-oss/fapolicy-analyzer/pull/1078)
     
 ## [v1.5.0](https://github.com/ctc-oss/fapolicy-analyzer/releases/tag/v1.5.0) - 2024-12-31
 

--- a/crates/tools/Cargo.toml
+++ b/crates/tools/Cargo.toml
@@ -2,7 +2,7 @@
 name = "fapolicy-tools"
 description = "Tools to assist with the configuration and maintenance of fapolicyd"
 license = "GPL-3.0-or-later"
-version = "1.5.0"
+version = "1.5.1"
 edition = "2021"
 
 [[bin]]

--- a/crates/tools/src/fapolicy_profiler.rs
+++ b/crates/tools/src/fapolicy_profiler.rs
@@ -26,7 +26,7 @@ use std::process::Command;
 use strip_ansi_escapes::strip_str;
 
 #[derive(Parser)]
-#[clap(name = "File Access Policy Profiler", version = "1.5.0")]
+#[clap(name = "File Access Policy Profiler", version = "1.5.1")]
 struct Opts {
     /// do not write events to stdout
     #[clap(long)]

--- a/crates/tools/src/rule_check.rs
+++ b/crates/tools/src/rule_check.rs
@@ -35,7 +35,7 @@ use std::io::{BufRead, BufReader};
 use std::process::ExitCode;
 
 #[derive(Parser)]
-#[clap(name = "Rule Checker", version = "1.5.0")]
+#[clap(name = "Rule Checker", version = "1.5.1")]
 struct Opts {
     /// path to *.rules or rules.d
     #[clap(default_value=fapolicyd::RULES_FILE_PATH)]

--- a/crates/tools/src/trust_db_util.rs
+++ b/crates/tools/src/trust_db_util.rs
@@ -69,7 +69,7 @@ pub enum Error {
 }
 
 #[derive(Parser)]
-#[clap(name = "Trust DB Util", version = "1.5.0")]
+#[clap(name = "Trust DB Util", version = "1.5.1")]
 struct Opts {
     #[clap(subcommand)]
     cmd: Subcommand,

--- a/fapolicy-analyzer.spec
+++ b/fapolicy-analyzer.spec
@@ -4,7 +4,7 @@
 
 Summary:       File Access Policy Analyzer
 Name:          fapolicy-analyzer
-Version:       1.5.0
+Version:       1.5.1
 Release:       1%{?dist}
 
 SourceLicense: GPL-3.0-or-later
@@ -209,5 +209,5 @@ desktop-file-validate %{buildroot}/%{_datadir}/applications/%{name}.desktop
 %license LICENSE.dependencies
 
 %changelog
-* Tue Dec 31 2024 John Wass <jwass3@gmail.com> 1.5.0-1
+* Sat Jan 31 2026 John Wass <jwass3@gmail.com> 1.5.1-1
 - New release

--- a/news/1065.packaging.md
+++ b/news/1065.packaging.md
@@ -1,1 +1,0 @@
-Add RPM build for EPEL-10.

--- a/news/1066.fixed.md
+++ b/news/1066.fixed.md
@@ -1,1 +1,0 @@
-Fixed use of quotes in profiler args allowing commands like bash -c "echo 'hello world'".

--- a/news/1078.fixed.md
+++ b/news/1078.fixed.md
@@ -1,1 +1,0 @@
-Preserve daemon state on deploy.

--- a/news/1079.packaging.md
+++ b/news/1079.packaging.md
@@ -1,1 +1,0 @@
-Builds are now performed with Maturin, all setuptools usage has been removed.

--- a/news/1082.packaging.md
+++ b/news/1082.packaging.md
@@ -1,1 +1,0 @@
-Updated Python Reactive Extensions (PyRx) to v4 to support upstream Fedora packaging changes.

--- a/scripts/srpm/fapolicy-analyzer.el10.spec
+++ b/scripts/srpm/fapolicy-analyzer.el10.spec
@@ -3,7 +3,7 @@
 
 Summary:       File Access Policy Analyzer
 Name:          fapolicy-analyzer
-Version:       1.5.0
+Version:       1.5.1
 Release:       1%{?dist}
 
 SourceLicense: GPL-3.0-or-later
@@ -242,5 +242,5 @@ desktop-file-validate %{buildroot}/%{_datadir}/applications/%{name}.desktop
 %license LICENSE
 
 %changelog
-* Tue Dec 31 2024 John Wass <jwass3@gmail.com> 1.5.0-1
+* Sat Jan 31 2026 John Wass <jwass3@gmail.com> 1.5.1-1
 - New release

--- a/scripts/srpm/fapolicy-analyzer.el9.spec
+++ b/scripts/srpm/fapolicy-analyzer.el9.spec
@@ -3,7 +3,7 @@
 
 Summary:       File Access Policy Analyzer
 Name:          fapolicy-analyzer
-Version:       1.5.0
+Version:       1.5.1
 Release:       1%{?dist}
 
 SourceLicense: GPL-3.0-or-later
@@ -321,5 +321,5 @@ desktop-file-validate %{buildroot}/%{_datadir}/applications/%{name}.desktop
 %license LICENSE
 
 %changelog
-* Tue Dec 31 2024 John Wass <jwass3@gmail.com> 1.5.0-1
+* Sat Jan 31 2026 John Wass <jwass3@gmail.com> 1.5.1-1
 - New release


### PR DESCRIPTION
## [v1.5.1](https://github.com/ctc-oss/fapolicy-analyzer/releases/tag/v1.5.1) - 2026-01-31
### Packaging

- Add RPM build for EPEL-10. [#1065](https://github.com/ctc-oss/fapolicy-analyzer/pull/1065)
- Builds are now performed with Maturin, setuptools usage has been removed (execpt el9). [#1079](https://github.com/ctc-oss/fapolicy-analyzer/pull/1079)
- Updated Python Reactive Extensions (PyRx) to v4 to support upstream Fedora packaging changes. [#1082](https://github.com/ctc-oss/fapolicy-analyzer/pull/1082)_

### Fixed

- Fixed use of quotes in profiler args allowing commands like bash -c "echo 'hello world'". [#1066](https://github.com/ctc-oss/fapolicy-analyzer/pull/1066)
- Preserve daemon state on deploy. [#1078](https://github.com/ctc-oss/fapolicy-analyzer/pull/1078)
